### PR TITLE
update list of aliases

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,8 @@ using Conda
 
 @BinDeps.setup
 
-libgdal = library_dependency("libgdal", aliases=["gdal", "gdal111"])
+libgdal = library_dependency("libgdal", aliases=["gdal","gdal111","gdal201",
+                                                 "gdal_w32","gdal_w64"])
 
 # install older gdal on windows
 @windows_only provides(Conda.Manager, "libgdal==1.11.2", libgdal)


### PR DESCRIPTION
@joa-quim: this library will eventually be the common dependency for both RasterIO and OGR-bindings, so I propose moving over the changes from https://github.com/wkearn/RasterIO.jl/pull/21 to this repository. You okay with that?