### PR TITLE
auto-generated documentation

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -1,0 +1,18 @@
+GDAL.jl generation documentation
+================================
+
+### Install Clang.jl
+Because a few tricks are used to be able to properly write documentation,
+this fork of Clang.jl is used: https://github.com/visr/Clang.jl (branch gdal)
+
+### Make sure you have the GDAL header files
+The `wrap_gdal.jl` script looks in `/usr/local/include` by default.
+
+### Prepare the GDAL Doxygen XML
+1. In the GDAL SVN, run Doxygen with `GENERATE_XML = YES`
+2. In the `xml` output dir, run `combine.xslt` to combine all documentation in one XML
+3. Copy this file to `GDAL.jl/gen/all.xml`
+
+### Run the wrapping scripts
+1. Run `julia gen/wrap_gdal.jl` to generate the low level wrapping (GDAL + documentation)
+2. Run `julia gen/rewriter.jl` to generate the higher level wrapping from the low level wrapping (GDAL + documentation)

--- a/gen/doc.jl
+++ b/gen/doc.jl
@@ -1,0 +1,61 @@
+"compose a markdown docstring based on a Doxygen XML element"
+function build_docstring(fnode)
+    io = IOBuffer()
+
+    # code block with function definition
+    print(io, "    ", text(fnode, "name"), "(")
+    nspace = position(io)
+    params = LibExpat.find(fnode, "param")
+    if isempty(params)
+        print(io, ")")
+    end
+    for param in params
+        param !== first(params) && print(io, " "^nspace) # align
+        islast = param === last(params)
+        print(io, text(param, "{type}"))
+        # declname not always present (with void)
+        lastchar = islast ? ")" : ",\n"
+        if !isempty(LibExpat.find(param, "{declname}"))
+            print(io, " ", text(param, "{declname}"), lastchar)
+        else
+            print(io, lastchar)
+        end
+    end
+    println(io, " -> ", text(fnode, "type"))
+
+    # brief description
+    if !isempty(LibExpat.find(fnode, "briefdescription")) &&
+        !isempty(strip(LibExpat.find(fnode, "briefdescription#string")))
+        println(io, "\n", text(fnode, "briefdescription"))
+    end
+
+    # parameters
+    params = LibExpat.find(fnode, "detaileddescription/para/parameterlist/parameteritem")
+    if !isempty(params)
+        println(io, "\n### Parameters")
+        for param in params
+            print(io, "* **", text(param, "parameternamelist"), "**: ")
+            println(io, text(param, "parameterdescription"))
+        end
+    end
+
+    # returns
+    return_elems = xpath(fnode, "detaileddescription/para/simplesect[@kind='return']")
+    if !isempty(return_elems)
+        println(io, "\n### Returns")
+        println(io, text(return_elems[1], "para"))
+    end
+
+    takebuf_string(io)
+end
+
+workdir = dirname(@__FILE__)
+
+# Change GENERATE_XML to YES in the Doxyfile from the GDAL SVN
+# then run combine.xslt to create this XML file.
+xmlfile = joinpath(workdir, "all.xml")
+
+xmlstring = readall(xmlfile)
+et = xp_parse(xmlstring)
+functionnode(et, fname) = et["/doxygen/compounddef/sectiondef/memberdef[name='$fname']"][1]
+text(node::LibExpat.ETree, el::AbstractString) = strip(LibExpat.find(node, "$el#string"))

--- a/src/C/cpl_error.jl
+++ b/src/C/cpl_error.jl
@@ -3,74 +3,219 @@
 
 
 
+
+"""
+    CPLEmergencyError(const char * pszMessage) -> void
+
+Fatal error when things are bad.
+
+### Parameters
+* **pszMessage**: the error message to report.
+"""
 function CPLEmergencyError(arg1::Ptr{UInt8})
     ccall((:CPLEmergencyError,libgdal),Void,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    CPLErrorReset() -> void
+
+Erase any traces of previous errors.
+"""
 function CPLErrorReset()
     ccall((:CPLErrorReset,libgdal),Void,())
 end
 
+
+"""
+    CPLGetLastErrorNo() -> int
+
+Fetch the last error number.
+
+### Returns
+the error number of the last error to occur, or CPLE_None (0) if there are no posted errors.
+"""
 function CPLGetLastErrorNo()
     ccall((:CPLGetLastErrorNo,libgdal),Cint,())
 end
 
+
+"""
+    CPLGetLastErrorType() -> CPLErr
+
+Fetch the last error type.
+
+### Returns
+the error type of the last error to occur, or CE_None (0) if there are no posted errors.
+"""
 function CPLGetLastErrorType()
     ccall((:CPLGetLastErrorType,libgdal),CPLErr,())
 end
 
+
+"""
+    CPLGetLastErrorMsg() -> const char *
+
+Get the last error message.
+
+### Returns
+the last error message, or NULL if there is no posted error message.
+"""
 function CPLGetLastErrorMsg()
     ccall((:CPLGetLastErrorMsg,libgdal),Ptr{UInt8},())
 end
 
+
+"""
+    CPLGetErrorHandlerUserData(void) -> void *
+
+Fetch the user data for the error context.
+
+### Returns
+the user data pointer for the error context
+"""
 function CPLGetErrorHandlerUserData()
     ccall((:CPLGetErrorHandlerUserData,libgdal),Ptr{Void},())
 end
 
+
+"""
+    CPLErrorSetState(CPLErr eErrClass,
+                     int err_no,
+                     const char * pszMsg) -> void
+
+Restore an error state, without emitting an error.
+"""
 function CPLErrorSetState(eErrClass::CPLErr,err_no::Cint,pszMsg::Ptr{UInt8})
     ccall((:CPLErrorSetState,libgdal),Void,(CPLErr,Cint,Ptr{UInt8}),eErrClass,err_no,pszMsg)
 end
 
+
+"""
+    CPLCleanupErrorMutex() -> void
+"""
 function CPLCleanupErrorMutex()
     ccall((:CPLCleanupErrorMutex,libgdal),Void,())
 end
 
+
+"""
+    CPLLoggingErrorHandler(CPLErr eErrClass,
+                           int nError,
+                           const char * pszErrorMsg) -> void
+"""
 function CPLLoggingErrorHandler(arg1::CPLErr,arg2::Cint,arg3::Ptr{UInt8})
     ccall((:CPLLoggingErrorHandler,libgdal),Void,(CPLErr,Cint,Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    CPLDefaultErrorHandler(CPLErr eErrClass,
+                           int nError,
+                           const char * pszErrorMsg) -> void
+"""
 function CPLDefaultErrorHandler(arg1::CPLErr,arg2::Cint,arg3::Ptr{UInt8})
     ccall((:CPLDefaultErrorHandler,libgdal),Void,(CPLErr,Cint,Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    CPLQuietErrorHandler(CPLErr eErrClass,
+                         int nError,
+                         const char * pszErrorMsg) -> void
+"""
 function CPLQuietErrorHandler(arg1::CPLErr,arg2::Cint,arg3::Ptr{UInt8})
     ccall((:CPLQuietErrorHandler,libgdal),Void,(CPLErr,Cint,Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    CPLTurnFailureIntoWarning(int bOn) -> void
+"""
 function CPLTurnFailureIntoWarning(bOn::Cint)
     ccall((:CPLTurnFailureIntoWarning,libgdal),Void,(Cint,),bOn)
 end
 
+
+"""
+    CPLSetErrorHandler(CPLErrorHandler pfnErrorHandlerNew) -> CPLErrorHandler
+
+Install custom error handler.
+
+### Parameters
+* **pfnErrorHandlerNew**: new error handler function.
+
+### Returns
+returns the previously installed error handler.
+"""
 function CPLSetErrorHandler(arg1::CPLErrorHandler)
     ccall((:CPLSetErrorHandler,libgdal),CPLErrorHandler,(CPLErrorHandler,),arg1)
 end
 
+
+"""
+    CPLSetErrorHandlerEx(CPLErrorHandler pfnErrorHandlerNew,
+                         void * pUserData) -> CPLErrorHandler
+
+Install custom error handle with user's data.
+
+### Parameters
+* **pfnErrorHandlerNew**: new error handler function.
+* **pUserData**: User data to carry along with the error context.
+
+### Returns
+returns the previously installed error handler.
+"""
 function CPLSetErrorHandlerEx(arg1::CPLErrorHandler,arg2::Ptr{Void})
     ccall((:CPLSetErrorHandlerEx,libgdal),CPLErrorHandler,(CPLErrorHandler,Ptr{Void}),arg1,arg2)
 end
 
+
+"""
+    CPLPushErrorHandler(CPLErrorHandler pfnErrorHandlerNew) -> void
+
+Push a new CPLError handler.
+
+### Parameters
+* **pfnErrorHandlerNew**: new error handler function.
+"""
 function CPLPushErrorHandler(arg1::CPLErrorHandler)
     ccall((:CPLPushErrorHandler,libgdal),Void,(CPLErrorHandler,),arg1)
 end
 
+
+"""
+    CPLPushErrorHandlerEx(CPLErrorHandler pfnErrorHandlerNew,
+                          void * pUserData) -> void
+
+Push a new CPLError handler with user data on the error context.
+
+### Parameters
+* **pfnErrorHandlerNew**: new error handler function.
+* **pUserData**: User data to put on the error context.
+"""
 function CPLPushErrorHandlerEx(arg1::CPLErrorHandler,arg2::Ptr{Void})
     ccall((:CPLPushErrorHandlerEx,libgdal),Void,(CPLErrorHandler,Ptr{Void}),arg1,arg2)
 end
 
+
+"""
+    CPLPopErrorHandler() -> void
+
+Pop error handler off stack.
+"""
 function CPLPopErrorHandler()
     ccall((:CPLPopErrorHandler,libgdal),Void,())
 end
 
+
+"""
+    _CPLAssert(const char * pszExpression,
+               const char * pszFile,
+               int iLine) -> void
+
+Report failure of a logical assertion.
+"""
 function _CPLAssert(arg1::Ptr{UInt8},arg2::Ptr{UInt8},arg3::Cint)
     ccall((:_CPLAssert,libgdal),Void,(Ptr{UInt8},Ptr{UInt8},Cint),arg1,arg2,arg3)
 end

--- a/src/C/cpl_minixml.jl
+++ b/src/C/cpl_minixml.jl
@@ -2,74 +2,308 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    CPLParseXMLString(const char * pszString) -> CPLXMLNode *
+
+Parse an XML string into tree form.
+
+### Parameters
+* **pszString**: the document to parse.
+
+### Returns
+parsed tree or NULL on error.
+"""
 function CPLParseXMLString(arg1::Ptr{UInt8})
     ccall((:CPLParseXMLString,libgdal),Ptr{CPLXMLNode},(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    CPLDestroyXMLNode(CPLXMLNode * psNode) -> void
+
+Destroy a tree.
+
+### Parameters
+* **psNode**: the tree to free.
+"""
 function CPLDestroyXMLNode(arg1::Ptr{CPLXMLNode})
     ccall((:CPLDestroyXMLNode,libgdal),Void,(Ptr{CPLXMLNode},),arg1)
 end
 
+
+"""
+    CPLGetXMLNode(CPLXMLNode * psRoot,
+                  const char * pszPath) -> CPLXMLNode *
+
+Find node by path.
+
+### Parameters
+* **psRoot**: the subtree in which to search. This should be a node of type CXT_Element. NULL is safe.
+* **pszPath**: the list of element names in the path (dot separated).
+
+### Returns
+the requested element node, or NULL if not found.
+"""
 function CPLGetXMLNode(poRoot::Ptr{CPLXMLNode},pszPath::Ptr{UInt8})
     ccall((:CPLGetXMLNode,libgdal),Ptr{CPLXMLNode},(Ptr{CPLXMLNode},Ptr{UInt8}),poRoot,pszPath)
 end
 
+
+"""
+    CPLSearchXMLNode(CPLXMLNode * psRoot,
+                     const char * pszElement) -> CPLXMLNode *
+
+Search for a node in document.
+
+### Parameters
+* **psRoot**: the subtree to search. This should be a node of type CXT_Element. NULL is safe.
+* **pszElement**: the name of the element or attribute to search for.
+
+### Returns
+The matching node or NULL on failure.
+"""
 function CPLSearchXMLNode(poRoot::Ptr{CPLXMLNode},pszTarget::Ptr{UInt8})
     ccall((:CPLSearchXMLNode,libgdal),Ptr{CPLXMLNode},(Ptr{CPLXMLNode},Ptr{UInt8}),poRoot,pszTarget)
 end
 
+
+"""
+    CPLGetXMLValue(CPLXMLNode * psRoot,
+                   const char * pszPath,
+                   const char * pszDefault) -> const char *
+
+Fetch element/attribute value.
+
+### Parameters
+* **psRoot**: the subtree in which to search. This should be a node of type CXT_Element. NULL is safe.
+* **pszPath**: the list of element names in the path (dot separated). An empty path means get the value of the psRoot node.
+* **pszDefault**: the value to return if a corresponding value is not found, may be NULL.
+
+### Returns
+the requested value or pszDefault if not found.
+"""
 function CPLGetXMLValue(poRoot::Ptr{CPLXMLNode},pszPath::Ptr{UInt8},pszDefault::Ptr{UInt8})
     ccall((:CPLGetXMLValue,libgdal),Ptr{UInt8},(Ptr{CPLXMLNode},Ptr{UInt8},Ptr{UInt8}),poRoot,pszPath,pszDefault)
 end
 
+
+"""
+    CPLCreateXMLNode(CPLXMLNode * poParent,
+                     CPLXMLNodeType eType,
+                     const char * pszText) -> CPLXMLNode *
+
+Create an document tree item.
+
+### Parameters
+* **poParent**: the parent to which this node should be attached as a child. May be NULL to keep as free standing.
+* **eType**: the type of the newly created node
+* **pszText**: the value of the newly created node
+
+### Returns
+the newly created node, now owned by the caller (or parent node).
+"""
 function CPLCreateXMLNode(poParent::Ptr{CPLXMLNode},eType::CPLXMLNodeType,pszText::Ptr{UInt8})
     ccall((:CPLCreateXMLNode,libgdal),Ptr{CPLXMLNode},(Ptr{CPLXMLNode},CPLXMLNodeType,Ptr{UInt8}),poParent,eType,pszText)
 end
 
+
+"""
+    CPLSerializeXMLTree(const CPLXMLNode * psNode) -> char *
+
+Convert tree into string document.
+
+### Parameters
+* **psNode**: the node to serialize.
+
+### Returns
+the document on success or NULL on failure.
+"""
 function CPLSerializeXMLTree(psNode::Ptr{CPLXMLNode})
     ccall((:CPLSerializeXMLTree,libgdal),Ptr{UInt8},(Ptr{CPLXMLNode},),psNode)
 end
 
+
+"""
+    CPLAddXMLChild(CPLXMLNode * psParent,
+                   CPLXMLNode * psChild) -> void
+
+Add child node to parent.
+
+### Parameters
+* **psParent**: the node to attach the child to. May not be NULL.
+* **psChild**: the child to add to the parent. May not be NULL. Should not be a child of any other parent.
+"""
 function CPLAddXMLChild(psParent::Ptr{CPLXMLNode},psChild::Ptr{CPLXMLNode})
     ccall((:CPLAddXMLChild,libgdal),Void,(Ptr{CPLXMLNode},Ptr{CPLXMLNode}),psParent,psChild)
 end
 
+
+"""
+    CPLRemoveXMLChild(CPLXMLNode * psParent,
+                      CPLXMLNode * psChild) -> int
+
+Remove child node from parent.
+
+### Parameters
+* **psParent**: the node to the child is attached to.
+* **psChild**: the child to remove.
+
+### Returns
+TRUE on success or FALSE if the child was not found.
+"""
 function CPLRemoveXMLChild(psParent::Ptr{CPLXMLNode},psChild::Ptr{CPLXMLNode})
     ccall((:CPLRemoveXMLChild,libgdal),Cint,(Ptr{CPLXMLNode},Ptr{CPLXMLNode}),psParent,psChild)
 end
 
+
+"""
+    CPLAddXMLSibling(CPLXMLNode * psOlderSibling,
+                     CPLXMLNode * psNewSibling) -> void
+
+Add new sibling.
+
+### Parameters
+* **psOlderSibling**: the node to attach the sibling after.
+* **psNewSibling**: the node to add at the end of psOlderSiblings psNext chain.
+"""
 function CPLAddXMLSibling(psOlderSibling::Ptr{CPLXMLNode},psNewSibling::Ptr{CPLXMLNode})
     ccall((:CPLAddXMLSibling,libgdal),Void,(Ptr{CPLXMLNode},Ptr{CPLXMLNode}),psOlderSibling,psNewSibling)
 end
 
+
+"""
+    CPLCreateXMLElementAndValue(CPLXMLNode * psParent,
+                                const char * pszName,
+                                const char * pszValue) -> CPLXMLNode *
+
+Create an element and text value.
+
+### Parameters
+* **psParent**: the parent node to which the resulting node should be attached. May be NULL to keep as freestanding.
+* **pszName**: the element name to create.
+* **pszValue**: the text to attach to the element. Must not be NULL.
+
+### Returns
+the pointer to the new element node.
+"""
 function CPLCreateXMLElementAndValue(psParent::Ptr{CPLXMLNode},pszName::Ptr{UInt8},pszValue::Ptr{UInt8})
     ccall((:CPLCreateXMLElementAndValue,libgdal),Ptr{CPLXMLNode},(Ptr{CPLXMLNode},Ptr{UInt8},Ptr{UInt8}),psParent,pszName,pszValue)
 end
 
+
+"""
+    CPLAddXMLAttributeAndValue(CPLXMLNode * psParent,
+                               const char * pszName,
+                               const char * pszValue) -> void
+
+Create an attribute and text value.
+
+### Parameters
+* **psParent**: the parent node to which the resulting node should be attached. May be NULL to keep as freestanding.
+* **pszName**: the attribute name to create.
+* **pszValue**: the text to attach to the attribute. Must not be NULL.
+"""
 function CPLAddXMLAttributeAndValue(psParent::Ptr{CPLXMLNode},pszName::Ptr{UInt8},pszValue::Ptr{UInt8})
     ccall((:CPLAddXMLAttributeAndValue,libgdal),Void,(Ptr{CPLXMLNode},Ptr{UInt8},Ptr{UInt8}),psParent,pszName,pszValue)
 end
 
+
+"""
+    CPLCloneXMLTree(CPLXMLNode * psTree) -> CPLXMLNode *
+
+Copy tree.
+
+### Parameters
+* **psTree**: the tree to duplicate.
+
+### Returns
+a copy of the whole tree.
+"""
 function CPLCloneXMLTree(psTree::Ptr{CPLXMLNode})
     ccall((:CPLCloneXMLTree,libgdal),Ptr{CPLXMLNode},(Ptr{CPLXMLNode},),psTree)
 end
 
+
+"""
+    CPLSetXMLValue(CPLXMLNode * psRoot,
+                   const char * pszPath,
+                   const char * pszValue) -> int
+
+Set element value by path.
+
+### Parameters
+* **psRoot**: the subdocument to be updated.
+* **pszPath**: the dot seperated path to the target element/attribute.
+* **pszValue**: the text value to assign.
+
+### Returns
+TRUE on success.
+"""
 function CPLSetXMLValue(psRoot::Ptr{CPLXMLNode},pszPath::Ptr{UInt8},pszValue::Ptr{UInt8})
     ccall((:CPLSetXMLValue,libgdal),Cint,(Ptr{CPLXMLNode},Ptr{UInt8},Ptr{UInt8}),psRoot,pszPath,pszValue)
 end
 
+
+"""
+    CPLStripXMLNamespace(CPLXMLNode * psRoot,
+                         const char * pszNamespace,
+                         int bRecurse) -> void
+
+Strip indicated namespaces.
+
+### Parameters
+* **psRoot**: the document to operate on.
+* **pszNamespace**: the name space prefix (not including colon), or NULL.
+* **bRecurse**: TRUE to recurse over whole document, or FALSE to only operate on the passed node.
+"""
 function CPLStripXMLNamespace(psRoot::Ptr{CPLXMLNode},pszNameSpace::Ptr{UInt8},bRecurse::Cint)
     ccall((:CPLStripXMLNamespace,libgdal),Void,(Ptr{CPLXMLNode},Ptr{UInt8},Cint),psRoot,pszNameSpace,bRecurse)
 end
 
+
+"""
+    CPLCleanXMLElementName(char * pszTarget) -> void
+
+Make string into safe XML token.
+
+### Parameters
+* **pszTarget**: the string to be adjusted. It is altered in place.
+"""
 function CPLCleanXMLElementName(arg1::Ptr{UInt8})
     ccall((:CPLCleanXMLElementName,libgdal),Void,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    CPLParseXMLFile(const char * pszFilename) -> CPLXMLNode *
+
+Parse XML file into tree.
+
+### Parameters
+* **pszFilename**: the file to open.
+
+### Returns
+NULL on failure, or the document tree on success.
+"""
 function CPLParseXMLFile(pszFilename::Ptr{UInt8})
     ccall((:CPLParseXMLFile,libgdal),Ptr{CPLXMLNode},(Ptr{UInt8},),pszFilename)
 end
 
+
+"""
+    CPLSerializeXMLTreeToFile(const CPLXMLNode * psTree,
+                              const char * pszFilename) -> int
+
+Write document tree to a file.
+
+### Parameters
+* **psTree**: the document tree to write.
+* **pszFilename**: the name of the file to write to.
+
+### Returns
+TRUE on success, FALSE otherwise.
+"""
 function CPLSerializeXMLTreeToFile(psTree::Ptr{CPLXMLNode},pszFilename::Ptr{UInt8})
     ccall((:CPLSerializeXMLTreeToFile,libgdal),Cint,(Ptr{CPLXMLNode},Ptr{UInt8}),psTree,pszFilename)
 end

--- a/src/C/cpl_progress.jl
+++ b/src/C/cpl_progress.jl
@@ -2,22 +2,81 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    GDALDummyProgress(CPL_UNUSED double dfComplete,
+                      CPL_UNUSED const char * pszMessage,
+                      CPL_UNUSED void * pData) -> int
+
+Stub progress function.
+"""
 function GDALDummyProgress(arg1::Cdouble,arg2::Ptr{UInt8},arg3::Ptr{Void})
     ccall((:GDALDummyProgress,libgdal),Cint,(Cdouble,Ptr{UInt8},Ptr{Void}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALTermProgress(CPL_UNUSED double dfComplete,
+                     CPL_UNUSED const char * pszMessage,
+                     void * pProgressArg) -> int
+
+Simple progress report to terminal.
+
+### Parameters
+* **dfComplete**: completion ratio from 0.0 to 1.0.
+* **pszMessage**: optional message.
+* **pProgressArg**: ignored callback data argument.
+
+### Returns
+Always returns TRUE indicating the process should continue.
+"""
 function GDALTermProgress(arg1::Cdouble,arg2::Ptr{UInt8},arg3::Ptr{Void})
     ccall((:GDALTermProgress,libgdal),Cint,(Cdouble,Ptr{UInt8},Ptr{Void}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALScaledProgress(double dfComplete,
+                       const char * pszMessage,
+                       void * pData) -> int
+
+Scaled progress transformer.
+"""
 function GDALScaledProgress(arg1::Cdouble,arg2::Ptr{UInt8},arg3::Ptr{Void})
     ccall((:GDALScaledProgress,libgdal),Cint,(Cdouble,Ptr{UInt8},Ptr{Void}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALCreateScaledProgress(double dfMin,
+                             double dfMax,
+                             GDALProgressFunc pfnProgress,
+                             void * pData) -> void *
+
+Create scaled progress transformer.
+
+### Parameters
+* **dfMin**: the value to which 0.0 in the sub operation is mapped.
+* **dfMax**: the value to which 1.0 is the sub operation is mapped.
+* **pfnProgress**: the overall progress function.
+* **pData**: the overall progress function callback data.
+
+### Returns
+pointer to pass as pProgressArg to sub functions. Should be freed with GDALDestroyScaledProgress().
+"""
 function GDALCreateScaledProgress(arg1::Cdouble,arg2::Cdouble,arg3::GDALProgressFunc,arg4::Ptr{Void})
     ccall((:GDALCreateScaledProgress,libgdal),Ptr{Void},(Cdouble,Cdouble,GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALDestroyScaledProgress(void * pData) -> void
+
+Cleanup scaled progress handle.
+
+### Parameters
+* **pData**: scaled progress handle returned by GDALCreateScaledProgress().
+"""
 function GDALDestroyScaledProgress(arg1::Ptr{Void})
     ccall((:GDALDestroyScaledProgress,libgdal),Void,(Ptr{Void},),arg1)
 end

--- a/src/C/gdal.jl
+++ b/src/C/gdal.jl
@@ -2,870 +2,3036 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    GDALGetDataTypeSize(GDALDataType) -> int
+
+Get data type size in bits.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bits or zero if it is not recognised.
+"""
 function GDALGetDataTypeSize(arg1::GDALDataType)
     ccall((:GDALGetDataTypeSize,libgdal),Cint,(GDALDataType,),arg1)
 end
 
+
+"""
+    GDALDataTypeIsComplex(GDALDataType) -> int
+
+Is data type complex?
+
+### Returns
+TRUE if the passed type is complex (one of GDT_CInt16, GDT_CInt32, GDT_CFloat32 or GDT_CFloat64), that is it consists of a real and imaginary component.
+"""
 function GDALDataTypeIsComplex(arg1::GDALDataType)
     ccall((:GDALDataTypeIsComplex,libgdal),Cint,(GDALDataType,),arg1)
 end
 
+
+"""
+    GDALGetDataTypeName(GDALDataType) -> const char *
+
+Get name of data type.
+
+### Parameters
+* **eDataType**: type to get name of.
+
+### Returns
+string corresponding to existing data type or NULL pointer if invalid type given.
+"""
 function GDALGetDataTypeName(arg1::GDALDataType)
     ccall((:GDALGetDataTypeName,libgdal),Ptr{UInt8},(GDALDataType,),arg1)
 end
 
+
+"""
+    GDALGetDataTypeByName(const char *) -> GDALDataType
+
+Get data type by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the type.
+
+### Returns
+GDAL data type.
+"""
 function GDALGetDataTypeByName(arg1::Ptr{UInt8})
     ccall((:GDALGetDataTypeByName,libgdal),GDALDataType,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALDataTypeUnion(GDALDataType,
+                      GDALDataType) -> GDALDataType
+
+Return the smallest data type that can fully express both input data types.
+
+### Parameters
+* **eType1**: first data type.
+* **eType2**: second data type.
+
+### Returns
+a data type able to express eType1 and eType2.
+"""
 function GDALDataTypeUnion(arg1::GDALDataType,arg2::GDALDataType)
     ccall((:GDALDataTypeUnion,libgdal),GDALDataType,(GDALDataType,GDALDataType),arg1,arg2)
 end
 
+
+"""
+    GDALGetAsyncStatusTypeName(GDALAsyncStatusType) -> const char *
+
+Get name of AsyncStatus data type.
+
+### Parameters
+* **eAsyncStatusType**: type to get name of.
+
+### Returns
+string corresponding to type.
+"""
 function GDALGetAsyncStatusTypeName(arg1::GDALAsyncStatusType)
     ccall((:GDALGetAsyncStatusTypeName,libgdal),Ptr{UInt8},(GDALAsyncStatusType,),arg1)
 end
 
+
+"""
+    GDALGetAsyncStatusTypeByName(const char *) -> GDALAsyncStatusType
+
+Get AsyncStatusType by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the type.
+
+### Returns
+GDAL AsyncStatus type.
+"""
 function GDALGetAsyncStatusTypeByName(arg1::Ptr{UInt8})
     ccall((:GDALGetAsyncStatusTypeByName,libgdal),GDALAsyncStatusType,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALGetColorInterpretationName(GDALColorInterp) -> const char *
+
+Get name of color interpretation.
+
+### Parameters
+* **eInterp**: color interpretation to get name of.
+
+### Returns
+string corresponding to color interpretation or NULL pointer if invalid enumerator given.
+"""
 function GDALGetColorInterpretationName(arg1::GDALColorInterp)
     ccall((:GDALGetColorInterpretationName,libgdal),Ptr{UInt8},(GDALColorInterp,),arg1)
 end
 
+
+"""
+    GDALGetColorInterpretationByName(const char * pszName) -> GDALColorInterp
+
+Get color interpreation by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the color interpretation.
+
+### Returns
+GDAL color interpretation.
+"""
 function GDALGetColorInterpretationByName(pszName::Ptr{UInt8})
     ccall((:GDALGetColorInterpretationByName,libgdal),GDALColorInterp,(Ptr{UInt8},),pszName)
 end
 
+
+"""
+    GDALGetPaletteInterpretationName(GDALPaletteInterp) -> const char *
+
+Get name of palette interpretation.
+
+### Parameters
+* **eInterp**: palette interpretation to get name of.
+
+### Returns
+string corresponding to palette interpretation.
+"""
 function GDALGetPaletteInterpretationName(arg1::GDALPaletteInterp)
     ccall((:GDALGetPaletteInterpretationName,libgdal),Ptr{UInt8},(GDALPaletteInterp,),arg1)
 end
 
+
+"""
+    GDALAllRegister(void) -> void
+
+Register all known configured GDAL drivers.
+"""
 function GDALAllRegister()
     ccall((:GDALAllRegister,libgdal),Void,())
 end
 
+
+"""
+    GDALCreate(GDALDriverH hDriver,
+               const char *,
+               int,
+               int,
+               int,
+               GDALDataType,
+               char **) -> GDALDatasetH
+
+Create a new dataset with this driver.
+"""
 function GDALCreate(hDriver::GDALDriverH,arg1::Ptr{UInt8},arg2::Cint,arg3::Cint,arg4::Cint,arg5::GDALDataType,arg6::Ptr{Ptr{UInt8}})
     ccall((:GDALCreate,libgdal),GDALDatasetH,(GDALDriverH,Ptr{UInt8},Cint,Cint,Cint,GDALDataType,Ptr{Ptr{UInt8}}),hDriver,arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    GDALCreateCopy(GDALDriverH,
+                   const char *,
+                   GDALDatasetH,
+                   int,
+                   char **,
+                   GDALProgressFunc,
+                   void *) -> GDALDatasetH
+
+Create a copy of a dataset.
+"""
 function GDALCreateCopy(arg1::GDALDriverH,arg2::Ptr{UInt8},arg3::GDALDatasetH,arg4::Cint,arg5::Ptr{Ptr{UInt8}},arg6::GDALProgressFunc,arg7::Ptr{Void})
     ccall((:GDALCreateCopy,libgdal),GDALDatasetH,(GDALDriverH,Ptr{UInt8},GDALDatasetH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7)
 end
 
+
+"""
+    GDALIdentifyDriver(const char * pszFilename,
+                       char ** papszFileList) -> GDALDriverH
+
+Identify the driver that can open a raster file.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset.
+* **papszFileList**: an array of strings, whose last element is the NULL pointer. These strings are filenames that are auxiliary to the main filename. The passed value may be NULL.
+
+### Returns
+A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
+"""
 function GDALIdentifyDriver(pszFilename::Ptr{UInt8},papszFileList::Ptr{Ptr{UInt8}})
     ccall((:GDALIdentifyDriver,libgdal),GDALDriverH,(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszFilename,papszFileList)
 end
 
+
+"""
+    GDALOpen(const char * pszFilename,
+             GDALAccess eAccess) -> GDALDatasetH
+
+Open a raster file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **eAccess**: the desired access, either GA_Update or GA_ReadOnly. Many drivers support only read only access.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function GDALOpen(pszFilename::Ptr{UInt8},eAccess::GDALAccess)
     ccall((:GDALOpen,libgdal),GDALDatasetH,(Ptr{UInt8},GDALAccess),pszFilename,eAccess)
 end
 
+
+"""
+    GDALOpenShared(const char *,
+                   GDALAccess) -> GDALDatasetH
+
+Open a raster file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **eAccess**: the desired access, either GA_Update or GA_ReadOnly. Many drivers support only read only access.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function GDALOpenShared(arg1::Ptr{UInt8},arg2::GDALAccess)
     ccall((:GDALOpenShared,libgdal),GDALDatasetH,(Ptr{UInt8},GDALAccess),arg1,arg2)
 end
 
+
+"""
+    GDALOpenEx(const char * pszFilename,
+               unsigned int nOpenFlags,
+               const char *const * papszAllowedDrivers,
+               const char *const * papszOpenOptions,
+               const char *const * papszSiblingFiles) -> friend GDALDatasetH
+
+Open a raster or vector file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **nOpenFlags**: a combination of GDAL_OF_ flags that may be combined through logical or operator. 
+
+Driver kind: GDAL_OF_RASTER for raster drivers, GDAL_OF_VECTOR for vector drivers. If none of the value is specified, both kinds are implied. 
+
+Access mode: GDAL_OF_READONLY (exclusive)or GDAL_OF_UPDATE. 
+
+Shared mode: GDAL_OF_SHARED. If set, it allows the sharing of GDALDataset handles for a dataset with other callers that have set GDAL_OF_SHARED. In particular, GDALOpenEx() will first consult its list of currently open and shared GDALDataset's, and if the GetDescription() name for one exactly matches the pszFilename passed to GDALOpenEx() it will be referenced and returned, if GDALOpenEx() is called from the same thread. 
+
+Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file will lead to an error message to be reported.
+* **papszAllowedDrivers**: NULL to consider all candidate drivers, or a NULL terminated list of strings with the driver short names that must be considered.
+* **papszOpenOptions**: NULL, or a NULL terminated list of strings with open options passed to candidate drivers. An option exists for all drivers, OVERVIEW_LEVEL=level, to select a particular overview level of a dataset. The level index starts at 0. The level number can be suffixed by "only" to specify that only this overview level must be visible, and not sub-levels. Open options are validated by default, and a warning is emitted in case the option is not recognized. In some scenarios, it might be not desirable (e.g. when not knowing which driver will open the file), so the special open option VALIDATE_OPEN_OPTIONS can be set to NO to avoid such warnings.
+* **papszSiblingFiles**: NULL, or a NULL terminated list of strings that are filenames that are auxiliary to the main filename. If NULL is passed, a probing of the file system will be done.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function GDALOpenEx(pszFilename::Ptr{UInt8},nOpenFlags::UInt32,papszAllowedDrivers::Ptr{Ptr{UInt8}},papszOpenOptions::Ptr{Ptr{UInt8}},papszSiblingFiles::Ptr{Ptr{UInt8}})
     ccall((:GDALOpenEx,libgdal),GDALDatasetH,(Ptr{UInt8},UInt32,Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}}),pszFilename,nOpenFlags,papszAllowedDrivers,papszOpenOptions,papszSiblingFiles)
 end
 
+
+"""
+    GDALDumpOpenDatasets(FILE *) -> int
+
+List open datasets.
+"""
 function GDALDumpOpenDatasets(arg1::Ptr{FILE})
     ccall((:GDALDumpOpenDatasets,libgdal),Cint,(Ptr{FILE},),arg1)
 end
 
+
+"""
+    GDALGetDriverByName(const char *) -> GDALDriverH
+
+Fetch a driver based on the short name.
+"""
 function GDALGetDriverByName(arg1::Ptr{UInt8})
     ccall((:GDALGetDriverByName,libgdal),GDALDriverH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALGetDriverCount(void) -> int
+
+Fetch the number of registered drivers.
+"""
 function GDALGetDriverCount()
     ccall((:GDALGetDriverCount,libgdal),Cint,())
 end
 
+
+"""
+    GDALGetDriver(int) -> GDALDriverH
+
+Fetch driver by index.
+"""
 function GDALGetDriver(arg1::Cint)
     ccall((:GDALGetDriver,libgdal),GDALDriverH,(Cint,),arg1)
 end
 
+
+"""
+    GDALDestroyDriver(GDALDriverH) -> void
+
+Destroy a GDALDriver.
+
+### Parameters
+* **hDriver**: the driver to destroy.
+"""
 function GDALDestroyDriver(arg1::GDALDriverH)
     ccall((:GDALDestroyDriver,libgdal),Void,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALRegisterDriver(GDALDriverH) -> int
+
+Register a driver for use.
+"""
 function GDALRegisterDriver(arg1::GDALDriverH)
     ccall((:GDALRegisterDriver,libgdal),Cint,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALDeregisterDriver(GDALDriverH) -> void
+
+Deregister the passed driver.
+"""
 function GDALDeregisterDriver(arg1::GDALDriverH)
     ccall((:GDALDeregisterDriver,libgdal),Void,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALDestroyDriverManager(void) -> void
+
+Destroy the driver manager.
+"""
 function GDALDestroyDriverManager()
     ccall((:GDALDestroyDriverManager,libgdal),Void,())
 end
 
+
+"""
+    GDALDestroy(void) -> void
+"""
 function GDALDestroy()
     ccall((:GDALDestroy,libgdal),Void,())
 end
 
+
+"""
+    GDALDeleteDataset(GDALDriverH,
+                      const char *) -> CPLErr
+
+Delete named dataset.
+"""
 function GDALDeleteDataset(arg1::GDALDriverH,arg2::Ptr{UInt8})
     ccall((:GDALDeleteDataset,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALRenameDataset(GDALDriverH,
+                      const char * pszNewName,
+                      const char * pszOldName) -> CPLErr
+
+Rename a dataset.
+"""
 function GDALRenameDataset(arg1::GDALDriverH,pszNewName::Ptr{UInt8},pszOldName::Ptr{UInt8})
     ccall((:GDALRenameDataset,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8},Ptr{UInt8}),arg1,pszNewName,pszOldName)
 end
 
+
+"""
+    GDALCopyDatasetFiles(GDALDriverH,
+                         const char * pszNewName,
+                         const char * pszOldName) -> CPLErr
+
+Copy the files of a dataset.
+"""
 function GDALCopyDatasetFiles(arg1::GDALDriverH,pszNewName::Ptr{UInt8},pszOldName::Ptr{UInt8})
     ccall((:GDALCopyDatasetFiles,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8},Ptr{UInt8}),arg1,pszNewName,pszOldName)
 end
 
+
+"""
+    GDALValidateCreationOptions(GDALDriverH,
+                                char ** papszCreationOptions) -> int
+
+Validate the list of creation options that are handled by a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver with whom the lists of creation option must be validated
+* **papszCreationOptions**: the list of creation options. An array of strings, whose last element is a NULL pointer
+
+### Returns
+TRUE if the list of creation options is compatible with the Create() and CreateCopy() method of the driver, FALSE otherwise.
+"""
 function GDALValidateCreationOptions(arg1::GDALDriverH,papszCreationOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALValidateCreationOptions,libgdal),Cint,(GDALDriverH,Ptr{Ptr{UInt8}}),arg1,papszCreationOptions)
 end
 
+
+"""
+    GDALGetDriverShortName(GDALDriverH) -> const char *
+
+Return the short name of a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the short name of the driver. The returned string should not be freed and is owned by the driver.
+"""
 function GDALGetDriverShortName(arg1::GDALDriverH)
     ccall((:GDALGetDriverShortName,libgdal),Ptr{UInt8},(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALGetDriverLongName(GDALDriverH) -> const char *
+
+Return the long name of a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the long name of the driver or empty string. The returned string should not be freed and is owned by the driver.
+"""
 function GDALGetDriverLongName(arg1::GDALDriverH)
     ccall((:GDALGetDriverLongName,libgdal),Ptr{UInt8},(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALGetDriverHelpTopic(GDALDriverH) -> const char *
+
+Return the URL to the help that describes the driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the URL to the help that describes the driver or NULL. The returned string should not be freed and is owned by the driver.
+"""
 function GDALGetDriverHelpTopic(arg1::GDALDriverH)
     ccall((:GDALGetDriverHelpTopic,libgdal),Ptr{UInt8},(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALGetDriverCreationOptionList(GDALDriverH) -> const char *
+
+Return the list of creation options of the driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+an XML string that describes the list of creation options or empty string. The returned string should not be freed and is owned by the driver.
+"""
 function GDALGetDriverCreationOptionList(arg1::GDALDriverH)
     ccall((:GDALGetDriverCreationOptionList,libgdal),Ptr{UInt8},(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALInitGCPs(int,
+                 GDAL_GCP *) -> void
+"""
 function GDALInitGCPs(arg1::Cint,arg2::Ptr{GDAL_GCP})
     ccall((:GDALInitGCPs,libgdal),Void,(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALDeinitGCPs(int,
+                   GDAL_GCP *) -> void
+"""
 function GDALDeinitGCPs(arg1::Cint,arg2::Ptr{GDAL_GCP})
     ccall((:GDALDeinitGCPs,libgdal),Void,(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALDuplicateGCPs(int,
+                      const GDAL_GCP *) -> GDAL_GCP *
+"""
 function GDALDuplicateGCPs(arg1::Cint,arg2::Ptr{GDAL_GCP})
     ccall((:GDALDuplicateGCPs,libgdal),Ptr{GDAL_GCP},(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALGCPsToGeoTransform(int nGCPCount,
+                           const GDAL_GCP * pasGCPs,
+                           double * padfGeoTransform,
+                           int bApproxOK) -> int
+
+Generate Geotransform from GCPs.
+
+### Parameters
+* **nGCPCount**: the number of GCPs being passed in.
+* **pasGCPs**: the list of GCP structures.
+* **padfGeoTransform**: the six double array in which the affine geotransformation will be returned.
+* **bApproxOK**: If FALSE the function will fail if the geotransform is not essentially an exact fit (within 0.25 pixel) for all GCPs.
+
+### Returns
+TRUE on success or FALSE if there aren't enough points to prepare a geotransform, the pointers are ill-determined or if bApproxOK is FALSE and the fit is poor.
+"""
 function GDALGCPsToGeoTransform(nGCPCount::Cint,pasGCPs::Ptr{GDAL_GCP},padfGeoTransform::Ptr{Cdouble},bApproxOK::Cint)
     ccall((:GDALGCPsToGeoTransform,libgdal),Cint,(Cint,Ptr{GDAL_GCP},Ptr{Cdouble},Cint),nGCPCount,pasGCPs,padfGeoTransform,bApproxOK)
 end
 
+
+"""
+    GDALInvGeoTransform(double * padfGeoTransformIn,
+                        double * padfInvGeoTransformOut) -> int
+
+Invert Geotransform.
+
+### Parameters
+* **gt_in**: Input geotransform (six doubles - unaltered).
+* **gt_out**: Output geotransform (six doubles - updated).
+
+### Returns
+TRUE on success or FALSE if the equation is uninvertable.
+"""
 function GDALInvGeoTransform(padfGeoTransformIn::Ptr{Cdouble},padfInvGeoTransformOut::Ptr{Cdouble})
     ccall((:GDALInvGeoTransform,libgdal),Cint,(Ptr{Cdouble},Ptr{Cdouble}),padfGeoTransformIn,padfInvGeoTransformOut)
 end
 
+
+"""
+    GDALApplyGeoTransform(double *,
+                          double,
+                          double,
+                          double *,
+                          double *) -> void
+
+Apply GeoTransform to x/y coordinate.
+
+### Parameters
+* **padfGeoTransform**: Six coefficient GeoTransform to apply.
+* **dfPixel**: Input pixel position.
+* **dfLine**: Input line position.
+* **pdfGeoX**: output location where geo_x (easting/longitude) location is placed.
+* **pdfGeoY**: output location where geo_y (northing/latitude) location is placed.
+"""
 function GDALApplyGeoTransform(arg1::Ptr{Cdouble},arg2::Cdouble,arg3::Cdouble,arg4::Ptr{Cdouble},arg5::Ptr{Cdouble})
     ccall((:GDALApplyGeoTransform,libgdal),Void,(Ptr{Cdouble},Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALComposeGeoTransforms(const double * padfGeoTransform1,
+                             const double * padfGeoTransform2,
+                             double * padfGeoTransformOut) -> void
+
+Compose two geotransforms.
+
+### Parameters
+* **padfGT1**: the first geotransform, six values.
+* **padfGT2**: the second geotransform, six values.
+* **padfGTOut**: the output geotransform, six values, may safely be the same array as padfGT1 or padfGT2.
+"""
 function GDALComposeGeoTransforms(padfGeoTransform1::Ptr{Cdouble},padfGeoTransform2::Ptr{Cdouble},padfGeoTransformOut::Ptr{Cdouble})
     ccall((:GDALComposeGeoTransforms,libgdal),Void,(Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),padfGeoTransform1,padfGeoTransform2,padfGeoTransformOut)
 end
 
+
+"""
+    GDALGetMetadataDomainList(GDALMajorObjectH hObject) -> char **
+
+Fetch list of metadata domains.
+"""
 function GDALGetMetadataDomainList(hObject::GDALMajorObjectH)
     ccall((:GDALGetMetadataDomainList,libgdal),Ptr{Ptr{UInt8}},(GDALMajorObjectH,),hObject)
 end
 
+
+"""
+    GDALGetMetadata(GDALMajorObjectH,
+                    const char *) -> char **
+
+Fetch metadata.
+"""
 function GDALGetMetadata(arg1::GDALMajorObjectH,arg2::Ptr{UInt8})
     ccall((:GDALGetMetadata,libgdal),Ptr{Ptr{UInt8}},(GDALMajorObjectH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALSetMetadata(GDALMajorObjectH,
+                    char **,
+                    const char *) -> CPLErr
+
+Set metadata.
+"""
 function GDALSetMetadata(arg1::GDALMajorObjectH,arg2::Ptr{Ptr{UInt8}},arg3::Ptr{UInt8})
     ccall((:GDALSetMetadata,libgdal),CPLErr,(GDALMajorObjectH,Ptr{Ptr{UInt8}},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALGetMetadataItem(GDALMajorObjectH,
+                        const char *,
+                        const char *) -> const char *
+
+Fetch single metadata item.
+"""
 function GDALGetMetadataItem(arg1::GDALMajorObjectH,arg2::Ptr{UInt8},arg3::Ptr{UInt8})
     ccall((:GDALGetMetadataItem,libgdal),Ptr{UInt8},(GDALMajorObjectH,Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALSetMetadataItem(GDALMajorObjectH,
+                        const char *,
+                        const char *,
+                        const char *) -> CPLErr
+
+Set single metadata item.
+"""
 function GDALSetMetadataItem(arg1::GDALMajorObjectH,arg2::Ptr{UInt8},arg3::Ptr{UInt8},arg4::Ptr{UInt8})
     ccall((:GDALSetMetadataItem,libgdal),CPLErr,(GDALMajorObjectH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetDescription(GDALMajorObjectH) -> const char *
+
+Fetch object description.
+"""
 function GDALGetDescription(arg1::GDALMajorObjectH)
     ccall((:GDALGetDescription,libgdal),Ptr{UInt8},(GDALMajorObjectH,),arg1)
 end
 
+
+"""
+    GDALSetDescription(GDALMajorObjectH,
+                       const char *) -> void
+
+Set object description.
+"""
 function GDALSetDescription(arg1::GDALMajorObjectH,arg2::Ptr{UInt8})
     ccall((:GDALSetDescription,libgdal),Void,(GDALMajorObjectH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALGetDatasetDriver(GDALDatasetH) -> GDALDriverH
+
+Fetch the driver to which this dataset relates.
+"""
 function GDALGetDatasetDriver(arg1::GDALDatasetH)
     ccall((:GDALGetDatasetDriver,libgdal),GDALDriverH,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetFileList(GDALDatasetH) -> char **
+
+Fetch files forming dataset.
+"""
 function GDALGetFileList(arg1::GDALDatasetH)
     ccall((:GDALGetFileList,libgdal),Ptr{Ptr{UInt8}},(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALClose(GDALDatasetH hDS) -> friend void
+
+Close GDAL dataset.
+
+### Parameters
+* **hDS**: The dataset to close. May be cast from a "GDALDataset *".
+"""
 function GDALClose(arg1::GDALDatasetH)
     ccall((:GDALClose,libgdal),Void,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterXSize(GDALDatasetH) -> int
+
+Fetch raster width in pixels.
+"""
 function GDALGetRasterXSize(arg1::GDALDatasetH)
     ccall((:GDALGetRasterXSize,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterYSize(GDALDatasetH) -> int
+
+Fetch raster height in pixels.
+"""
 function GDALGetRasterYSize(arg1::GDALDatasetH)
     ccall((:GDALGetRasterYSize,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterCount(GDALDatasetH) -> int
+
+Fetch the number of raster bands on this dataset.
+"""
 function GDALGetRasterCount(arg1::GDALDatasetH)
     ccall((:GDALGetRasterCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterBand(GDALDatasetH,
+                      int) -> GDALRasterBandH
+
+Fetch a band object for a dataset.
+"""
 function GDALGetRasterBand(arg1::GDALDatasetH,arg2::Cint)
     ccall((:GDALGetRasterBand,libgdal),GDALRasterBandH,(GDALDatasetH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALAddBand(GDALDatasetH hDS,
+                GDALDataType eType,
+                char ** papszOptions) -> CPLErr
+
+Add a band to a dataset.
+"""
 function GDALAddBand(hDS::GDALDatasetH,eType::GDALDataType,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALAddBand,libgdal),CPLErr,(GDALDatasetH,GDALDataType,Ptr{Ptr{UInt8}}),hDS,eType,papszOptions)
 end
 
+
+"""
+    GDALBeginAsyncReader(GDALDatasetH hDS,
+                         int nXOff,
+                         int nYOff,
+                         int nXSize,
+                         int nYSize,
+                         void * pBuf,
+                         int nBufXSize,
+                         int nBufYSize,
+                         GDALDataType eBufType,
+                         int nBandCount,
+                         int * panBandMap,
+                         int nPixelSpace,
+                         int nLineSpace,
+                         int nBandSpace,
+                         char ** papszOptions) -> GDALAsyncReaderH
+"""
 function GDALBeginAsyncReader(hDS::GDALDatasetH,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,pBuf::Ptr{Void},nBufXSize::Cint,nBufYSize::Cint,eBufType::GDALDataType,nBandCount::Cint,panBandMap::Ptr{Cint},nPixelSpace::Cint,nLineSpace::Cint,nBandSpace::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALBeginAsyncReader,libgdal),GDALAsyncReaderH,(GDALDatasetH,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,Cint,Cint,Ptr{Ptr{UInt8}}),hDS,nXOff,nYOff,nXSize,nYSize,pBuf,nBufXSize,nBufYSize,eBufType,nBandCount,panBandMap,nPixelSpace,nLineSpace,nBandSpace,papszOptions)
 end
 
+
+"""
+    GDALEndAsyncReader(GDALDatasetH hDS,
+                       GDALAsyncReaderH hAsynchReaderH) -> void
+"""
 function GDALEndAsyncReader(hDS::GDALDatasetH,hAsynchReaderH::GDALAsyncReaderH)
     ccall((:GDALEndAsyncReader,libgdal),Void,(GDALDatasetH,GDALAsyncReaderH),hDS,hAsynchReaderH)
 end
 
+
+"""
+    GDALDatasetRasterIO(GDALDatasetH hDS,
+                        GDALRWFlag eRWFlag,
+                        int nDSXOff,
+                        int nDSYOff,
+                        int nDSXSize,
+                        int nDSYSize,
+                        void * pBuffer,
+                        int nBXSize,
+                        int nBYSize,
+                        GDALDataType eBDataType,
+                        int nBandCount,
+                        int * panBandCount,
+                        int nPixelSpace,
+                        int nLineSpace,
+                        int nBandSpace) -> CPLErr
+
+Read/write a region of image data from multiple bands.
+"""
 function GDALDatasetRasterIO(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,pBuffer::Ptr{Void},nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,nBandCount::Cint,panBandCount::Ptr{Cint},nPixelSpace::Cint,nLineSpace::Cint,nBandSpace::Cint)
     ccall((:GDALDatasetRasterIO,libgdal),CPLErr,(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,Cint,Cint),hDS,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,nPixelSpace,nLineSpace,nBandSpace)
 end
 
+
+"""
+    GDALDatasetRasterIOEx(GDALDatasetH hDS,
+                          GDALRWFlag eRWFlag,
+                          int nDSXOff,
+                          int nDSYOff,
+                          int nDSXSize,
+                          int nDSYSize,
+                          void * pBuffer,
+                          int nBXSize,
+                          int nBYSize,
+                          GDALDataType eBDataType,
+                          int nBandCount,
+                          int * panBandCount,
+                          GSpacing nPixelSpace,
+                          GSpacing nLineSpace,
+                          GSpacing nBandSpace,
+                          GDALRasterIOExtraArg * psExtraArg) -> CPLErr
+
+Read/write a region of image data from multiple bands.
+"""
 function GDALDatasetRasterIOEx(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,pBuffer::Ptr{Void},nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,nBandCount::Cint,panBandCount::Ptr{Cint},nPixelSpace::GSpacing,nLineSpace::GSpacing,nBandSpace::GSpacing,psExtraArg::Ptr{GDALRasterIOExtraArg})
     ccall((:GDALDatasetRasterIOEx,libgdal),CPLErr,(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},GSpacing,GSpacing,GSpacing,Ptr{GDALRasterIOExtraArg}),hDS,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,nPixelSpace,nLineSpace,nBandSpace,psExtraArg)
 end
 
+
+"""
+    GDALDatasetAdviseRead(GDALDatasetH hDS,
+                          int nDSXOff,
+                          int nDSYOff,
+                          int nDSXSize,
+                          int nDSYSize,
+                          int nBXSize,
+                          int nBYSize,
+                          GDALDataType eBDataType,
+                          int nBandCount,
+                          int * panBandCount,
+                          char ** papszOptions) -> CPLErr
+
+Advise driver of upcoming read requests.
+"""
 function GDALDatasetAdviseRead(hDS::GDALDatasetH,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,nBandCount::Cint,panBandCount::Ptr{Cint},papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALDatasetAdviseRead,libgdal),CPLErr,(GDALDatasetH,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},Ptr{Ptr{UInt8}}),hDS,nDSXOff,nDSYOff,nDSXSize,nDSYSize,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,papszOptions)
 end
 
+
+"""
+    GDALGetProjectionRef(GDALDatasetH) -> const char *
+
+Fetch the projection definition string for this dataset.
+"""
 function GDALGetProjectionRef(arg1::GDALDatasetH)
     ccall((:GDALGetProjectionRef,libgdal),Ptr{UInt8},(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALSetProjection(GDALDatasetH,
+                      const char *) -> CPLErr
+
+Set the projection reference string for this dataset.
+"""
 function GDALSetProjection(arg1::GDALDatasetH,arg2::Ptr{UInt8})
     ccall((:GDALSetProjection,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALGetGeoTransform(GDALDatasetH,
+                        double *) -> CPLErr
+
+Fetch the affine transformation coefficients.
+"""
 function GDALGetGeoTransform(arg1::GDALDatasetH,arg2::Ptr{Cdouble})
     ccall((:GDALGetGeoTransform,libgdal),CPLErr,(GDALDatasetH,Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALSetGeoTransform(GDALDatasetH,
+                        double *) -> CPLErr
+
+Set the affine transformation coefficients.
+"""
 function GDALSetGeoTransform(arg1::GDALDatasetH,arg2::Ptr{Cdouble})
     ccall((:GDALSetGeoTransform,libgdal),CPLErr,(GDALDatasetH,Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALGetGCPCount(GDALDatasetH) -> int
+
+Get number of GCPs.
+"""
 function GDALGetGCPCount(arg1::GDALDatasetH)
     ccall((:GDALGetGCPCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetGCPProjection(GDALDatasetH) -> const char *
+
+Get output projection for GCPs.
+"""
 function GDALGetGCPProjection(arg1::GDALDatasetH)
     ccall((:GDALGetGCPProjection,libgdal),Ptr{UInt8},(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetGCPs(GDALDatasetH) -> const GDAL_GCP *
+
+Fetch GCPs.
+"""
 function GDALGetGCPs(arg1::GDALDatasetH)
     ccall((:GDALGetGCPs,libgdal),Ptr{GDAL_GCP},(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALSetGCPs(GDALDatasetH,
+                int,
+                const GDAL_GCP *,
+                const char *) -> CPLErr
+
+Assign GCPs.
+"""
 function GDALSetGCPs(arg1::GDALDatasetH,arg2::Cint,arg3::Ptr{GDAL_GCP},arg4::Ptr{UInt8})
     ccall((:GDALSetGCPs,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{GDAL_GCP},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetInternalHandle(GDALDatasetH,
+                          const char *) -> void *
+
+Fetch a format specific internally meaningful handle.
+"""
 function GDALGetInternalHandle(arg1::GDALDatasetH,arg2::Ptr{UInt8})
     ccall((:GDALGetInternalHandle,libgdal),Ptr{Void},(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALReferenceDataset(GDALDatasetH) -> int
+
+Add one to dataset reference count.
+"""
 function GDALReferenceDataset(arg1::GDALDatasetH)
     ccall((:GDALReferenceDataset,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALDereferenceDataset(GDALDatasetH) -> int
+
+Subtract one from dataset reference count.
+"""
 function GDALDereferenceDataset(arg1::GDALDatasetH)
     ccall((:GDALDereferenceDataset,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALBuildOverviews(GDALDatasetH,
+                       const char *,
+                       int,
+                       int *,
+                       int,
+                       int *,
+                       GDALProgressFunc,
+                       void *) -> CPLErr
+
+Build raster overview(s)
+"""
 function GDALBuildOverviews(arg1::GDALDatasetH,arg2::Ptr{UInt8},arg3::Cint,arg4::Ptr{Cint},arg5::Cint,arg6::Ptr{Cint},arg7::GDALProgressFunc,arg8::Ptr{Void})
     ccall((:GDALBuildOverviews,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8},Cint,Ptr{Cint},Cint,Ptr{Cint},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)
 end
 
+
+"""
+    GDALGetOpenDatasets(GDALDatasetH ** hDS,
+                        int * pnCount) -> void
+
+Fetch all open GDAL dataset handles.
+"""
 function GDALGetOpenDatasets(hDS::Ptr{Ptr{GDALDatasetH}},pnCount::Ptr{Cint})
     ccall((:GDALGetOpenDatasets,libgdal),Void,(Ptr{Ptr{GDALDatasetH}},Ptr{Cint}),hDS,pnCount)
 end
 
+
+"""
+    GDALGetAccess(GDALDatasetH hDS) -> int
+
+Return access flag.
+"""
 function GDALGetAccess(hDS::GDALDatasetH)
     ccall((:GDALGetAccess,libgdal),Cint,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALFlushCache(GDALDatasetH hDS) -> void
+
+Flush all write cached data to disk.
+"""
 function GDALFlushCache(hDS::GDALDatasetH)
     ccall((:GDALFlushCache,libgdal),Void,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALCreateDatasetMaskBand(GDALDatasetH hDS,
+                              int nFlags) -> CPLErr
+
+Adds a mask band to the dataset.
+"""
 function GDALCreateDatasetMaskBand(hDS::GDALDatasetH,nFlags::Cint)
     ccall((:GDALCreateDatasetMaskBand,libgdal),CPLErr,(GDALDatasetH,Cint),hDS,nFlags)
 end
 
+
+"""
+    GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
+                               GDALDatasetH hDstDS,
+                               char ** papszOptions,
+                               GDALProgressFunc pfnProgress,
+                               void * pProgressData) -> CPLErr
+
+Copy all dataset raster data.
+
+### Parameters
+* **hSrcDS**: the source dataset
+* **hDstDS**: the destination dataset
+* **papszOptions**: transfer hints in "StringList" Name=Value format.
+* **pfnProgress**: progress reporting function.
+* **pProgressData**: callback data for progress function.
+
+### Returns
+CE_None on success, or CE_Failure on failure.
+"""
 function GDALDatasetCopyWholeRaster(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALDatasetCopyWholeRaster,libgdal),CPLErr,(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcDS,hDstDS,papszOptions,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALRasterBandCopyWholeRaster(GDALRasterBandH hSrcBand,
+                                  GDALRasterBandH hDstBand,
+                                  char ** papszOptions,
+                                  GDALProgressFunc pfnProgress,
+                                  void * pProgressData) -> CPLErr
+
+Copy all raster band raster data.
+
+### Parameters
+* **hSrcBand**: the source band
+* **hDstBand**: the destination band
+* **papszOptions**: transfer hints in "StringList" Name=Value format.
+* **pfnProgress**: progress reporting function.
+* **pProgressData**: callback data for progress function.
+
+### Returns
+CE_None on success, or CE_Failure on failure.
+"""
 function GDALRasterBandCopyWholeRaster(hSrcBand::GDALRasterBandH,hDstBand::GDALRasterBandH,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALRasterBandCopyWholeRaster,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hDstBand,papszOptions,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALRegenerateOverviews(GDALRasterBandH hSrcBand,
+                            int nOverviewCount,
+                            GDALRasterBandH * pahOverviewBands,
+                            const char * pszResampling,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressData) -> CPLErr
+
+Generate downsampled overviews.
+
+### Parameters
+* **hSrcBand**: the source (base level) band.
+* **nOverviewCount**: the number of downsampled bands being generated.
+* **pahOvrBands**: the list of downsampled bands to be generated.
+* **pszResampling**: Resampling algorithm (eg. "AVERAGE").
+* **pfnProgress**: progress report function.
+* **pProgressData**: progress function callback data.
+
+### Returns
+CE_None on success or CE_Failure on failure.
+"""
 function GDALRegenerateOverviews(hSrcBand::GDALRasterBandH,nOverviewCount::Cint,pahOverviewBands::Ptr{GDALRasterBandH},pszResampling::Ptr{UInt8},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALRegenerateOverviews,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{GDALRasterBandH},Ptr{UInt8},GDALProgressFunc,Ptr{Void}),hSrcBand,nOverviewCount,pahOverviewBands,pszResampling,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALDatasetGetLayerCount(GDALDatasetH) -> int
+
+Get the number of layers in this dataset.
+
+### Parameters
+* **hDS**: the dataset handle.
+
+### Returns
+layer count.
+"""
 function GDALDatasetGetLayerCount(arg1::GDALDatasetH)
     ccall((:GDALDatasetGetLayerCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALDatasetGetLayer(GDALDatasetH,
+                        int) -> OGRLayerH
+
+Fetch a layer by index.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **iLayer**: a layer number between 0 and GetLayerCount()-1.
+
+### Returns
+the layer, or NULL if iLayer is out of range or an error occurs.
+"""
 function GDALDatasetGetLayer(arg1::GDALDatasetH,arg2::Cint)
     ccall((:GDALDatasetGetLayer,libgdal),OGRLayerH,(GDALDatasetH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetGetLayerByName(GDALDatasetH,
+                              const char *) -> OGRLayerH
+
+Fetch a layer by name.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszLayerName**: the layer name of the layer to fetch.
+
+### Returns
+the layer, or NULL if Layer is not found or an error occurs.
+"""
 function GDALDatasetGetLayerByName(arg1::GDALDatasetH,arg2::Ptr{UInt8})
     ccall((:GDALDatasetGetLayerByName,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetDeleteLayer(GDALDatasetH,
+                           int) -> OGRErr
+
+Delete the indicated layer from the datasource.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **iLayer**: the index of the layer to delete.
+
+### Returns
+OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
+"""
 function GDALDatasetDeleteLayer(arg1::GDALDatasetH,arg2::Cint)
     ccall((:GDALDatasetDeleteLayer,libgdal),OGRErr,(GDALDatasetH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetCreateLayer(GDALDatasetH,
+                           const char *,
+                           OGRSpatialReferenceH,
+                           OGRwkbGeometryType,
+                           char **) -> OGRLayerH
+
+This function attempts to create a new layer on the dataset with the indicated name, coordinate system, geometry type.
+
+### Parameters
+* **hDS**: the dataset handle
+* **pszName**: the name for the new layer. This should ideally not match any existing layer on the datasource.
+* **poSpatialRef**: the coordinate system to use for the new layer, or NULL if no coordinate system is available.
+* **eGType**: the geometry type for the layer. Use wkbUnknown if there are no constraints on the types geometry to be written.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+NULL is returned on failure, or a new OGRLayer handle on success.
+"""
 function GDALDatasetCreateLayer(arg1::GDALDatasetH,arg2::Ptr{UInt8},arg3::OGRSpatialReferenceH,arg4::OGRwkbGeometryType,arg5::Ptr{Ptr{UInt8}})
     ccall((:GDALDatasetCreateLayer,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8},OGRSpatialReferenceH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALDatasetCopyLayer(GDALDatasetH,
+                         OGRLayerH,
+                         const char *,
+                         char **) -> OGRLayerH
+
+Duplicate an existing layer.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **hSrcLayer**: source layer.
+* **pszNewName**: the name of the layer to create.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+an handle to the layer, or NULL if an error occurs.
+"""
 function GDALDatasetCopyLayer(arg1::GDALDatasetH,arg2::OGRLayerH,arg3::Ptr{UInt8},arg4::Ptr{Ptr{UInt8}})
     ccall((:GDALDatasetCopyLayer,libgdal),OGRLayerH,(GDALDatasetH,OGRLayerH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALDatasetTestCapability(GDALDatasetH,
+                              const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszCapability**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function GDALDatasetTestCapability(arg1::GDALDatasetH,arg2::Ptr{UInt8})
     ccall((:GDALDatasetTestCapability,libgdal),Cint,(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetExecuteSQL(GDALDatasetH,
+                          const char *,
+                          OGRGeometryH,
+                          const char *) -> OGRLayerH
+
+Execute an SQL statement against the data store.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszStatement**: the SQL statement to execute.
+* **hSpatialFilter**: geometry which represents a spatial filter. Can be NULL.
+* **pszDialect**: allows control of the statement dialect. If set to NULL, the OGR SQL engine will be used, except for RDBMS drivers that will use their dedicated SQL engine, unless OGRSQL is explicitly passed as the dialect. Starting with OGR 1.10, the SQLITE dialect can also be used.
+
+### Returns
+an OGRLayer containing the results of the query. Deallocate with ReleaseResultSet().
+"""
 function GDALDatasetExecuteSQL(arg1::GDALDatasetH,arg2::Ptr{UInt8},arg3::OGRGeometryH,arg4::Ptr{UInt8})
     ccall((:GDALDatasetExecuteSQL,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8},OGRGeometryH,Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALDatasetReleaseResultSet(GDALDatasetH,
+                                OGRLayerH) -> void
+
+Release results of ExecuteSQL().
+
+### Parameters
+* **hDS**: the dataset handle.
+* **poResultsSet**: the result of a previous ExecuteSQL() call.
+"""
 function GDALDatasetReleaseResultSet(arg1::GDALDatasetH,arg2::OGRLayerH)
     ccall((:GDALDatasetReleaseResultSet,libgdal),Void,(GDALDatasetH,OGRLayerH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetGetStyleTable(GDALDatasetH) -> OGRStyleTableH
+
+Returns dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+
+### Returns
+handle to a style table which should not be modified or freed by the caller.
+"""
 function GDALDatasetGetStyleTable(arg1::GDALDatasetH)
     ccall((:GDALDatasetGetStyleTable,libgdal),OGRStyleTableH,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALDatasetSetStyleTableDirectly(GDALDatasetH,
+                                     OGRStyleTableH) -> void
+
+Set dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+* **hStyleTable**: style table handle to set
+"""
 function GDALDatasetSetStyleTableDirectly(arg1::GDALDatasetH,arg2::OGRStyleTableH)
     ccall((:GDALDatasetSetStyleTableDirectly,libgdal),Void,(GDALDatasetH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetSetStyleTable(GDALDatasetH,
+                             OGRStyleTableH) -> void
+
+Set dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+* **hStyleTable**: style table handle to set
+"""
 function GDALDatasetSetStyleTable(arg1::GDALDatasetH,arg2::OGRStyleTableH)
     ccall((:GDALDatasetSetStyleTable,libgdal),Void,(GDALDatasetH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetStartTransaction(GDALDatasetH hDS,
+                                int bForce) -> OGRErr
+
+For datasources which support transactions, StartTransaction creates a transaction.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **bForce**: can be set to TRUE if an emulation, possibly slow, of a transaction mechanism is acceptable.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function GDALDatasetStartTransaction(hDS::GDALDatasetH,bForce::Cint)
     ccall((:GDALDatasetStartTransaction,libgdal),OGRErr,(GDALDatasetH,Cint),hDS,bForce)
 end
 
+
+"""
+    GDALDatasetCommitTransaction(GDALDatasetH hDS) -> OGRErr
+
+For datasources which support transactions, CommitTransaction commits a transaction.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function GDALDatasetCommitTransaction(hDS::GDALDatasetH)
     ccall((:GDALDatasetCommitTransaction,libgdal),OGRErr,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALDatasetRollbackTransaction(GDALDatasetH hDS) -> OGRErr
+
+For datasources which support transactions, RollbackTransaction will roll back a datasource to its state before the start of the current transaction.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function GDALDatasetRollbackTransaction(hDS::GDALDatasetH)
     ccall((:GDALDatasetRollbackTransaction,libgdal),OGRErr,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALGetRasterDataType(GDALRasterBandH) -> GDALDataType
+
+Fetch the pixel data type for this band.
+"""
 function GDALGetRasterDataType(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterDataType,libgdal),GDALDataType,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBlockSize(GDALRasterBandH,
+                     int * pnXSize,
+                     int * pnYSize) -> void
+
+Fetch the "natural" block size of this band.
+"""
 function GDALGetBlockSize(arg1::GDALRasterBandH,pnXSize::Ptr{Cint},pnYSize::Ptr{Cint})
     ccall((:GDALGetBlockSize,libgdal),Void,(GDALRasterBandH,Ptr{Cint},Ptr{Cint}),arg1,pnXSize,pnYSize)
 end
 
+
+"""
+    GDALRasterAdviseRead(GDALRasterBandH hRB,
+                         int nDSXOff,
+                         int nDSYOff,
+                         int nDSXSize,
+                         int nDSYSize,
+                         int nBXSize,
+                         int nBYSize,
+                         GDALDataType eBDataType,
+                         char ** papszOptions) -> CPLErr
+
+Advise driver of upcoming read requests.
+"""
 function GDALRasterAdviseRead(hRB::GDALRasterBandH,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALRasterAdviseRead,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Ptr{Ptr{UInt8}}),hRB,nDSXOff,nDSYOff,nDSXSize,nDSYSize,nBXSize,nBYSize,eBDataType,papszOptions)
 end
 
+
+"""
+    GDALRasterIO(GDALRasterBandH hRBand,
+                 GDALRWFlag eRWFlag,
+                 int nDSXOff,
+                 int nDSYOff,
+                 int nDSXSize,
+                 int nDSYSize,
+                 void * pBuffer,
+                 int nBXSize,
+                 int nBYSize,
+                 GDALDataType eBDataType,
+                 int nPixelSpace,
+                 int nLineSpace) -> CPLErr
+
+Read/write a region of image data for this band.
+"""
 function GDALRasterIO(hRBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,pBuffer::Ptr{Void},nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,nPixelSpace::Cint,nLineSpace::Cint)
     ccall((:GDALRasterIO,libgdal),CPLErr,(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Cint),hRBand,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nPixelSpace,nLineSpace)
 end
 
+
+"""
+    GDALRasterIOEx(GDALRasterBandH hRBand,
+                   GDALRWFlag eRWFlag,
+                   int nDSXOff,
+                   int nDSYOff,
+                   int nDSXSize,
+                   int nDSYSize,
+                   void * pBuffer,
+                   int nBXSize,
+                   int nBYSize,
+                   GDALDataType eBDataType,
+                   GSpacing nPixelSpace,
+                   GSpacing nLineSpace,
+                   GDALRasterIOExtraArg * psExtraArg) -> CPLErr
+
+Read/write a region of image data for this band.
+"""
 function GDALRasterIOEx(hRBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nDSXOff::Cint,nDSYOff::Cint,nDSXSize::Cint,nDSYSize::Cint,pBuffer::Ptr{Void},nBXSize::Cint,nBYSize::Cint,eBDataType::GDALDataType,nPixelSpace::GSpacing,nLineSpace::GSpacing,psExtraArg::Ptr{GDALRasterIOExtraArg})
     ccall((:GDALRasterIOEx,libgdal),CPLErr,(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,GSpacing,GSpacing,Ptr{GDALRasterIOExtraArg}),hRBand,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nPixelSpace,nLineSpace,psExtraArg)
 end
 
+
+"""
+    GDALReadBlock(GDALRasterBandH,
+                  int,
+                  int,
+                  void *) -> CPLErr
+
+Read a block of image data efficiently.
+"""
 function GDALReadBlock(arg1::GDALRasterBandH,arg2::Cint,arg3::Cint,arg4::Ptr{Void})
     ccall((:GDALReadBlock,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Void}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALWriteBlock(GDALRasterBandH,
+                   int,
+                   int,
+                   void *) -> CPLErr
+
+Write a block of image data efficiently.
+"""
 function GDALWriteBlock(arg1::GDALRasterBandH,arg2::Cint,arg3::Cint,arg4::Ptr{Void})
     ccall((:GDALWriteBlock,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Void}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetRasterBandXSize(GDALRasterBandH) -> int
+
+Fetch XSize of raster.
+"""
 function GDALGetRasterBandXSize(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterBandXSize,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetRasterBandYSize(GDALRasterBandH) -> int
+
+Fetch YSize of raster.
+"""
 function GDALGetRasterBandYSize(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterBandYSize,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetRasterAccess(GDALRasterBandH) -> GDALAccess
+
+Find out if we have update permission for this band.
+"""
 function GDALGetRasterAccess(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterAccess,libgdal),GDALAccess,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBandNumber(GDALRasterBandH) -> int
+
+Fetch the band number.
+"""
 function GDALGetBandNumber(arg1::GDALRasterBandH)
     ccall((:GDALGetBandNumber,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBandDataset(GDALRasterBandH) -> GDALDatasetH
+
+Fetch the owning dataset handle.
+"""
 function GDALGetBandDataset(arg1::GDALRasterBandH)
     ccall((:GDALGetBandDataset,libgdal),GDALDatasetH,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetRasterColorInterpretation(GDALRasterBandH) -> GDALColorInterp
+
+How should this band be interpreted as color?
+"""
 function GDALGetRasterColorInterpretation(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterColorInterpretation,libgdal),GDALColorInterp,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALSetRasterColorInterpretation(GDALRasterBandH,
+                                     GDALColorInterp) -> CPLErr
+
+Set color interpretation of a band.
+"""
 function GDALSetRasterColorInterpretation(arg1::GDALRasterBandH,arg2::GDALColorInterp)
     ccall((:GDALSetRasterColorInterpretation,libgdal),CPLErr,(GDALRasterBandH,GDALColorInterp),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterColorTable(GDALRasterBandH) -> GDALColorTableH
+
+Fetch the color table associated with band.
+"""
 function GDALGetRasterColorTable(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterColorTable,libgdal),GDALColorTableH,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALSetRasterColorTable(GDALRasterBandH,
+                            GDALColorTableH) -> CPLErr
+
+Set the raster color table.
+"""
 function GDALSetRasterColorTable(arg1::GDALRasterBandH,arg2::GDALColorTableH)
     ccall((:GDALSetRasterColorTable,libgdal),CPLErr,(GDALRasterBandH,GDALColorTableH),arg1,arg2)
 end
 
+
+"""
+    GDALHasArbitraryOverviews(GDALRasterBandH) -> int
+
+Check for arbitrary overviews.
+"""
 function GDALHasArbitraryOverviews(arg1::GDALRasterBandH)
     ccall((:GDALHasArbitraryOverviews,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetOverviewCount(GDALRasterBandH) -> int
+
+Return the number of overview layers available.
+"""
 function GDALGetOverviewCount(arg1::GDALRasterBandH)
     ccall((:GDALGetOverviewCount,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetOverview(GDALRasterBandH,
+                    int) -> GDALRasterBandH
+
+Fetch overview raster band object.
+"""
 function GDALGetOverview(arg1::GDALRasterBandH,arg2::Cint)
     ccall((:GDALGetOverview,libgdal),GDALRasterBandH,(GDALRasterBandH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterNoDataValue(GDALRasterBandH,
+                             int *) -> double
+
+Fetch the no data value for this band.
+"""
 function GDALGetRasterNoDataValue(arg1::GDALRasterBandH,arg2::Ptr{Cint})
     ccall((:GDALGetRasterNoDataValue,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,arg2)
 end
 
+
+"""
+    GDALSetRasterNoDataValue(GDALRasterBandH,
+                             double) -> CPLErr
+
+Set the no data value for this band.
+"""
 function GDALSetRasterNoDataValue(arg1::GDALRasterBandH,arg2::Cdouble)
     ccall((:GDALSetRasterNoDataValue,libgdal),CPLErr,(GDALRasterBandH,Cdouble),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterCategoryNames(GDALRasterBandH) -> char **
+
+Fetch the list of category names for this raster.
+"""
 function GDALGetRasterCategoryNames(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterCategoryNames,libgdal),Ptr{Ptr{UInt8}},(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALSetRasterCategoryNames(GDALRasterBandH,
+                               char **) -> CPLErr
+
+Set the category names for this band.
+"""
 function GDALSetRasterCategoryNames(arg1::GDALRasterBandH,arg2::Ptr{Ptr{UInt8}})
     ccall((:GDALSetRasterCategoryNames,libgdal),CPLErr,(GDALRasterBandH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterMinimum(GDALRasterBandH,
+                         int * pbSuccess) -> double
+
+Fetch the minimum value for this band.
+"""
 function GDALGetRasterMinimum(arg1::GDALRasterBandH,pbSuccess::Ptr{Cint})
     ccall((:GDALGetRasterMinimum,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALGetRasterMaximum(GDALRasterBandH,
+                         int * pbSuccess) -> double
+
+Fetch the maximum value for this band.
+"""
 function GDALGetRasterMaximum(arg1::GDALRasterBandH,pbSuccess::Ptr{Cint})
     ccall((:GDALGetRasterMaximum,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALGetRasterStatistics(GDALRasterBandH,
+                            int bApproxOK,
+                            int bForce,
+                            double * pdfMin,
+                            double * pdfMax,
+                            double * pdfMean,
+                            double * pdfStdDev) -> CPLErr
+
+Fetch image statistics.
+"""
 function GDALGetRasterStatistics(arg1::GDALRasterBandH,bApproxOK::Cint,bForce::Cint,pdfMin::Ptr{Cdouble},pdfMax::Ptr{Cdouble},pdfMean::Ptr{Cdouble},pdfStdDev::Ptr{Cdouble})
     ccall((:GDALGetRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,bApproxOK,bForce,pdfMin,pdfMax,pdfMean,pdfStdDev)
 end
 
+
+"""
+    GDALComputeRasterStatistics(GDALRasterBandH,
+                                int bApproxOK,
+                                double * pdfMin,
+                                double * pdfMax,
+                                double * pdfMean,
+                                double * pdfStdDev,
+                                GDALProgressFunc pfnProgress,
+                                void * pProgressData) -> CPLErr
+
+Compute image statistics.
+"""
 function GDALComputeRasterStatistics(arg1::GDALRasterBandH,bApproxOK::Cint,pdfMin::Ptr{Cdouble},pdfMax::Ptr{Cdouble},pdfMean::Ptr{Cdouble},pdfStdDev::Ptr{Cdouble},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALComputeRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},GDALProgressFunc,Ptr{Void}),arg1,bApproxOK,pdfMin,pdfMax,pdfMean,pdfStdDev,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALSetRasterStatistics(GDALRasterBandH hBand,
+                            double dfMin,
+                            double dfMax,
+                            double dfMean,
+                            double dfStdDev) -> CPLErr
+
+Set statistics on band.
+"""
 function GDALSetRasterStatistics(hBand::GDALRasterBandH,dfMin::Cdouble,dfMax::Cdouble,dfMean::Cdouble,dfStdDev::Cdouble)
     ccall((:GDALSetRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cdouble,Cdouble),hBand,dfMin,dfMax,dfMean,dfStdDev)
 end
 
+
+"""
+    GDALGetRasterUnitType(GDALRasterBandH) -> const char *
+
+Return raster unit type.
+"""
 function GDALGetRasterUnitType(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterUnitType,libgdal),Ptr{UInt8},(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALSetRasterUnitType(GDALRasterBandH hBand,
+                          const char * pszNewValue) -> CPLErr
+
+Set unit type.
+"""
 function GDALSetRasterUnitType(hBand::GDALRasterBandH,pszNewValue::Ptr{UInt8})
     ccall((:GDALSetRasterUnitType,libgdal),CPLErr,(GDALRasterBandH,Ptr{UInt8}),hBand,pszNewValue)
 end
 
+
+"""
+    GDALGetRasterOffset(GDALRasterBandH,
+                        int * pbSuccess) -> double
+
+Fetch the raster value offset.
+"""
 function GDALGetRasterOffset(arg1::GDALRasterBandH,pbSuccess::Ptr{Cint})
     ccall((:GDALGetRasterOffset,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALSetRasterOffset(GDALRasterBandH hBand,
+                        double dfNewOffset) -> CPLErr
+
+Set scaling offset.
+"""
 function GDALSetRasterOffset(hBand::GDALRasterBandH,dfNewOffset::Cdouble)
     ccall((:GDALSetRasterOffset,libgdal),CPLErr,(GDALRasterBandH,Cdouble),hBand,dfNewOffset)
 end
 
+
+"""
+    GDALGetRasterScale(GDALRasterBandH,
+                       int * pbSuccess) -> double
+
+Fetch the raster value scale.
+"""
 function GDALGetRasterScale(arg1::GDALRasterBandH,pbSuccess::Ptr{Cint})
     ccall((:GDALGetRasterScale,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALSetRasterScale(GDALRasterBandH hBand,
+                       double dfNewOffset) -> CPLErr
+
+Set scaling ratio.
+"""
 function GDALSetRasterScale(hBand::GDALRasterBandH,dfNewOffset::Cdouble)
     ccall((:GDALSetRasterScale,libgdal),CPLErr,(GDALRasterBandH,Cdouble),hBand,dfNewOffset)
 end
 
+
+"""
+    GDALComputeRasterMinMax(GDALRasterBandH hBand,
+                            int bApproxOK,
+                            double adfMinMax) -> void
+
+Compute the min/max values for a band.
+"""
 function GDALComputeRasterMinMax(hBand::GDALRasterBandH,bApproxOK::Cint,adfMinMax::Array_2_Cdouble)
     ccall((:GDALComputeRasterMinMax,libgdal),Void,(GDALRasterBandH,Cint,Array_2_Cdouble),hBand,bApproxOK,adfMinMax)
 end
 
+
+"""
+    GDALFlushRasterCache(GDALRasterBandH hBand) -> CPLErr
+
+Flush raster data cache.
+"""
 function GDALFlushRasterCache(hBand::GDALRasterBandH)
     ccall((:GDALFlushRasterCache,libgdal),CPLErr,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALGetRasterHistogram(GDALRasterBandH hBand,
+                           double dfMin,
+                           double dfMax,
+                           int nBuckets,
+                           int * panHistogram,
+                           int bIncludeOutOfRange,
+                           int bApproxOK,
+                           GDALProgressFunc pfnProgress,
+                           void * pProgressData) -> CPLErr
+
+Compute raster histogram.
+"""
 function GDALGetRasterHistogram(hBand::GDALRasterBandH,dfMin::Cdouble,dfMax::Cdouble,nBuckets::Cint,panHistogram::Ptr{Cint},bIncludeOutOfRange::Cint,bApproxOK::Cint,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetRasterHistogram,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cint},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfMin,dfMax,nBuckets,panHistogram,bIncludeOutOfRange,bApproxOK,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetRasterHistogramEx(GDALRasterBandH hBand,
+                             double dfMin,
+                             double dfMax,
+                             int nBuckets,
+                             GUIntBig * panHistogram,
+                             int bIncludeOutOfRange,
+                             int bApproxOK,
+                             GDALProgressFunc pfnProgress,
+                             void * pProgressData) -> CPLErr
+
+Compute raster histogram.
+"""
 function GDALGetRasterHistogramEx(hBand::GDALRasterBandH,dfMin::Cdouble,dfMax::Cdouble,nBuckets::Cint,panHistogram::Ptr{GUIntBig},bIncludeOutOfRange::Cint,bApproxOK::Cint,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetRasterHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{GUIntBig},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfMin,dfMax,nBuckets,panHistogram,bIncludeOutOfRange,bApproxOK,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultHistogram(GDALRasterBandH hBand,
+                            double * pdfMin,
+                            double * pdfMax,
+                            int * pnBuckets,
+                            int ** ppanHistogram,
+                            int bForce,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressData) -> CPLErr
+
+Fetch default raster histogram.
+"""
 function GDALGetDefaultHistogram(hBand::GDALRasterBandH,pdfMin::Ptr{Cdouble},pdfMax::Ptr{Cdouble},pnBuckets::Ptr{Cint},ppanHistogram::Ptr{Ptr{Cint}},bForce::Cint,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetDefaultHistogram,libgdal),CPLErr,(GDALRasterBandH,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint},Ptr{Ptr{Cint}},Cint,GDALProgressFunc,Ptr{Void}),hBand,pdfMin,pdfMax,pnBuckets,ppanHistogram,bForce,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultHistogramEx(GDALRasterBandH hBand,
+                              double * pdfMin,
+                              double * pdfMax,
+                              int * pnBuckets,
+                              GUIntBig ** ppanHistogram,
+                              int bForce,
+                              GDALProgressFunc pfnProgress,
+                              void * pProgressData) -> CPLErr
+
+Fetch default raster histogram.
+"""
 function GDALGetDefaultHistogramEx(hBand::GDALRasterBandH,pdfMin::Ptr{Cdouble},pdfMax::Ptr{Cdouble},pnBuckets::Ptr{Cint},ppanHistogram::Ptr{Ptr{GUIntBig}},bForce::Cint,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetDefaultHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint},Ptr{Ptr{GUIntBig}},Cint,GDALProgressFunc,Ptr{Void}),hBand,pdfMin,pdfMax,pnBuckets,ppanHistogram,bForce,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALSetDefaultHistogram(GDALRasterBandH hBand,
+                            double dfMin,
+                            double dfMax,
+                            int nBuckets,
+                            int * panHistogram) -> CPLErr
+
+Set default histogram.
+"""
 function GDALSetDefaultHistogram(hBand::GDALRasterBandH,dfMin::Cdouble,dfMax::Cdouble,nBuckets::Cint,panHistogram::Ptr{Cint})
     ccall((:GDALSetDefaultHistogram,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cint}),hBand,dfMin,dfMax,nBuckets,panHistogram)
 end
 
+
+"""
+    GDALSetDefaultHistogramEx(GDALRasterBandH hBand,
+                              double dfMin,
+                              double dfMax,
+                              int nBuckets,
+                              GUIntBig * panHistogram) -> CPLErr
+
+Set default histogram.
+"""
 function GDALSetDefaultHistogramEx(hBand::GDALRasterBandH,dfMin::Cdouble,dfMax::Cdouble,nBuckets::Cint,panHistogram::Ptr{GUIntBig})
     ccall((:GDALSetDefaultHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{GUIntBig}),hBand,dfMin,dfMax,nBuckets,panHistogram)
 end
 
+
+"""
+    GDALGetRandomRasterSample(GDALRasterBandH,
+                              int,
+                              float *) -> int
+"""
 function GDALGetRandomRasterSample(arg1::GDALRasterBandH,arg2::Cint,arg3::Ptr{Cfloat})
     ccall((:GDALGetRandomRasterSample,libgdal),Cint,(GDALRasterBandH,Cint,Ptr{Cfloat}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALGetRasterSampleOverview(GDALRasterBandH,
+                                int) -> GDALRasterBandH
+
+Fetch best sampling overview.
+"""
 function GDALGetRasterSampleOverview(arg1::GDALRasterBandH,arg2::Cint)
     ccall((:GDALGetRasterSampleOverview,libgdal),GDALRasterBandH,(GDALRasterBandH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterSampleOverviewEx(GDALRasterBandH,
+                                  GUIntBig) -> GDALRasterBandH
+
+Fetch best sampling overview.
+"""
 function GDALGetRasterSampleOverviewEx(arg1::GDALRasterBandH,arg2::GUIntBig)
     ccall((:GDALGetRasterSampleOverviewEx,libgdal),GDALRasterBandH,(GDALRasterBandH,GUIntBig),arg1,arg2)
 end
 
+
+"""
+    GDALFillRaster(GDALRasterBandH hBand,
+                   double dfRealValue,
+                   double dfImaginaryValue) -> CPLErr
+
+Fill this band with a constant value.
+"""
 function GDALFillRaster(hBand::GDALRasterBandH,dfRealValue::Cdouble,dfImaginaryValue::Cdouble)
     ccall((:GDALFillRaster,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble),hBand,dfRealValue,dfImaginaryValue)
 end
 
+
+"""
+    GDALComputeBandStats(GDALRasterBandH hBand,
+                         int nSampleStep,
+                         double * pdfMean,
+                         double * pdfStdDev,
+                         GDALProgressFunc pfnProgress,
+                         void * pProgressData) -> CPLErr
+"""
 function GDALComputeBandStats(hBand::GDALRasterBandH,nSampleStep::Cint,pdfMean::Ptr{Cdouble},pdfStdDev::Ptr{Cdouble},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALComputeBandStats,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{Cdouble},Ptr{Cdouble},GDALProgressFunc,Ptr{Void}),hBand,nSampleStep,pdfMean,pdfStdDev,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALOverviewMagnitudeCorrection(GDALRasterBandH hBaseBand,
+                                    int nOverviewCount,
+                                    GDALRasterBandH * pahOverviews,
+                                    GDALProgressFunc pfnProgress,
+                                    void * pProgressData) -> CPLErr
+"""
 function GDALOverviewMagnitudeCorrection(hBaseBand::GDALRasterBandH,nOverviewCount::Cint,pahOverviews::Ptr{GDALRasterBandH},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALOverviewMagnitudeCorrection,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{GDALRasterBandH},GDALProgressFunc,Ptr{Void}),hBaseBand,nOverviewCount,pahOverviews,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultRAT(GDALRasterBandH hBand) -> GDALRasterAttributeTableH
+
+Fetch default Raster Attribute Table.
+"""
 function GDALGetDefaultRAT(hBand::GDALRasterBandH)
     ccall((:GDALGetDefaultRAT,libgdal),GDALRasterAttributeTableH,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALSetDefaultRAT(GDALRasterBandH,
+                      GDALRasterAttributeTableH) -> CPLErr
+
+Set default Raster Attribute Table.
+"""
 function GDALSetDefaultRAT(arg1::GDALRasterBandH,arg2::GDALRasterAttributeTableH)
     ccall((:GDALSetDefaultRAT,libgdal),CPLErr,(GDALRasterBandH,GDALRasterAttributeTableH),arg1,arg2)
 end
 
+
+"""
+    GDALAddDerivedBandPixelFunc(const char * pszName,
+                                GDALDerivedPixelFunc pfnPixelFunc) -> CPLErr
+
+This adds a pixel function to the global list of available pixel functions for derived bands.
+
+### Parameters
+* **pszFuncName**: Name used to access pixel function
+* **pfnNewFunction**: Pixel function associated with name. An existing pixel function registered with the same name will be replaced with the new one.
+
+### Returns
+CE_None, invalid (NULL) parameters are currently ignored.
+"""
 function GDALAddDerivedBandPixelFunc(pszName::Ptr{UInt8},pfnPixelFunc::GDALDerivedPixelFunc)
     ccall((:GDALAddDerivedBandPixelFunc,libgdal),CPLErr,(Ptr{UInt8},GDALDerivedPixelFunc),pszName,pfnPixelFunc)
 end
 
+
+"""
+    GDALGetMaskBand(GDALRasterBandH hBand) -> GDALRasterBandH
+
+Return the mask band associated with the band.
+"""
 function GDALGetMaskBand(hBand::GDALRasterBandH)
     ccall((:GDALGetMaskBand,libgdal),GDALRasterBandH,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALGetMaskFlags(GDALRasterBandH hBand) -> int
+
+Return the status flags of the mask band associated with the band.
+"""
 function GDALGetMaskFlags(hBand::GDALRasterBandH)
     ccall((:GDALGetMaskFlags,libgdal),Cint,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALCreateMaskBand(GDALRasterBandH hBand,
+                       int nFlags) -> CPLErr
+
+Adds a mask band to the current band.
+"""
 function GDALCreateMaskBand(hBand::GDALRasterBandH,nFlags::Cint)
     ccall((:GDALCreateMaskBand,libgdal),CPLErr,(GDALRasterBandH,Cint),hBand,nFlags)
 end
 
+
+"""
+    GDALARGetNextUpdatedRegion(GDALAsyncReaderH hARIO,
+                               double dfTimeout,
+                               int * pnXBufOff,
+                               int * pnYBufOff,
+                               int * pnXBufSize,
+                               int * pnYBufSize) -> GDALAsyncStatusType
+"""
 function GDALARGetNextUpdatedRegion(hARIO::GDALAsyncReaderH,dfTimeout::Cdouble,pnXBufOff::Ptr{Cint},pnYBufOff::Ptr{Cint},pnXBufSize::Ptr{Cint},pnYBufSize::Ptr{Cint})
     ccall((:GDALARGetNextUpdatedRegion,libgdal),GDALAsyncStatusType,(GDALAsyncReaderH,Cdouble,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),hARIO,dfTimeout,pnXBufOff,pnYBufOff,pnXBufSize,pnYBufSize)
 end
 
+
+"""
+    GDALARLockBuffer(GDALAsyncReaderH hARIO,
+                     double dfTimeout) -> int
+"""
 function GDALARLockBuffer(hARIO::GDALAsyncReaderH,dfTimeout::Cdouble)
     ccall((:GDALARLockBuffer,libgdal),Cint,(GDALAsyncReaderH,Cdouble),hARIO,dfTimeout)
 end
 
+
+"""
+    GDALARUnlockBuffer(GDALAsyncReaderH hARIO) -> void
+"""
 function GDALARUnlockBuffer(hARIO::GDALAsyncReaderH)
     ccall((:GDALARUnlockBuffer,libgdal),Void,(GDALAsyncReaderH,),hARIO)
 end
 
+
+"""
+    GDALGeneralCmdLineProcessor(int nArgc,
+                                char *** ppapszArgv,
+                                int nOptions) -> int
+
+General utility option processing.
+
+### Parameters
+* **nArgc**: number of values in the argument list.
+* **ppapszArgv**: pointer to the argument list array (will be updated in place).
+* **nOptions**: a or-able combination of GDAL_OF_RASTER and GDAL_OF_VECTOR to determine which drivers should be displayed by formats. If set to 0, GDAL_OF_RASTER is assumed.
+
+### Returns
+updated nArgc argument count. Return of 0 requests terminate without error, return of -1 requests exit with error code.
+"""
 function GDALGeneralCmdLineProcessor(nArgc::Cint,ppapszArgv::Ptr{Ptr{Ptr{UInt8}}},nOptions::Cint)
     ccall((:GDALGeneralCmdLineProcessor,libgdal),Cint,(Cint,Ptr{Ptr{Ptr{UInt8}}},Cint),nArgc,ppapszArgv,nOptions)
 end
 
+
+"""
+    GDALSwapWords(void * pData,
+                  int nWordSize,
+                  int nWordCount,
+                  int nWordSkip) -> void
+
+Byte swap words in-place.
+
+### Parameters
+* **pData**: pointer to start of data buffer.
+* **nWordSize**: size of words being swapped in bytes. Normally 2, 4 or 8.
+* **nWordCount**: the number of words to be swapped in this call.
+* **nWordSkip**: the byte offset from the start of one word to the start of the next. For packed buffers this is the same as nWordSize.
+"""
 function GDALSwapWords(pData::Ptr{Void},nWordSize::Cint,nWordCount::Cint,nWordSkip::Cint)
     ccall((:GDALSwapWords,libgdal),Void,(Ptr{Void},Cint,Cint,Cint),pData,nWordSize,nWordCount,nWordSkip)
 end
 
+
+"""
+    GDALCopyWords(void * pSrcData,
+                  GDALDataType eSrcType,
+                  int nSrcPixelOffset,
+                  void * pDstData,
+                  GDALDataType eDstType,
+                  int nDstPixelOffset,
+                  int nWordCount) -> void
+
+Copy pixel words from buffer to buffer.
+
+### Parameters
+* **pSrcData**: Pointer to source data to be converted.
+* **eSrcType**: the source data type (see GDALDataType enum)
+* **nSrcPixelStride**: Source pixel stride (i.e. distance between 2 words), in bytes
+* **pDstData**: Pointer to buffer where destination data should go
+* **eDstType**: the destination data type (see GDALDataType enum)
+* **nDstPixelStride**: Destination pixel stride (i.e. distance between 2 words), in bytes
+* **nWordCount**: number of words to be copied
+"""
 function GDALCopyWords(pSrcData::Ptr{Void},eSrcType::GDALDataType,nSrcPixelOffset::Cint,pDstData::Ptr{Void},eDstType::GDALDataType,nDstPixelOffset::Cint,nWordCount::Cint)
     ccall((:GDALCopyWords,libgdal),Void,(Ptr{Void},GDALDataType,Cint,Ptr{Void},GDALDataType,Cint,Cint),pSrcData,eSrcType,nSrcPixelOffset,pDstData,eDstType,nDstPixelOffset,nWordCount)
 end
 
+
+"""
+    GDALCopyBits(const GByte * pabySrcData,
+                 int nSrcOffset,
+                 int nSrcStep,
+                 GByte * pabyDstData,
+                 int nDstOffset,
+                 int nDstStep,
+                 int nBitCount,
+                 int nStepCount) -> void
+
+Bitwise word copying.
+
+### Parameters
+* **pabySrcData**: the source data buffer.
+* **nSrcOffset**: the offset (in bits) in pabySrcData to the start of the first word to copy.
+* **nSrcStep**: the offset in bits from the start one source word to the start of the next.
+* **pabyDstData**: the destination data buffer.
+* **nDstOffset**: the offset (in bits) in pabyDstData to the start of the first word to copy over.
+* **nDstStep**: the offset in bits from the start one word to the start of the next.
+* **nBitCount**: the number of bits in a word to be copied.
+* **nStepCount**: the number of words to copy.
+"""
 function GDALCopyBits(pabySrcData::Ptr{GByte},nSrcOffset::Cint,nSrcStep::Cint,pabyDstData::Ptr{GByte},nDstOffset::Cint,nDstStep::Cint,nBitCount::Cint,nStepCount::Cint)
     ccall((:GDALCopyBits,libgdal),Void,(Ptr{GByte},Cint,Cint,Ptr{GByte},Cint,Cint,Cint,Cint),pabySrcData,nSrcOffset,nSrcStep,pabyDstData,nDstOffset,nDstStep,nBitCount,nStepCount)
 end
 
+
+"""
+    GDALLoadWorldFile(const char *,
+                      double *) -> int
+
+Read ESRI world file.
+
+### Parameters
+* **pszFilename**: the world file name.
+* **padfGeoTransform**: the six double array into which the geotransformation should be placed.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function GDALLoadWorldFile(arg1::Ptr{UInt8},arg2::Ptr{Cdouble})
     ccall((:GDALLoadWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALReadWorldFile(const char *,
+                      const char *,
+                      double *) -> int
+
+Read ESRI world file.
+
+### Parameters
+* **pszBaseFilename**: the target raster file.
+* **pszExtension**: the extension to use (ie. ".wld") or NULL to derive it from the pszBaseFilename
+* **padfGeoTransform**: the six double array into which the geotransformation should be placed.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function GDALReadWorldFile(arg1::Ptr{UInt8},arg2::Ptr{UInt8},arg3::Ptr{Cdouble})
     ccall((:GDALReadWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALWriteWorldFile(const char *,
+                       const char *,
+                       double *) -> int
+
+Write ESRI world file.
+
+### Parameters
+* **pszBaseFilename**: the target raster file.
+* **pszExtension**: the extension to use (ie. ".wld"). Must not be NULL
+* **padfGeoTransform**: the six double array from which the geotransformation should be read.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function GDALWriteWorldFile(arg1::Ptr{UInt8},arg2::Ptr{UInt8},arg3::Ptr{Cdouble})
     ccall((:GDALWriteWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALLoadTabFile(const char *,
+                    double *,
+                    char **,
+                    int *,
+                    GDAL_GCP **) -> int
+"""
 function GDALLoadTabFile(arg1::Ptr{UInt8},arg2::Ptr{Cdouble},arg3::Ptr{Ptr{UInt8}},arg4::Ptr{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALLoadTabFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALReadTabFile(const char *,
+                    double *,
+                    char **,
+                    int *,
+                    GDAL_GCP **) -> int
+"""
 function GDALReadTabFile(arg1::Ptr{UInt8},arg2::Ptr{Cdouble},arg3::Ptr{Ptr{UInt8}},arg4::Ptr{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALReadTabFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALLoadOziMapFile(const char *,
+                       double *,
+                       char **,
+                       int *,
+                       GDAL_GCP **) -> int
+"""
 function GDALLoadOziMapFile(arg1::Ptr{UInt8},arg2::Ptr{Cdouble},arg3::Ptr{Ptr{UInt8}},arg4::Ptr{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALLoadOziMapFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALReadOziMapFile(const char *,
+                       double *,
+                       char **,
+                       int *,
+                       GDAL_GCP **) -> int
+"""
 function GDALReadOziMapFile(arg1::Ptr{UInt8},arg2::Ptr{Cdouble},arg3::Ptr{Ptr{UInt8}},arg4::Ptr{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALReadOziMapFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALDecToDMS(double,
+                 const char *,
+                 int) -> const char *
+"""
 function GDALDecToDMS(arg1::Cdouble,arg2::Ptr{UInt8},arg3::Cint)
     ccall((:GDALDecToDMS,libgdal),Ptr{UInt8},(Cdouble,Ptr{UInt8},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALPackedDMSToDec(double) -> double
+
+Convert a packed DMS value (DDDMMMSSS.SS) into decimal degrees.
+"""
 function GDALPackedDMSToDec(arg1::Cdouble)
     ccall((:GDALPackedDMSToDec,libgdal),Cdouble,(Cdouble,),arg1)
 end
 
+
+"""
+    GDALDecToPackedDMS(double) -> double
+
+Convert decimal degrees into packed DMS value (DDDMMMSSS.SS).
+"""
 function GDALDecToPackedDMS(arg1::Cdouble)
     ccall((:GDALDecToPackedDMS,libgdal),Cdouble,(Cdouble,),arg1)
 end
 
+
+"""
+    GDALExtractRPCInfo(char **,
+                       GDALRPCInfo *) -> int
+"""
 function GDALExtractRPCInfo(arg1::Ptr{Ptr{UInt8}},arg2::Ptr{GDALRPCInfo})
     ccall((:GDALExtractRPCInfo,libgdal),Cint,(Ptr{Ptr{UInt8}},Ptr{GDALRPCInfo}),arg1,arg2)
 end
 
+
+"""
+    GDALCreateColorTable(GDALPaletteInterp) -> GDALColorTableH
+
+Construct a new color table.
+"""
 function GDALCreateColorTable(arg1::GDALPaletteInterp)
     ccall((:GDALCreateColorTable,libgdal),GDALColorTableH,(GDALPaletteInterp,),arg1)
 end
 
+
+"""
+    GDALDestroyColorTable(GDALColorTableH) -> void
+
+Destroys a color table.
+"""
 function GDALDestroyColorTable(arg1::GDALColorTableH)
     ccall((:GDALDestroyColorTable,libgdal),Void,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALCloneColorTable(GDALColorTableH) -> GDALColorTableH
+
+Make a copy of a color table.
+"""
 function GDALCloneColorTable(arg1::GDALColorTableH)
     ccall((:GDALCloneColorTable,libgdal),GDALColorTableH,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALGetPaletteInterpretation(GDALColorTableH) -> GDALPaletteInterp
+
+Fetch palette interpretation.
+"""
 function GDALGetPaletteInterpretation(arg1::GDALColorTableH)
     ccall((:GDALGetPaletteInterpretation,libgdal),GDALPaletteInterp,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALGetColorEntryCount(GDALColorTableH) -> int
+
+Get number of color entries in table.
+"""
 function GDALGetColorEntryCount(arg1::GDALColorTableH)
     ccall((:GDALGetColorEntryCount,libgdal),Cint,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALGetColorEntry(GDALColorTableH,
+                      int) -> const GDALColorEntry *
+
+Fetch a color entry from table.
+"""
 function GDALGetColorEntry(arg1::GDALColorTableH,arg2::Cint)
     ccall((:GDALGetColorEntry,libgdal),Ptr{GDALColorEntry},(GDALColorTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALGetColorEntryAsRGB(GDALColorTableH,
+                           int,
+                           GDALColorEntry *) -> int
+
+Fetch a table entry in RGB format.
+"""
 function GDALGetColorEntryAsRGB(arg1::GDALColorTableH,arg2::Cint,arg3::Ptr{GDALColorEntry})
     ccall((:GDALGetColorEntryAsRGB,libgdal),Cint,(GDALColorTableH,Cint,Ptr{GDALColorEntry}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALSetColorEntry(GDALColorTableH,
+                      int,
+                      const GDALColorEntry *) -> void
+
+Set entry in color table.
+"""
 function GDALSetColorEntry(arg1::GDALColorTableH,arg2::Cint,arg3::Ptr{GDALColorEntry})
     ccall((:GDALSetColorEntry,libgdal),Void,(GDALColorTableH,Cint,Ptr{GDALColorEntry}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALCreateColorRamp(GDALColorTableH hTable,
+                        int nStartIndex,
+                        const GDALColorEntry * psStartColor,
+                        int nEndIndex,
+                        const GDALColorEntry * psEndColor) -> void
+
+Create color ramp.
+"""
 function GDALCreateColorRamp(hTable::GDALColorTableH,nStartIndex::Cint,psStartColor::Ptr{GDALColorEntry},nEndIndex::Cint,psEndColor::Ptr{GDALColorEntry})
     ccall((:GDALCreateColorRamp,libgdal),Void,(GDALColorTableH,Cint,Ptr{GDALColorEntry},Cint,Ptr{GDALColorEntry}),hTable,nStartIndex,psStartColor,nEndIndex,psEndColor)
 end
 
+
+"""
+    GDALCreateRasterAttributeTable(void) -> GDALRasterAttributeTableH
+
+Construct empty table.
+"""
 function GDALCreateRasterAttributeTable()
     ccall((:GDALCreateRasterAttributeTable,libgdal),GDALRasterAttributeTableH,())
 end
 
+
+"""
+    GDALDestroyRasterAttributeTable(GDALRasterAttributeTableH) -> void
+
+Destroys a RAT.
+"""
 function GDALDestroyRasterAttributeTable(arg1::GDALRasterAttributeTableH)
     ccall((:GDALDestroyRasterAttributeTable,libgdal),Void,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetColumnCount(GDALRasterAttributeTableH) -> int
+
+Fetch table column count.
+"""
 function GDALRATGetColumnCount(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATGetColumnCount,libgdal),Cint,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetNameOfCol(GDALRasterAttributeTableH,
+                        int) -> const char *
+
+Fetch name of indicated column.
+"""
 function GDALRATGetNameOfCol(arg1::GDALRasterAttributeTableH,arg2::Cint)
     ccall((:GDALRATGetNameOfCol,libgdal),Ptr{UInt8},(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetUsageOfCol(GDALRasterAttributeTableH,
+                         int) -> GDALRATFieldUsage
+
+Fetch column usage value.
+"""
 function GDALRATGetUsageOfCol(arg1::GDALRasterAttributeTableH,arg2::Cint)
     ccall((:GDALRATGetUsageOfCol,libgdal),GDALRATFieldUsage,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetTypeOfCol(GDALRasterAttributeTableH,
+                        int) -> GDALRATFieldType
+
+Fetch column type.
+"""
 function GDALRATGetTypeOfCol(arg1::GDALRasterAttributeTableH,arg2::Cint)
     ccall((:GDALRATGetTypeOfCol,libgdal),GDALRATFieldType,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetColOfUsage(GDALRasterAttributeTableH,
+                         GDALRATFieldUsage) -> int
+
+Fetch column index for given usage.
+"""
 function GDALRATGetColOfUsage(arg1::GDALRasterAttributeTableH,arg2::GDALRATFieldUsage)
     ccall((:GDALRATGetColOfUsage,libgdal),Cint,(GDALRasterAttributeTableH,GDALRATFieldUsage),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetRowCount(GDALRasterAttributeTableH) -> int
+
+Fetch row count.
+"""
 function GDALRATGetRowCount(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATGetRowCount,libgdal),Cint,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetValueAsString(GDALRasterAttributeTableH,
+                            int,
+                            int) -> const char *
+
+Fetch field value as a string.
+"""
 function GDALRATGetValueAsString(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint)
     ccall((:GDALRATGetValueAsString,libgdal),Ptr{UInt8},(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATGetValueAsInt(GDALRasterAttributeTableH,
+                         int,
+                         int) -> int
+
+Fetch field value as a integer.
+"""
 function GDALRATGetValueAsInt(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint)
     ccall((:GDALRATGetValueAsInt,libgdal),Cint,(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATGetValueAsDouble(GDALRasterAttributeTableH,
+                            int,
+                            int) -> double
+
+Fetch field value as a double.
+"""
 function GDALRATGetValueAsDouble(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint)
     ccall((:GDALRATGetValueAsDouble,libgdal),Cdouble,(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATSetValueAsString(GDALRasterAttributeTableH,
+                            int,
+                            int,
+                            const char *) -> void
+
+Set field value from string.
+"""
 function GDALRATSetValueAsString(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint,arg4::Ptr{UInt8})
     ccall((:GDALRATSetValueAsString,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetValueAsInt(GDALRasterAttributeTableH,
+                         int,
+                         int,
+                         int) -> void
+
+Set field value from integer.
+"""
 function GDALRATSetValueAsInt(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint,arg4::Cint)
     ccall((:GDALRATSetValueAsInt,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Cint),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetValueAsDouble(GDALRasterAttributeTableH,
+                            int,
+                            int,
+                            double) -> void
+
+Set field value from double.
+"""
 function GDALRATSetValueAsDouble(arg1::GDALRasterAttributeTableH,arg2::Cint,arg3::Cint,arg4::Cdouble)
     ccall((:GDALRATSetValueAsDouble,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATChangesAreWrittenToFile(GDALRasterAttributeTableH hRAT) -> int
+
+Determine whether changes made to this RAT are reflected directly in the dataset.
+"""
 function GDALRATChangesAreWrittenToFile(hRAT::GDALRasterAttributeTableH)
     ccall((:GDALRATChangesAreWrittenToFile,libgdal),Cint,(GDALRasterAttributeTableH,),hRAT)
 end
 
+
+"""
+    GDALRATValuesIOAsDouble(GDALRasterAttributeTableH hRAT,
+                            GDALRWFlag eRWFlag,
+                            int iField,
+                            int iStartRow,
+                            int iLength,
+                            double * pdfData) -> CPLErr
+
+Read or Write a block of doubles to/from the Attribute Table.
+"""
 function GDALRATValuesIOAsDouble(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Cint,iStartRow::Cint,iLength::Cint,pdfData::Ptr{Cdouble})
     ccall((:GDALRATValuesIOAsDouble,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Cdouble}),hRAT,eRWFlag,iField,iStartRow,iLength,pdfData)
 end
 
+
+"""
+    GDALRATValuesIOAsInteger(GDALRasterAttributeTableH hRAT,
+                             GDALRWFlag eRWFlag,
+                             int iField,
+                             int iStartRow,
+                             int iLength,
+                             int * pnData) -> CPLErr
+
+Read or Write a block of ints to/from the Attribute Table.
+"""
 function GDALRATValuesIOAsInteger(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Cint,iStartRow::Cint,iLength::Cint,pnData::Ptr{Cint})
     ccall((:GDALRATValuesIOAsInteger,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Cint}),hRAT,eRWFlag,iField,iStartRow,iLength,pnData)
 end
 
+
+"""
+    GDALRATValuesIOAsString(GDALRasterAttributeTableH hRAT,
+                            GDALRWFlag eRWFlag,
+                            int iField,
+                            int iStartRow,
+                            int iLength,
+                            char ** papszStrList) -> CPLErr
+
+Read or Write a block of strings to/from the Attribute Table.
+"""
 function GDALRATValuesIOAsString(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Cint,iStartRow::Cint,iLength::Cint,papszStrList::Ptr{Ptr{UInt8}})
     ccall((:GDALRATValuesIOAsString,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Ptr{UInt8}}),hRAT,eRWFlag,iField,iStartRow,iLength,papszStrList)
 end
 
+
+"""
+    GDALRATSetRowCount(GDALRasterAttributeTableH,
+                       int) -> void
+
+Set row count.
+"""
 function GDALRATSetRowCount(arg1::GDALRasterAttributeTableH,arg2::Cint)
     ccall((:GDALRATSetRowCount,libgdal),Void,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATCreateColumn(GDALRasterAttributeTableH,
+                        const char *,
+                        GDALRATFieldType,
+                        GDALRATFieldUsage) -> CPLErr
+
+Create new column.
+"""
 function GDALRATCreateColumn(arg1::GDALRasterAttributeTableH,arg2::Ptr{UInt8},arg3::GDALRATFieldType,arg4::GDALRATFieldUsage)
     ccall((:GDALRATCreateColumn,libgdal),CPLErr,(GDALRasterAttributeTableH,Ptr{UInt8},GDALRATFieldType,GDALRATFieldUsage),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetLinearBinning(GDALRasterAttributeTableH,
+                            double,
+                            double) -> CPLErr
+
+Set linear binning information.
+"""
 function GDALRATSetLinearBinning(arg1::GDALRasterAttributeTableH,arg2::Cdouble,arg3::Cdouble)
     ccall((:GDALRATSetLinearBinning,libgdal),CPLErr,(GDALRasterAttributeTableH,Cdouble,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATGetLinearBinning(GDALRasterAttributeTableH,
+                            double *,
+                            double *) -> int
+
+Get linear binning information.
+"""
 function GDALRATGetLinearBinning(arg1::GDALRasterAttributeTableH,arg2::Ptr{Cdouble},arg3::Ptr{Cdouble})
     ccall((:GDALRATGetLinearBinning,libgdal),Cint,(GDALRasterAttributeTableH,Ptr{Cdouble},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATInitializeFromColorTable(GDALRasterAttributeTableH,
+                                    GDALColorTableH) -> CPLErr
+
+Initialize from color table.
+"""
 function GDALRATInitializeFromColorTable(arg1::GDALRasterAttributeTableH,arg2::GDALColorTableH)
     ccall((:GDALRATInitializeFromColorTable,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALColorTableH),arg1,arg2)
 end
 
+
+"""
+    GDALRATTranslateToColorTable(GDALRasterAttributeTableH,
+                                 int nEntryCount) -> GDALColorTableH
+
+Translate to a color table.
+"""
 function GDALRATTranslateToColorTable(arg1::GDALRasterAttributeTableH,nEntryCount::Cint)
     ccall((:GDALRATTranslateToColorTable,libgdal),GDALColorTableH,(GDALRasterAttributeTableH,Cint),arg1,nEntryCount)
 end
 
+
+"""
+    GDALRATDumpReadable(GDALRasterAttributeTableH,
+                        FILE *) -> void
+
+Dump RAT in readable form.
+"""
 function GDALRATDumpReadable(arg1::GDALRasterAttributeTableH,arg2::Ptr{FILE})
     ccall((:GDALRATDumpReadable,libgdal),Void,(GDALRasterAttributeTableH,Ptr{FILE}),arg1,arg2)
 end
 
+
+"""
+    GDALRATClone(GDALRasterAttributeTableH) -> GDALRasterAttributeTableH
+
+Copy Raster Attribute Table.
+"""
 function GDALRATClone(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATClone,libgdal),GDALRasterAttributeTableH,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATSerializeJSON(GDALRasterAttributeTableH) -> void *
+
+Serialize Raster Attribute Table in Json format.
+"""
 function GDALRATSerializeJSON(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATSerializeJSON,libgdal),Ptr{Void},(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetRowOfValue(GDALRasterAttributeTableH,
+                         double) -> int
+
+Get row for pixel value.
+"""
 function GDALRATGetRowOfValue(arg1::GDALRasterAttributeTableH,arg2::Cdouble)
     ccall((:GDALRATGetRowOfValue,libgdal),Cint,(GDALRasterAttributeTableH,Cdouble),arg1,arg2)
 end
 
+
+"""
+    GDALSetCacheMax(int nBytes) -> void
+
+Set maximum cache memory.
+
+### Parameters
+* **nNewSizeInBytes**: the maximum number of bytes for caching.
+"""
 function GDALSetCacheMax(nBytes::Cint)
     ccall((:GDALSetCacheMax,libgdal),Void,(Cint,),nBytes)
 end
 
+
+"""
+    GDALGetCacheMax(void) -> int
+
+Get maximum cache memory.
+
+### Returns
+maximum in bytes.
+"""
 function GDALGetCacheMax()
     ccall((:GDALGetCacheMax,libgdal),Cint,())
 end
 
+
+"""
+    GDALGetCacheUsed(void) -> int
+
+Get cache memory used.
+
+### Returns
+the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
+"""
 function GDALGetCacheUsed()
     ccall((:GDALGetCacheUsed,libgdal),Cint,())
 end
 
+
+"""
+    GDALSetCacheMax64(GIntBig nBytes) -> void
+
+Set maximum cache memory.
+
+### Parameters
+* **nNewSizeInBytes**: the maximum number of bytes for caching.
+"""
 function GDALSetCacheMax64(nBytes::GIntBig)
     ccall((:GDALSetCacheMax64,libgdal),Void,(GIntBig,),nBytes)
 end
 
+
+"""
+    GDALGetCacheMax64(void) -> GIntBig
+
+Get maximum cache memory.
+
+### Returns
+maximum in bytes.
+"""
 function GDALGetCacheMax64()
     ccall((:GDALGetCacheMax64,libgdal),GIntBig,())
 end
 
+
+"""
+    GDALGetCacheUsed64(void) -> GIntBig
+
+Get cache memory used.
+
+### Returns
+the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
+"""
 function GDALGetCacheUsed64()
     ccall((:GDALGetCacheUsed64,libgdal),GIntBig,())
 end
 
+
+"""
+    GDALFlushCacheBlock(void) -> int
+
+Try to flush one cached raster block.
+
+### Returns
+TRUE if one block was flushed, FALSE if there are no cached blocks or if they are currently locked.
+"""
 function GDALFlushCacheBlock()
     ccall((:GDALFlushCacheBlock,libgdal),Cint,())
 end
 
+
+"""
+    GDALDatasetGetVirtualMem(GDALDatasetH hDS,
+                             GDALRWFlag eRWFlag,
+                             int nXOff,
+                             int nYOff,
+                             int nXSize,
+                             int nYSize,
+                             int nBufXSize,
+                             int nBufYSize,
+                             GDALDataType eBufType,
+                             int nBandCount,
+                             int * panBandMap,
+                             int nPixelSpace,
+                             GIntBig nLineSpace,
+                             GIntBig nBandSpace,
+                             size_t nCacheSize,
+                             size_t nPageSizeHint,
+                             int bSingleThreadUsage,
+                             char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL dataset object.
+
+### Parameters
+* **hDS**: Dataset object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nBufXSize**: the width of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **nBufYSize**: the height of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nBandCount**: the number of bands being read or written.
+* **panBandMap**: the list of nBandCount band numbers being read/written. Note band numbers are 1 based. This may be NULL to select the first nBandCount bands.
+* **nPixelSpace**: The byte offset from the start of one pixel value in the buffer to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in the buffer to the start of the next. If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+* **nBandSpace**: the byte offset from the start of one bands data to the start of the next. If defaulted (0) the value will be nLineSpace * nBufYSize implying band sequential organization of the data buffer.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **nPageSizeHint**: hint for the page size. Must be a multiple of the system page size, returned by CPLGetPageSize(). Minimum value is generally 4096. Might be set to 0 to let the function determine a default page size.
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function GDALDatasetGetVirtualMem(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,nBufXSize::Cint,nBufYSize::Cint,eBufType::GDALDataType,nBandCount::Cint,panBandMap::Ptr{Cint},nPixelSpace::Cint,nLineSpace::GIntBig,nBandSpace::GIntBig,nCacheSize::Csize_t,nPageSizeHint::Csize_t,bSingleThreadUsage::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALDatasetGetVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,GIntBig,GIntBig,Csize_t,Csize_t,Cint,Ptr{Ptr{UInt8}}),hDS,eRWFlag,nXOff,nYOff,nXSize,nYSize,nBufXSize,nBufYSize,eBufType,nBandCount,panBandMap,nPixelSpace,nLineSpace,nBandSpace,nCacheSize,nPageSizeHint,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALRasterBandGetVirtualMem(GDALRasterBandH hBand,
+                                GDALRWFlag eRWFlag,
+                                int nXOff,
+                                int nYOff,
+                                int nXSize,
+                                int nYSize,
+                                int nBufXSize,
+                                int nBufYSize,
+                                GDALDataType eBufType,
+                                int nPixelSpace,
+                                GIntBig nLineSpace,
+                                size_t nCacheSize,
+                                size_t nPageSizeHint,
+                                int bSingleThreadUsage,
+                                char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL raster band object.
+
+### Parameters
+* **hBand**: Rasterband object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nBufXSize**: the width of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **nBufYSize**: the height of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nPixelSpace**: The byte offset from the start of one pixel value in the buffer to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in the buffer to the start of the next. If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **nPageSizeHint**: hint for the page size. Must be a multiple of the system page size, returned by CPLGetPageSize(). Minimum value is generally 4096. Might be set to 0 to let the function determine a default page size.
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function GDALRasterBandGetVirtualMem(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,nBufXSize::Cint,nBufYSize::Cint,eBufType::GDALDataType,nPixelSpace::Cint,nLineSpace::GIntBig,nCacheSize::Csize_t,nPageSizeHint::Csize_t,bSingleThreadUsage::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALRasterBandGetVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,GIntBig,Csize_t,Csize_t,Cint,Ptr{Ptr{UInt8}}),hBand,eRWFlag,nXOff,nYOff,nXSize,nYSize,nBufXSize,nBufYSize,eBufType,nPixelSpace,nLineSpace,nCacheSize,nPageSizeHint,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALGetVirtualMemAuto(GDALRasterBandH hBand,
+                          GDALRWFlag eRWFlag,
+                          int * pnPixelSpace,
+                          GIntBig * pnLineSpace,
+                          char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL raster band object.
+"""
 function GDALGetVirtualMemAuto(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,pnPixelSpace::Ptr{Cint},pnLineSpace::Ptr{GIntBig},papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALGetVirtualMemAuto,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Ptr{Cint},Ptr{GIntBig},Ptr{Ptr{UInt8}}),hBand,eRWFlag,pnPixelSpace,pnLineSpace,papszOptions)
 end
 
+
+"""
+    GDALDatasetGetTiledVirtualMem(GDALDatasetH hDS,
+                                  GDALRWFlag eRWFlag,
+                                  int nXOff,
+                                  int nYOff,
+                                  int nXSize,
+                                  int nYSize,
+                                  int nTileXSize,
+                                  int nTileYSize,
+                                  GDALDataType eBufType,
+                                  int nBandCount,
+                                  int * panBandMap,
+                                  GDALTileOrganization eTileOrganization,
+                                  size_t nCacheSize,
+                                  int bSingleThreadUsage,
+                                  char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL dataset object, with tiling organization.
+
+### Parameters
+* **hDS**: Dataset object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nTileXSize**: the width of the tiles.
+* **nTileYSize**: the height of the tiles.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nBandCount**: the number of bands being read or written.
+* **panBandMap**: the list of nBandCount band numbers being read/written. Note band numbers are 1 based. This may be NULL to select the first nBandCount bands.
+* **eTileOrganization**: tile organization.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function GDALDatasetGetTiledVirtualMem(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,nTileXSize::Cint,nTileYSize::Cint,eBufType::GDALDataType,nBandCount::Cint,panBandMap::Ptr{Cint},eTileOrganization::GDALTileOrganization,nCacheSize::Csize_t,bSingleThreadUsage::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALDatasetGetTiledVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},GDALTileOrganization,Csize_t,Cint,Ptr{Ptr{UInt8}}),hDS,eRWFlag,nXOff,nYOff,nXSize,nYSize,nTileXSize,nTileYSize,eBufType,nBandCount,panBandMap,eTileOrganization,nCacheSize,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALRasterBandGetTiledVirtualMem(GDALRasterBandH hBand,
+                                     GDALRWFlag eRWFlag,
+                                     int nXOff,
+                                     int nYOff,
+                                     int nXSize,
+                                     int nYSize,
+                                     int nTileXSize,
+                                     int nTileYSize,
+                                     GDALDataType eBufType,
+                                     size_t nCacheSize,
+                                     int bSingleThreadUsage,
+                                     char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL rasterband object, with tiling organization.
+
+### Parameters
+* **hBand**: Rasterband object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nTileXSize**: the width of the tiles.
+* **nTileYSize**: the height of the tiles.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function GDALRasterBandGetTiledVirtualMem(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,nTileXSize::Cint,nTileYSize::Cint,eBufType::GDALDataType,nCacheSize::Csize_t,bSingleThreadUsage::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALRasterBandGetTiledVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Csize_t,Cint,Ptr{Ptr{UInt8}}),hBand,eRWFlag,nXOff,nYOff,nXSize,nYSize,nTileXSize,nTileYSize,eBufType,nCacheSize,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALGetJPEG2000Structure(const char * pszFilename,
+                             char ** papszOptions) -> CPLXMLNode *
+
+Dump the structure of a JPEG2000 file as a XML tree.
+
+### Parameters
+* **pszFilename**: filename.
+* **papszOptions**: NULL terminated list of options, or NULL. Allowed options are BINARY_CONTENT=YES, TEXT_CONTENT=YES, CODESTREAM=YES, ALL=YES.
+
+### Returns
+XML tree (to be freed with CPLDestroyXMLNode()) or NULL in case of error
+"""
 function GDALGetJPEG2000Structure(pszFilename::Ptr{UInt8},papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALGetJPEG2000Structure,libgdal),Ptr{CPLXMLNode},(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszFilename,papszOptions)
 end

--- a/src/C/gdal_alg.jl
+++ b/src/C/gdal_alg.jl
@@ -2,222 +2,1038 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    GDALComputeMedianCutPCT(GDALRasterBandH hRed,
+                            GDALRasterBandH hGreen,
+                            GDALRasterBandH hBlue,
+                            int(*)(int, int, void *) pfnIncludePixel,
+                            int nColors,
+                            GDALColorTableH hColorTable,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressArg) -> int
+
+Compute optimal PCT for RGB image.
+
+### Parameters
+* **hRed**: Red input band.
+* **hGreen**: Green input band.
+* **hBlue**: Blue input band.
+* **pfnIncludePixel**: function used to test which pixels should be included in the analysis. At this time this argument is ignored and all pixels are utilized. This should normally be NULL.
+* **nColors**: the desired number of colors to be returned (2-256).
+* **hColorTable**: the colors will be returned in this color table object.
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+returns CE_None on success or CE_Failure if an error occurs.
+"""
 function GDALComputeMedianCutPCT(hRed::GDALRasterBandH,hGreen::GDALRasterBandH,hBlue::GDALRasterBandH,pfnIncludePixel::Ptr{Void},nColors::Cint,hColorTable::GDALColorTableH,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALComputeMedianCutPCT,libgdal),Cint,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,Ptr{Void},Cint,GDALColorTableH,GDALProgressFunc,Ptr{Void}),hRed,hGreen,hBlue,pfnIncludePixel,nColors,hColorTable,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALDitherRGB2PCT(GDALRasterBandH hRed,
+                      GDALRasterBandH hGreen,
+                      GDALRasterBandH hBlue,
+                      GDALRasterBandH hTarget,
+                      GDALColorTableH hColorTable,
+                      GDALProgressFunc pfnProgress,
+                      void * pProgressArg) -> int
+
+24bit to 8bit conversion with dithering.
+
+### Parameters
+* **hRed**: Red input band.
+* **hGreen**: Green input band.
+* **hBlue**: Blue input band.
+* **hTarget**: Output band.
+* **hColorTable**: the color table to use with the output band.
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure if an error occurs.
+"""
 function GDALDitherRGB2PCT(hRed::GDALRasterBandH,hGreen::GDALRasterBandH,hBlue::GDALRasterBandH,hTarget::GDALRasterBandH,hColorTable::GDALColorTableH,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALDitherRGB2PCT,libgdal),Cint,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALColorTableH,GDALProgressFunc,Ptr{Void}),hRed,hGreen,hBlue,hTarget,hColorTable,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALChecksumImage(GDALRasterBandH hBand,
+                      int nXOff,
+                      int nYOff,
+                      int nXSize,
+                      int nYSize) -> int
+
+Compute checksum for image region.
+
+### Parameters
+* **hBand**: the raster band to read from.
+* **nXOff**: pixel offset of window to read.
+* **nYOff**: line offset of window to read.
+* **nXSize**: pixel size of window to read.
+* **nYSize**: line size of window to read.
+
+### Returns
+Checksum value.
+"""
 function GDALChecksumImage(hBand::GDALRasterBandH,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint)
     ccall((:GDALChecksumImage,libgdal),Cint,(GDALRasterBandH,Cint,Cint,Cint,Cint),hBand,nXOff,nYOff,nXSize,nYSize)
 end
 
+
+"""
+    GDALComputeProximity(GDALRasterBandH hSrcBand,
+                         GDALRasterBandH hProximityBand,
+                         char ** papszOptions,
+                         GDALProgressFunc pfnProgress,
+                         void * pProgressArg) -> CPLErr
+
+Compute the proximity of all pixels in the image to a set of pixels in the source image.
+"""
 function GDALComputeProximity(hSrcBand::GDALRasterBandH,hProximityBand::GDALRasterBandH,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALComputeProximity,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hProximityBand,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALFillNodata(GDALRasterBandH hTargetBand,
+                   GDALRasterBandH hMaskBand,
+                   double dfMaxSearchDist,
+                   int bDeprecatedOption,
+                   int nSmoothingIterations,
+                   char ** papszOptions,
+                   GDALProgressFunc pfnProgress,
+                   void * pProgressArg) -> CPLErr
+
+Fill selected raster regions by interpolation from the edges.
+
+### Parameters
+* **hTargetBand**: the raster band to be modified in place.
+* **hMaskBand**: a mask band indicating pixels to be interpolated (zero valued
+* **dfMaxSearchDist**: the maximum number of pixels to search in all directions to find values to interpolate from.
+* **bDeprecatedOption**: unused argument, should be zero.
+* **nSmoothingIterations**: the number of 3x3 smoothing filter passes to run (0 or more).
+* **papszOptions**: additional name=value options in a string list (the temporary file driver can be specified like TEMP_FILE_DRIVER=MEM).
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure if something goes wrong.
+"""
 function GDALFillNodata(hTargetBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,dfMaxSearchDist::Cdouble,bDeprecatedOption::Cint,nSmoothingIterations::Cint,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALFillNodata,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Cdouble,Cint,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hTargetBand,hMaskBand,dfMaxSearchDist,bDeprecatedOption,nSmoothingIterations,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALPolygonize(GDALRasterBandH hSrcBand,
+                   GDALRasterBandH hMaskBand,
+                   OGRLayerH hOutLayer,
+                   int iPixValField,
+                   char ** papszOptions,
+                   GDALProgressFunc pfnProgress,
+                   void * pProgressArg) -> CPLErr
+
+Create polygon coverage from raster data.
+
+### Parameters
+* **hSrcBand**: the source raster band to be processed.
+* **hMaskBand**: an optional mask band. All pixels in the mask band with a value other than zero will be considered suitable for collection as polygons.
+* **hOutLayer**: the vector feature layer to which the polygons should be written.
+* **iPixValField**: the attribute field index indicating the feature attribute into which the pixel value of the polygon should be written.
+* **papszOptions**: a name/value list of additional options 
+"8CONNECTED": May be set to "8" to use 8 connectedness. Otherwise 4 connectedness will be applied to the algorithm
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure on a failure.
+"""
 function GDALPolygonize(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hOutLayer::OGRLayerH,iPixValField::Cint,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALPolygonize,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,OGRLayerH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hOutLayer,iPixValField,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALFPolygonize(GDALRasterBandH hSrcBand,
+                    GDALRasterBandH hMaskBand,
+                    OGRLayerH hOutLayer,
+                    int iPixValField,
+                    char ** papszOptions,
+                    GDALProgressFunc pfnProgress,
+                    void * pProgressArg) -> CPLErr
+
+Create polygon coverage from raster data.
+
+### Parameters
+* **hSrcBand**: the source raster band to be processed.
+* **hMaskBand**: an optional mask band. All pixels in the mask band with a value other than zero will be considered suitable for collection as polygons.
+* **hOutLayer**: the vector feature layer to which the polygons should be written.
+* **iPixValField**: the attribute field index indicating the feature attribute into which the pixel value of the polygon should be written.
+* **papszOptions**: a name/value list of additional options 
+"8CONNECTED": May be set to "8" to use 8 connectedness. Otherwise 4 connectedness will be applied to the algorithm
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure on a failure.
+"""
 function GDALFPolygonize(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hOutLayer::OGRLayerH,iPixValField::Cint,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALFPolygonize,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,OGRLayerH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hOutLayer,iPixValField,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALSieveFilter(GDALRasterBandH hSrcBand,
+                    GDALRasterBandH hMaskBand,
+                    GDALRasterBandH hDstBand,
+                    int nSizeThreshold,
+                    int nConnectedness,
+                    char ** papszOptions,
+                    GDALProgressFunc pfnProgress,
+                    void * pProgressArg) -> CPLErr
+"""
 function GDALSieveFilter(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hDstBand::GDALRasterBandH,nSizeThreshold::Cint,nConnectedness::Cint,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALSieveFilter,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,Cint,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hDstBand,nSizeThreshold,nConnectedness,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALDestroyTransformer(void * pTransformerArg) -> void
+"""
 function GDALDestroyTransformer(pTransformerArg::Ptr{Void})
     ccall((:GDALDestroyTransformer,libgdal),Void,(Ptr{Void},),pTransformerArg)
 end
 
+
+"""
+    GDALUseTransformer(void * pTranformerArg,
+                       int bDstToSrc,
+                       int nPointCount,
+                       double * x,
+                       double * y,
+                       double * z,
+                       int * panSuccess) -> int
+"""
 function GDALUseTransformer(pTranformerArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALUseTransformer,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTranformerArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateSimilarTransformer(void * psTransformerArg,
+                                 double dfSrcRatioX,
+                                 double dfSrcRatioY) -> void *
+"""
 function GDALCreateSimilarTransformer(psTransformerArg::Ptr{Void},dfSrcRatioX::Cdouble,dfSrcRatioY::Cdouble)
     ccall((:GDALCreateSimilarTransformer,libgdal),Ptr{Void},(Ptr{Void},Cdouble,Cdouble),psTransformerArg,dfSrcRatioX,dfSrcRatioY)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer(GDALDatasetH hSrcDS,
+                                    const char * pszSrcWKT,
+                                    GDALDatasetH hDstDS,
+                                    const char * pszDstWKT,
+                                    int bGCPUseOK,
+                                    double dfGCPErrorThreshold,
+                                    int nOrder) -> void *
+"""
 function GDALCreateGenImgProjTransformer(hSrcDS::GDALDatasetH,pszSrcWKT::Ptr{UInt8},hDstDS::GDALDatasetH,pszDstWKT::Ptr{UInt8},bGCPUseOK::Cint,dfGCPErrorThreshold::Cdouble,nOrder::Cint)
     ccall((:GDALCreateGenImgProjTransformer,libgdal),Ptr{Void},(GDALDatasetH,Ptr{UInt8},GDALDatasetH,Ptr{UInt8},Cint,Cdouble,Cint),hSrcDS,pszSrcWKT,hDstDS,pszDstWKT,bGCPUseOK,dfGCPErrorThreshold,nOrder)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS,
+                                     GDALDatasetH hDstDS,
+                                     char ** papszOptions) -> void *
+
+Create image to image transformer.
+
+### Parameters
+* **hSrcDS**: source dataset, or NULL.
+* **hDstDS**: destination dataset (or NULL).
+* **papszOptions**: NULL-terminated list of string options (or NULL).
+
+### Returns
+handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
+"""
 function GDALCreateGenImgProjTransformer2(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALCreateGenImgProjTransformer2,libgdal),Ptr{Void},(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}}),hSrcDS,hDstDS,papszOptions)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer3(const char * pszSrcWKT,
+                                     const double * padfSrcGeoTransform,
+                                     const char * pszDstWKT,
+                                     const double * padfDstGeoTransform) -> void *
+
+Create image to image transformer.
+
+### Parameters
+* **pszSrcWKT**: source WKT (or NULL).
+* **padfSrcGeoTransform**: source geotransform (or NULL).
+* **pszDstWKT**: destination WKT (or NULL).
+* **padfDstGeoTransform**: destination geotransform (or NULL).
+
+### Returns
+handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
+"""
 function GDALCreateGenImgProjTransformer3(pszSrcWKT::Ptr{UInt8},padfSrcGeoTransform::Ptr{Cdouble},pszDstWKT::Ptr{UInt8},padfDstGeoTransform::Ptr{Cdouble})
     ccall((:GDALCreateGenImgProjTransformer3,libgdal),Ptr{Void},(Ptr{UInt8},Ptr{Cdouble},Ptr{UInt8},Ptr{Cdouble}),pszSrcWKT,padfSrcGeoTransform,pszDstWKT,padfDstGeoTransform)
 end
 
+
+"""
+    GDALSetGenImgProjTransformerDstGeoTransform(void *,
+                                                const double *) -> void
+
+Set GenImgProj output geotransform.
+
+### Parameters
+* **hTransformArg**: the handle to update.
+* **padfGeoTransform**: the destination geotransform to apply (six doubles).
+"""
 function GDALSetGenImgProjTransformerDstGeoTransform(arg1::Ptr{Void},arg2::Ptr{Cdouble})
     ccall((:GDALSetGenImgProjTransformerDstGeoTransform,libgdal),Void,(Ptr{Void},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALDestroyGenImgProjTransformer(void *) -> void
+
+GenImgProjTransformer deallocator.
+
+### Parameters
+* **hTransformArg**: the handle to deallocate.
+"""
 function GDALDestroyGenImgProjTransformer(arg1::Ptr{Void})
     ccall((:GDALDestroyGenImgProjTransformer,libgdal),Void,(Ptr{Void},),arg1)
 end
 
+
+"""
+    GDALGenImgProjTransform(void * pTransformArg,
+                            int bDstToSrc,
+                            int nPointCount,
+                            double * x,
+                            double * y,
+                            double * z,
+                            int * panSuccess) -> int
+
+Perform general image reprojection transformation.
+"""
 function GDALGenImgProjTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALGenImgProjTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALSetTransformerDstGeoTransform(void *,
+                                      const double *) -> void
+"""
 function GDALSetTransformerDstGeoTransform(arg1::Ptr{Void},arg2::Ptr{Cdouble})
     ccall((:GDALSetTransformerDstGeoTransform,libgdal),Void,(Ptr{Void},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALCreateReprojectionTransformer(const char * pszSrcWKT,
+                                      const char * pszDstWKT) -> void *
+
+Create reprojection transformer.
+
+### Parameters
+* **pszSrcWKT**: the coordinate system for the source coordinate system.
+* **pszDstWKT**: the coordinate system for the destination coordinate system.
+
+### Returns
+Handle for use with GDALReprojectionTransform(), or NULL if the system fails to initialize the reprojection.
+"""
 function GDALCreateReprojectionTransformer(pszSrcWKT::Ptr{UInt8},pszDstWKT::Ptr{UInt8})
     ccall((:GDALCreateReprojectionTransformer,libgdal),Ptr{Void},(Ptr{UInt8},Ptr{UInt8}),pszSrcWKT,pszDstWKT)
 end
 
+
+"""
+    GDALDestroyReprojectionTransformer(void *) -> void
+
+Destroy reprojection transformation.
+
+### Parameters
+* **pTransformArg**: the transformation handle returned by GDALCreateReprojectionTransformer().
+"""
 function GDALDestroyReprojectionTransformer(arg1::Ptr{Void})
     ccall((:GDALDestroyReprojectionTransformer,libgdal),Void,(Ptr{Void},),arg1)
 end
 
+
+"""
+    GDALReprojectionTransform(void * pTransformArg,
+                              int bDstToSrc,
+                              int nPointCount,
+                              double * x,
+                              double * y,
+                              double * z,
+                              int * panSuccess) -> int
+
+Perform reprojection transformation.
+"""
 function GDALReprojectionTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALReprojectionTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateGCPTransformer(int nGCPCount,
+                             const GDAL_GCP * pasGCPList,
+                             int nReqOrder,
+                             int bReversed) -> void *
+
+Create GCP based polynomial transformer.
+
+### Parameters
+* **nGCPCount**: the number of GCPs in pasGCPList.
+* **pasGCPList**: an array of GCPs to be used as input.
+* **nReqOrder**: the requested polynomial order. It should be 1, 2 or 3.
+* **bReversed**: set it to TRUE to compute the reversed transformation.
+
+### Returns
+the transform argument or NULL if creation fails.
+"""
 function GDALCreateGCPTransformer(nGCPCount::Cint,pasGCPList::Ptr{GDAL_GCP},nReqOrder::Cint,bReversed::Cint)
     ccall((:GDALCreateGCPTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint,Cint),nGCPCount,pasGCPList,nReqOrder,bReversed)
 end
 
+
+"""
+    GDALCreateGCPRefineTransformer(int nGCPCount,
+                                   const GDAL_GCP * pasGCPList,
+                                   int nReqOrder,
+                                   int bReversed,
+                                   double tolerance,
+                                   int minimumGcps) -> void *
+"""
 function GDALCreateGCPRefineTransformer(nGCPCount::Cint,pasGCPList::Ptr{GDAL_GCP},nReqOrder::Cint,bReversed::Cint,tolerance::Cdouble,minimumGcps::Cint)
     ccall((:GDALCreateGCPRefineTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint,Cint,Cdouble,Cint),nGCPCount,pasGCPList,nReqOrder,bReversed,tolerance,minimumGcps)
 end
 
+
+"""
+    GDALDestroyGCPTransformer(void * pTransformArg) -> void
+
+Destroy GCP transformer.
+
+### Parameters
+* **pTransformArg**: the transform arg previously returned by GDALCreateGCPTransformer().
+"""
 function GDALDestroyGCPTransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyGCPTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALGCPTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+
+Transforms point based on GCP derived polynomial model.
+
+### Parameters
+* **pTransformArg**: return value from GDALCreateGCPTransformer().
+* **bDstToSrc**: TRUE if transformation is from the destination (georeferenced) coordinates to pixel/line or FALSE when transforming from pixel/line to georeferenced coordinates.
+* **nPointCount**: the number of values in the x, y and z arrays.
+* **x**: array containing the X values to be transformed.
+* **y**: array containing the Y values to be transformed.
+* **z**: array containing the Z values to be transformed.
+* **panSuccess**: array in which a flag indicating success (TRUE) or failure (FALSE) of the transformation are placed.
+
+### Returns
+TRUE.
+"""
 function GDALGCPTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALGCPTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateTPSTransformer(int nGCPCount,
+                             const GDAL_GCP * pasGCPList,
+                             int bReversed) -> void *
+
+Create Thin Plate Spline transformer from GCPs.
+
+### Parameters
+* **nGCPCount**: the number of GCPs in pasGCPList.
+* **pasGCPList**: an array of GCPs to be used as input.
+* **bReversed**: set it to TRUE to compute the reversed transformation.
+
+### Returns
+the transform argument or NULL if creation fails.
+"""
 function GDALCreateTPSTransformer(nGCPCount::Cint,pasGCPList::Ptr{GDAL_GCP},bReversed::Cint)
     ccall((:GDALCreateTPSTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint),nGCPCount,pasGCPList,bReversed)
 end
 
+
+"""
+    GDALDestroyTPSTransformer(void * pTransformArg) -> void
+
+Destroy TPS transformer.
+
+### Parameters
+* **pTransformArg**: the transform arg previously returned by GDALCreateTPSTransformer().
+"""
 function GDALDestroyTPSTransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyTPSTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALTPSTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+"""
 function GDALTPSTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALTPSTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    RPCInfoToMD(GDALRPCInfo * psRPCInfo) -> char **
+"""
 function RPCInfoToMD(psRPCInfo::Ptr{GDALRPCInfo})
     ccall((:RPCInfoToMD,libgdal),Ptr{Ptr{UInt8}},(Ptr{GDALRPCInfo},),psRPCInfo)
 end
 
+
+"""
+    GDALCreateRPCTransformer(GDALRPCInfo * psRPC,
+                             int bReversed,
+                             double dfPixErrThreshold,
+                             char ** papszOptions) -> void *
+
+Create an RPC based transformer.
+
+### Parameters
+* **psRPCInfo**: Definition of the RPC parameters.
+* **bReversed**: If true "forward" transformation will be lat/long to pixel/line instead of the normal pixel/line to lat/long.
+* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations).
+* **papszOptions**: Other transformer options (ie. RPC_HEIGHT=<z>).
+
+### Returns
+transformer callback data (deallocate with GDALDestroyTransformer()).
+"""
 function GDALCreateRPCTransformer(psRPC::Ptr{GDALRPCInfo},bReversed::Cint,dfPixErrThreshold::Cdouble,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALCreateRPCTransformer,libgdal),Ptr{Void},(Ptr{GDALRPCInfo},Cint,Cdouble,Ptr{Ptr{UInt8}}),psRPC,bReversed,dfPixErrThreshold,papszOptions)
 end
 
+
+"""
+    GDALDestroyRPCTransformer(void * pTransformArg) -> void
+"""
 function GDALDestroyRPCTransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyRPCTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALRPCTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+"""
 function GDALRPCTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALRPCTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateGeoLocTransformer(GDALDatasetH hBaseDS,
+                                char ** papszGeolocationInfo,
+                                int bReversed) -> void *
+"""
 function GDALCreateGeoLocTransformer(hBaseDS::GDALDatasetH,papszGeolocationInfo::Ptr{Ptr{UInt8}},bReversed::Cint)
     ccall((:GDALCreateGeoLocTransformer,libgdal),Ptr{Void},(GDALDatasetH,Ptr{Ptr{UInt8}},Cint),hBaseDS,papszGeolocationInfo,bReversed)
 end
 
+
+"""
+    GDALDestroyGeoLocTransformer(void * pTransformArg) -> void
+"""
 function GDALDestroyGeoLocTransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyGeoLocTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALGeoLocTransform(void * pTransformArg,
+                        int bDstToSrc,
+                        int nPointCount,
+                        double * x,
+                        double * y,
+                        double * z,
+                        int * panSuccess) -> int
+"""
 function GDALGeoLocTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALGeoLocTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateApproxTransformer(GDALTransformerFunc pfnRawTransformer,
+                                void * pRawTransformerArg,
+                                double dfMaxError) -> void *
+
+Create an approximating transformer.
+
+### Parameters
+* **pfnBaseTransformer**: the high precision transformer which should be approximated.
+* **pBaseTransformArg**: the callback argument for the high precision transformer.
+* **dfMaxError**: the maximum cartesian error in the "output" space that is to be accepted in the linear approximation.
+
+### Returns
+callback pointer suitable for use with GDALApproxTransform(). It should be deallocated with GDALDestroyApproxTransformer().
+"""
 function GDALCreateApproxTransformer(pfnRawTransformer::GDALTransformerFunc,pRawTransformerArg::Ptr{Void},dfMaxError::Cdouble)
     ccall((:GDALCreateApproxTransformer,libgdal),Ptr{Void},(GDALTransformerFunc,Ptr{Void},Cdouble),pfnRawTransformer,pRawTransformerArg,dfMaxError)
 end
 
+
+"""
+    GDALApproxTransformerOwnsSubtransformer(void * pCBData,
+                                            int bOwnFlag) -> void
+"""
 function GDALApproxTransformerOwnsSubtransformer(pCBData::Ptr{Void},bOwnFlag::Cint)
     ccall((:GDALApproxTransformerOwnsSubtransformer,libgdal),Void,(Ptr{Void},Cint),pCBData,bOwnFlag)
 end
 
+
+"""
+    GDALDestroyApproxTransformer(void * pApproxArg) -> void
+
+Cleanup approximate transformer.
+
+### Parameters
+* **pCBData**: callback data originally returned by GDALCreateApproxTransformer().
+"""
 function GDALDestroyApproxTransformer(pApproxArg::Ptr{Void})
     ccall((:GDALDestroyApproxTransformer,libgdal),Void,(Ptr{Void},),pApproxArg)
 end
 
+
+"""
+    GDALApproxTransform(void * pTransformArg,
+                        int bDstToSrc,
+                        int nPointCount,
+                        double * x,
+                        double * y,
+                        double * z,
+                        int * panSuccess) -> int
+
+Perform approximate transformation.
+"""
 function GDALApproxTransform(pTransformArg::Ptr{Void},bDstToSrc::Cint,nPointCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},panSuccess::Ptr{Cint})
     ccall((:GDALApproxTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALSimpleImageWarp(GDALDatasetH hSrcDS,
+                        GDALDatasetH hDstDS,
+                        int nBandCount,
+                        int * panBandList,
+                        GDALTransformerFunc pfnTransform,
+                        void * pTransformArg,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg,
+                        char ** papszWarpOptions) -> int
+
+Perform simple image warp.
+
+### Parameters
+* **hSrcDS**: the source image dataset.
+* **hDstDS**: the destination image dataset.
+* **nBandCount**: the number of bands to be warped. If zero, all bands will be processed.
+* **panBandList**: the list of bands to translate.
+* **pfnTransform**: the transformation function to call. See GDALTransformerFunc().
+* **pTransformArg**: the callback handle to pass to pfnTransform.
+* **pfnProgress**: the function used to report progress. See GDALProgressFunc().
+* **pProgressArg**: the callback handle to pass to pfnProgress.
+* **papszWarpOptions**: additional options controlling the warp.
+
+### Returns
+TRUE if the operation completes, or FALSE if an error occurs.
+"""
 function GDALSimpleImageWarp(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,nBandCount::Cint,panBandList::Ptr{Cint},pfnTransform::GDALTransformerFunc,pTransformArg::Ptr{Void},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},papszWarpOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALSimpleImageWarp,libgdal),Cint,(GDALDatasetH,GDALDatasetH,Cint,Ptr{Cint},GDALTransformerFunc,Ptr{Void},GDALProgressFunc,Ptr{Void},Ptr{Ptr{UInt8}}),hSrcDS,hDstDS,nBandCount,panBandList,pfnTransform,pTransformArg,pfnProgress,pProgressArg,papszWarpOptions)
 end
 
+
+"""
+    GDALSuggestedWarpOutput(GDALDatasetH hSrcDS,
+                            GDALTransformerFunc pfnTransformer,
+                            void * pTransformArg,
+                            double * padfGeoTransformOut,
+                            int * pnPixels,
+                            int * pnLines) -> CPLErr
+
+Suggest output file size.
+
+### Parameters
+* **hSrcDS**: the input image (it is assumed the whole input images is being transformed).
+* **pfnTransformer**: the transformer function.
+* **pTransformArg**: the callback data for the transformer function.
+* **padfGeoTransformOut**: the array of six doubles in which the suggested geotransform is returned.
+* **pnPixels**: int in which the suggest pixel width of output is returned.
+* **pnLines**: int in which the suggest pixel height of output is returned.
+
+### Returns
+CE_None if successful or CE_Failure otherwise.
+"""
 function GDALSuggestedWarpOutput(hSrcDS::GDALDatasetH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeoTransformOut::Ptr{Cdouble},pnPixels::Ptr{Cint},pnLines::Ptr{Cint})
     ccall((:GDALSuggestedWarpOutput,libgdal),CPLErr,(GDALDatasetH,GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Cint},Ptr{Cint}),hSrcDS,pfnTransformer,pTransformArg,padfGeoTransformOut,pnPixels,pnLines)
 end
 
+
+"""
+    GDALSuggestedWarpOutput2(GDALDatasetH hSrcDS,
+                             GDALTransformerFunc pfnTransformer,
+                             void * pTransformArg,
+                             double * padfGeoTransformOut,
+                             int * pnPixels,
+                             int * pnLines,
+                             double * padfExtents,
+                             int nOptions) -> CPLErr
+"""
 function GDALSuggestedWarpOutput2(hSrcDS::GDALDatasetH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeoTransformOut::Ptr{Cdouble},pnPixels::Ptr{Cint},pnLines::Ptr{Cint},padfExtents::Ptr{Cdouble},nOptions::Cint)
     ccall((:GDALSuggestedWarpOutput2,libgdal),CPLErr,(GDALDatasetH,GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Cint),hSrcDS,pfnTransformer,pTransformArg,padfGeoTransformOut,pnPixels,pnLines,padfExtents,nOptions)
 end
 
+
+"""
+    GDALSerializeTransformer(GDALTransformerFunc pfnFunc,
+                             void * pTransformArg) -> CPLXMLNode *
+"""
 function GDALSerializeTransformer(pfnFunc::GDALTransformerFunc,pTransformArg::Ptr{Void})
     ccall((:GDALSerializeTransformer,libgdal),Ptr{CPLXMLNode},(GDALTransformerFunc,Ptr{Void}),pfnFunc,pTransformArg)
 end
 
+
+"""
+    GDALDeserializeTransformer(CPLXMLNode * psTree,
+                               GDALTransformerFunc * ppfnFunc,
+                               void ** ppTransformArg) -> CPLErr
+"""
 function GDALDeserializeTransformer(psTree::Ptr{CPLXMLNode},ppfnFunc::Ptr{GDALTransformerFunc},ppTransformArg::Ptr{Ptr{Void}})
     ccall((:GDALDeserializeTransformer,libgdal),CPLErr,(Ptr{CPLXMLNode},Ptr{GDALTransformerFunc},Ptr{Ptr{Void}}),psTree,ppfnFunc,ppTransformArg)
 end
 
+
+"""
+    GDALTransformGeolocations(GDALRasterBandH hXBand,
+                              GDALRasterBandH hYBand,
+                              GDALRasterBandH hZBand,
+                              GDALTransformerFunc pfnTransformer,
+                              void * pTransformArg,
+                              GDALProgressFunc pfnProgress,
+                              void * pProgressArg,
+                              char ** papszOptions) -> CPLErr
+"""
 function GDALTransformGeolocations(hXBand::GDALRasterBandH,hYBand::GDALRasterBandH,hZBand::GDALRasterBandH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},papszOptions::Ptr{Ptr{UInt8}})
     ccall((:GDALTransformGeolocations,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALTransformerFunc,Ptr{Void},GDALProgressFunc,Ptr{Void},Ptr{Ptr{UInt8}}),hXBand,hYBand,hZBand,pfnTransformer,pTransformArg,pfnProgress,pProgressArg,papszOptions)
 end
 
+
+"""
+    GDAL_CG_Create(int nWidth,
+                   int nHeight,
+                   int bNoDataSet,
+                   double dfNoDataValue,
+                   double dfContourInterval,
+                   double dfContourBase,
+                   GDALContourWriter pfnWriter,
+                   void * pCBData) -> GDALContourGeneratorH
+"""
 function GDAL_CG_Create(nWidth::Cint,nHeight::Cint,bNoDataSet::Cint,dfNoDataValue::Cdouble,dfContourInterval::Cdouble,dfContourBase::Cdouble,pfnWriter::GDALContourWriter,pCBData::Ptr{Void})
     ccall((:GDAL_CG_Create,libgdal),GDALContourGeneratorH,(Cint,Cint,Cint,Cdouble,Cdouble,Cdouble,GDALContourWriter,Ptr{Void}),nWidth,nHeight,bNoDataSet,dfNoDataValue,dfContourInterval,dfContourBase,pfnWriter,pCBData)
 end
 
+
+"""
+    GDAL_CG_FeedLine(GDALContourGeneratorH hCG,
+                     double * padfScanline) -> CPLErr
+"""
 function GDAL_CG_FeedLine(hCG::GDALContourGeneratorH,padfScanline::Ptr{Cdouble})
     ccall((:GDAL_CG_FeedLine,libgdal),CPLErr,(GDALContourGeneratorH,Ptr{Cdouble}),hCG,padfScanline)
 end
 
+
+"""
+    GDAL_CG_Destroy(GDALContourGeneratorH hCG) -> void
+"""
 function GDAL_CG_Destroy(hCG::GDALContourGeneratorH)
     ccall((:GDAL_CG_Destroy,libgdal),Void,(GDALContourGeneratorH,),hCG)
 end
 
+
+"""
+    OGRContourWriter(double dfLevel,
+                     int nPoints,
+                     double * padfX,
+                     double * padfY,
+                     void * pInfo) -> CPLErr
+"""
 function OGRContourWriter(arg1::Cdouble,arg2::Cint,arg3::Ptr{Cdouble},arg4::Ptr{Cdouble},pInfo::Ptr{Void})
     ccall((:OGRContourWriter,libgdal),CPLErr,(Cdouble,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Void}),arg1,arg2,arg3,arg4,pInfo)
 end
 
+
+"""
+    GDALContourGenerate(GDALRasterBandH hBand,
+                        double dfContourInterval,
+                        double dfContourBase,
+                        int nFixedLevelCount,
+                        double * padfFixedLevels,
+                        int bUseNoData,
+                        double dfNoDataValue,
+                        void * hLayer,
+                        int iIDField,
+                        int iElevField,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg) -> CPLErr
+
+Create vector contours from raster DEM.
+
+### Parameters
+* **hBand**: The band to read raster data from. The whole band will be processed.
+* **dfContourInterval**: The elevation interval between contours generated.
+* **dfContourBase**: The "base" relative to which contour intervals are applied. This is normally zero, but could be different. To generate 10m contours at 5, 15, 25, ... the ContourBase would be 5.
+* **nFixedLevelCount**: The number of fixed levels. If this is greater than zero, then fixed levels will be used, and ContourInterval and ContourBase are ignored.
+* **padfFixedLevels**: The list of fixed contour levels at which contours should be generated. It will contain FixedLevelCount entries, and may be NULL if fixed levels are disabled (FixedLevelCount = 0).
+* **bUseNoData**: If TRUE the dfNoDataValue will be used.
+* **dfNoDataValue**: The value to use as a "nodata" value. That is, a pixel value which should be ignored in generating contours as if the value of the pixel were not known.
+* **hLayer**: The layer to which new contour vectors will be written. Each contour will have a LINESTRING geometry attached to it. This is really of type OGRLayerH, but void * is used to avoid pulling the ogr_api.h file in here.
+* **iIDField**: If not -1 this will be used as a field index to indicate where a unique id should be written for each feature (contour) written.
+* **iElevField**: If not -1 this will be used as a field index to indicate where the elevation value of the contour should be written.
+* **pfnProgress**: A GDALProgressFunc that may be used to report progress to the user, or to interrupt the algorithm. May be NULL if not required.
+* **pProgressArg**: The callback data for the pfnProgress function.
+
+### Returns
+CE_None on success or CE_Failure if an error occurs.
+"""
 function GDALContourGenerate(hBand::GDALRasterBandH,dfContourInterval::Cdouble,dfContourBase::Cdouble,nFixedLevelCount::Cint,padfFixedLevels::Ptr{Cdouble},bUseNoData::Cint,dfNoDataValue::Cdouble,hLayer::Ptr{Void},iIDField::Cint,iElevField::Cint,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALContourGenerate,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cdouble},Cint,Cdouble,Ptr{Void},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfContourInterval,dfContourBase,nFixedLevelCount,padfFixedLevels,bUseNoData,dfNoDataValue,hLayer,iIDField,iElevField,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeGeometries(GDALDatasetH hDS,
+                            int nBandCount,
+                            int * panBandList,
+                            int nGeomCount,
+                            OGRGeometryH * pahGeometries,
+                            GDALTransformerFunc pfnTransformer,
+                            void * pTransformArg,
+                            double * padfGeomBurnValue,
+                            char ** papszOptions,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressArg) -> CPLErr
+
+Burn geometries into raster.
+
+### Parameters
+* **hDS**: output data, must be opened in update mode.
+* **nBandCount**: the number of bands to be updated.
+* **panBandList**: the list of bands to be updated.
+* **nGeomCount**: the number of geometries being passed in pahGeometries.
+* **pahGeometries**: the array of geometries to burn in.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **padfGeomBurnValue**: the array of values to burn into the raster. There should be nBandCount values for each geometry.
+* **papszOptions**: special options controlling rasterization 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"BURN_VALUE_FROM": 
+May be set to "Z" to use the Z values of the geometries. dfBurnValue is added to this before burning. Defaults to GDALBurnValueSrc.GBV_UserBurnValue in which case just the dfBurnValue is burned. This is implemented only for points and lines for now. The M value may be supported in the future. 
+"MERGE_ALG": 
+May be REPLACE (the default) or ADD. REPLACE results in overwriting of value, while ADD adds the new value to the existing raster, suitable for heatmaps for instance.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function GDALRasterizeGeometries(hDS::GDALDatasetH,nBandCount::Cint,panBandList::Ptr{Cint},nGeomCount::Cint,pahGeometries::Ptr{OGRGeometryH},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeomBurnValue::Ptr{Cdouble},papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeGeometries,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{Cint},Cint,Ptr{OGRGeometryH},GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hDS,nBandCount,panBandList,nGeomCount,pahGeometries,pfnTransformer,pTransformArg,padfGeomBurnValue,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeLayers(GDALDatasetH hDS,
+                        int nBandCount,
+                        int * panBandList,
+                        int nLayerCount,
+                        OGRLayerH * pahLayers,
+                        GDALTransformerFunc pfnTransformer,
+                        void * pTransformArg,
+                        double * padfLayerBurnValues,
+                        char ** papszOptions,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg) -> CPLErr
+
+Burn geometries from the specified list of layers into raster.
+
+### Parameters
+* **hDS**: output data, must be opened in update mode.
+* **nBandCount**: the number of bands to be updated.
+* **panBandList**: the list of bands to be updated.
+* **nLayerCount**: the number of layers being passed in pahLayers array.
+* **pahLayers**: the array of layers to burn in.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **padfLayerBurnValues**: the array of values to burn into the raster. There should be nBandCount values for each layer.
+* **papszOptions**: special options controlling rasterization: 
+"ATTRIBUTE": 
+Identifies an attribute field on the features to be used for a burn in value. The value will be burned into all output bands. If specified, padfLayerBurnValues will not be used and can be a NULL pointer. 
+"CHUNKYSIZE": 
+The height in lines of the chunk to operate on. The larger the chunk size the less times we need to make a pass through all the shapes. If it is not set or set to zero the default chunk size will be used. Default size will be estimated based on the GDAL cache buffer size using formula: cache_size_bytes/scanline_size_bytes, so the chunk will not exceed the cache. 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"BURN_VALUE_FROM": 
+May be set to "Z" to use the Z values of the geometries. The value from padfLayerBurnValues or the attribute field value is added to this before burning. In default case dfBurnValue is burned as it is. This is implemented properly only for points and lines for now. Polygons will be burned using the Z value from the first point. The M value may be supported in the future. 
+"MERGE_ALG": 
+May be REPLACE (the default) or ADD. REPLACE results in overwriting of value, while ADD adds the new value to the existing raster, suitable for heatmaps for instance.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function GDALRasterizeLayers(hDS::GDALDatasetH,nBandCount::Cint,panBandList::Ptr{Cint},nLayerCount::Cint,pahLayers::Ptr{OGRLayerH},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfLayerBurnValues::Ptr{Cdouble},papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeLayers,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{Cint},Cint,Ptr{OGRLayerH},GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hDS,nBandCount,panBandList,nLayerCount,pahLayers,pfnTransformer,pTransformArg,padfLayerBurnValues,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeLayersBuf(void * pData,
+                           int nBufXSize,
+                           int nBufYSize,
+                           GDALDataType eBufType,
+                           int nPixelSpace,
+                           int nLineSpace,
+                           int nLayerCount,
+                           OGRLayerH * pahLayers,
+                           const char * pszDstProjection,
+                           double * padfDstGeoTransform,
+                           GDALTransformerFunc pfnTransformer,
+                           void * pTransformArg,
+                           double dfBurnValue,
+                           char ** papszOptions,
+                           GDALProgressFunc pfnProgress,
+                           void * pProgressArg) -> CPLErr
+
+Burn geometries from the specified list of layer into raster.
+
+### Parameters
+* **pData**: pointer to the output data array.
+* **nBufXSize**: width of the output data array in pixels.
+* **nBufYSize**: height of the output data array in pixels.
+* **eBufType**: data type of the output data array.
+* **nPixelSpace**: The byte offset from the start of one pixel value in pData to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in pData to the start of the next. If defaulted the size of the datatype eBufType * nBufXSize is used.
+* **nLayerCount**: the number of layers being passed in pahLayers array.
+* **pahLayers**: the array of layers to burn in.
+* **pszDstProjection**: WKT defining the coordinate system of the target raster.
+* **padfDstGeoTransform**: geotransformation matrix of the target raster.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **dfBurnValue**: the value to burn into the raster.
+* **papszOptions**: special options controlling rasterization: 
+"ATTRIBUTE": 
+Identifies an attribute field on the features to be used for a burn in value. The value will be burned into all output bands. If specified, padfLayerBurnValues will not be used and can be a NULL pointer. 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function GDALRasterizeLayersBuf(pData::Ptr{Void},nBufXSize::Cint,nBufYSize::Cint,eBufType::GDALDataType,nPixelSpace::Cint,nLineSpace::Cint,nLayerCount::Cint,pahLayers::Ptr{OGRLayerH},pszDstProjection::Ptr{UInt8},padfDstGeoTransform::Ptr{Cdouble},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},dfBurnValue::Cdouble,papszOptions::Ptr{Ptr{UInt8}},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeLayersBuf,libgdal),CPLErr,(Ptr{Void},Cint,Cint,GDALDataType,Cint,Cint,Cint,Ptr{OGRLayerH},Ptr{UInt8},Ptr{Cdouble},GDALTransformerFunc,Ptr{Void},Cdouble,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),pData,nBufXSize,nBufYSize,eBufType,nPixelSpace,nLineSpace,nLayerCount,pahLayers,pszDstProjection,padfDstGeoTransform,pfnTransformer,pTransformArg,dfBurnValue,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALGridCreate(GDALGridAlgorithm,
+                   const void *,
+                   GUInt32,
+                   const double *,
+                   const double *,
+                   const double *,
+                   double,
+                   double,
+                   double,
+                   double,
+                   GUInt32,
+                   GUInt32,
+                   GDALDataType,
+                   void *,
+                   GDALProgressFunc,
+                   void *) -> CPLErr
+
+Create regular grid from the scattered data.
+
+### Parameters
+* **eAlgorithm**: Gridding method.
+* **poOptions**: Options to control choosen gridding method.
+* **nPoints**: Number of elements in input arrays.
+* **padfX**: Input array of X coordinates.
+* **padfY**: Input array of Y coordinates.
+* **padfZ**: Input array of Z values.
+* **dfXMin**: Lowest X border of output grid.
+* **dfXMax**: Highest X border of output grid.
+* **dfYMin**: Lowest Y border of output grid.
+* **dfYMax**: Highest Y border of output grid.
+* **nXSize**: Number of columns in output grid.
+* **nYSize**: Number of rows in output grid.
+* **eType**: Data type of output array.
+* **pData**: Pointer to array where the computed grid will be stored.
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+CE_None on success or CE_Failure if something goes wrong.
+"""
 function GDALGridCreate(arg1::GDALGridAlgorithm,arg2::Ptr{Void},arg3::GUInt32,arg4::Ptr{Cdouble},arg5::Ptr{Cdouble},arg6::Ptr{Cdouble},arg7::Cdouble,arg8::Cdouble,arg9::Cdouble,arg10::Cdouble,arg11::GUInt32,arg12::GUInt32,arg13::GDALDataType,arg14::Ptr{Void},arg15::GDALProgressFunc,arg16::Ptr{Void})
     ccall((:GDALGridCreate,libgdal),CPLErr,(GDALGridAlgorithm,Ptr{Void},GUInt32,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Cdouble,Cdouble,Cdouble,Cdouble,GUInt32,GUInt32,GDALDataType,Ptr{Void},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16)
 end
 
+
+"""
+    GDALComputeMatchingPoints(GDALDatasetH hFirstImage,
+                              GDALDatasetH hSecondImage,
+                              char ** papszOptions,
+                              int * pnGCPCount) -> GDAL_GCP *
+"""
 function GDALComputeMatchingPoints(hFirstImage::GDALDatasetH,hSecondImage::GDALDatasetH,papszOptions::Ptr{Ptr{UInt8}},pnGCPCount::Ptr{Cint})
     ccall((:GDALComputeMatchingPoints,libgdal),Ptr{GDAL_GCP},(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}},Ptr{Cint}),hFirstImage,hSecondImage,papszOptions,pnGCPCount)
 end

--- a/src/C/gdalwarper.jl
+++ b/src/C/gdalwarper.jl
@@ -2,98 +2,348 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    GDALWarpNoDataMasker(void * pMaskFuncArg,
+                         int nBandCount,
+                         GDALDataType eType,
+                         int,
+                         int,
+                         int nXSize,
+                         int nYSize,
+                         GByte ** ppImageData,
+                         int bMaskIsFloat,
+                         void * pValidityMask,
+                         int * pbOutAllValid) -> CPLErr
+"""
 function GDALWarpNoDataMasker(pMaskFuncArg::Ptr{Void},nBandCount::Cint,eType::GDALDataType,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,papabyImageData::Ptr{Ptr{GByte}},bMaskIsFloat::Cint,pValidityMask::Ptr{Void},pbOutAllValid::Ptr{Cint})
     ccall((:GDALWarpNoDataMasker,libgdal),CPLErr,(Ptr{Void},Cint,GDALDataType,Cint,Cint,Cint,Cint,Ptr{Ptr{GByte}},Cint,Ptr{Void},Ptr{Cint}),pMaskFuncArg,nBandCount,eType,nXOff,nYOff,nXSize,nYSize,papabyImageData,bMaskIsFloat,pValidityMask,pbOutAllValid)
 end
 
+
+"""
+    GDALWarpDstAlphaMasker(void * pMaskFuncArg,
+                           int nBandCount,
+                           CPL_UNUSED GDALDataType eType,
+                           int nXOff,
+                           int nYOff,
+                           int nXSize,
+                           int nYSize,
+                           GByte **,
+                           int bMaskIsFloat,
+                           void * pValidityMask) -> CPLErr
+"""
 function GDALWarpDstAlphaMasker(pMaskFuncArg::Ptr{Void},nBandCount::Cint,eType::GDALDataType,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,arg1::Ptr{Ptr{GByte}},bMaskIsFloat::Cint,pValidityMask::Ptr{Void})
     ccall((:GDALWarpDstAlphaMasker,libgdal),CPLErr,(Ptr{Void},Cint,GDALDataType,Cint,Cint,Cint,Cint,Ptr{Ptr{GByte}},Cint,Ptr{Void}),pMaskFuncArg,nBandCount,eType,nXOff,nYOff,nXSize,nYSize,arg1,bMaskIsFloat,pValidityMask)
 end
 
+
+"""
+    GDALWarpSrcAlphaMasker(void * pMaskFuncArg,
+                           CPL_UNUSED int nBandCount,
+                           CPL_UNUSED GDALDataType eType,
+                           int nXOff,
+                           int nYOff,
+                           int nXSize,
+                           int nYSize,
+                           GByte **,
+                           int bMaskIsFloat,
+                           void * pValidityMask,
+                           int * pbOutAllOpaque) -> CPLErr
+"""
 function GDALWarpSrcAlphaMasker(pMaskFuncArg::Ptr{Void},nBandCount::Cint,eType::GDALDataType,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,arg1::Ptr{Ptr{GByte}},bMaskIsFloat::Cint,pValidityMask::Ptr{Void},pbOutAllOpaque::Ptr{Cint})
     ccall((:GDALWarpSrcAlphaMasker,libgdal),CPLErr,(Ptr{Void},Cint,GDALDataType,Cint,Cint,Cint,Cint,Ptr{Ptr{GByte}},Cint,Ptr{Void},Ptr{Cint}),pMaskFuncArg,nBandCount,eType,nXOff,nYOff,nXSize,nYSize,arg1,bMaskIsFloat,pValidityMask,pbOutAllOpaque)
 end
 
+
+"""
+    GDALWarpSrcMaskMasker(void * pMaskFuncArg,
+                          CPL_UNUSED int nBandCount,
+                          CPL_UNUSED GDALDataType eType,
+                          int nXOff,
+                          int nYOff,
+                          int nXSize,
+                          int nYSize,
+                          GByte **,
+                          int bMaskIsFloat,
+                          void * pValidityMask) -> CPLErr
+"""
 function GDALWarpSrcMaskMasker(pMaskFuncArg::Ptr{Void},nBandCount::Cint,eType::GDALDataType,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,arg1::Ptr{Ptr{GByte}},bMaskIsFloat::Cint,pValidityMask::Ptr{Void})
     ccall((:GDALWarpSrcMaskMasker,libgdal),CPLErr,(Ptr{Void},Cint,GDALDataType,Cint,Cint,Cint,Cint,Ptr{Ptr{GByte}},Cint,Ptr{Void}),pMaskFuncArg,nBandCount,eType,nXOff,nYOff,nXSize,nYSize,arg1,bMaskIsFloat,pValidityMask)
 end
 
+
+"""
+    GDALWarpCutlineMasker(void * pMaskFuncArg,
+                          CPL_UNUSED int nBandCount,
+                          CPL_UNUSED GDALDataType eType,
+                          int nXOff,
+                          int nYOff,
+                          int nXSize,
+                          int nYSize,
+                          GByte **,
+                          int bMaskIsFloat,
+                          void * pValidityMask) -> CPLErr
+"""
 function GDALWarpCutlineMasker(pMaskFuncArg::Ptr{Void},nBandCount::Cint,eType::GDALDataType,nXOff::Cint,nYOff::Cint,nXSize::Cint,nYSize::Cint,arg1::Ptr{Ptr{GByte}},bMaskIsFloat::Cint,pValidityMask::Ptr{Void})
     ccall((:GDALWarpCutlineMasker,libgdal),CPLErr,(Ptr{Void},Cint,GDALDataType,Cint,Cint,Cint,Cint,Ptr{Ptr{GByte}},Cint,Ptr{Void}),pMaskFuncArg,nBandCount,eType,nXOff,nYOff,nXSize,nYSize,arg1,bMaskIsFloat,pValidityMask)
 end
 
+
+"""
+    GDALCreateWarpOptions() -> GDALWarpOptions *
+"""
 function GDALCreateWarpOptions()
     ccall((:GDALCreateWarpOptions,libgdal),Ptr{GDALWarpOptions},())
 end
 
+
+"""
+    GDALDestroyWarpOptions(GDALWarpOptions * psOptions) -> void
+"""
 function GDALDestroyWarpOptions(arg1::Ptr{GDALWarpOptions})
     ccall((:GDALDestroyWarpOptions,libgdal),Void,(Ptr{GDALWarpOptions},),arg1)
 end
 
+
+"""
+    GDALCloneWarpOptions(const GDALWarpOptions * psSrcOptions) -> GDALWarpOptions *
+"""
 function GDALCloneWarpOptions(arg1::Ptr{GDALWarpOptions})
     ccall((:GDALCloneWarpOptions,libgdal),Ptr{GDALWarpOptions},(Ptr{GDALWarpOptions},),arg1)
 end
 
+
+"""
+    GDALSerializeWarpOptions(const GDALWarpOptions * psWO) -> CPLXMLNode *
+"""
 function GDALSerializeWarpOptions(arg1::Ptr{GDALWarpOptions})
     ccall((:GDALSerializeWarpOptions,libgdal),Ptr{CPLXMLNode},(Ptr{GDALWarpOptions},),arg1)
 end
 
+
+"""
+    GDALDeserializeWarpOptions(CPLXMLNode * psTree) -> GDALWarpOptions *
+"""
 function GDALDeserializeWarpOptions(arg1::Ptr{CPLXMLNode})
     ccall((:GDALDeserializeWarpOptions,libgdal),Ptr{GDALWarpOptions},(Ptr{CPLXMLNode},),arg1)
 end
 
+
+"""
+    GDALReprojectImage(GDALDatasetH hSrcDS,
+                       const char * pszSrcWKT,
+                       GDALDatasetH hDstDS,
+                       const char * pszDstWKT,
+                       GDALResampleAlg eResampleAlg,
+                       CPL_UNUSED double dfWarpMemoryLimit,
+                       double dfMaxError,
+                       GDALProgressFunc pfnProgress,
+                       void * pProgressArg,
+                       GDALWarpOptions * psOptions) -> CPLErr
+
+Reproject image.
+
+### Parameters
+* **hSrcDS**: the source image file.
+* **pszSrcWKT**: the source projection. If NULL the source projection is read from from hSrcDS.
+* **hDstDS**: the destination image file.
+* **pszDstWKT**: the destination projection. If NULL the destination projection will be read from hDstDS.
+* **eResampleAlg**: the type of resampling to use.
+* **dfWarpMemoryLimit**: the amount of memory (in bytes) that the warp API is allowed to use for caching. This is in addition to the memory already allocated to the GDAL caching (as per GDALSetCacheMax()). May be 0.0 to use default memory settings.
+* **dfMaxError**: maximum error measured in input pixels that is allowed in approximating the transformation (0.0 for exact calculations).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+* **psOptions**: warp options, normally NULL.
+
+### Returns
+CE_None on success or CE_Failure if something goes wrong.
+"""
 function GDALReprojectImage(hSrcDS::GDALDatasetH,pszSrcWKT::Ptr{UInt8},hDstDS::GDALDatasetH,pszDstWKT::Ptr{UInt8},eResampleAlg::GDALResampleAlg,dfWarpMemoryLimit::Cdouble,dfMaxError::Cdouble,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},psOptions::Ptr{GDALWarpOptions})
     ccall((:GDALReprojectImage,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8},GDALDatasetH,Ptr{UInt8},GDALResampleAlg,Cdouble,Cdouble,GDALProgressFunc,Ptr{Void},Ptr{GDALWarpOptions}),hSrcDS,pszSrcWKT,hDstDS,pszDstWKT,eResampleAlg,dfWarpMemoryLimit,dfMaxError,pfnProgress,pProgressArg,psOptions)
 end
 
+
+"""
+    GDALCreateAndReprojectImage(GDALDatasetH hSrcDS,
+                                const char * pszSrcWKT,
+                                const char * pszDstFilename,
+                                const char * pszDstWKT,
+                                GDALDriverH hDstDriver,
+                                char ** papszCreateOptions,
+                                GDALResampleAlg eResampleAlg,
+                                double dfWarpMemoryLimit,
+                                double dfMaxError,
+                                GDALProgressFunc pfnProgress,
+                                void * pProgressArg,
+                                GDALWarpOptions * psOptions) -> CPLErr
+"""
 function GDALCreateAndReprojectImage(hSrcDS::GDALDatasetH,pszSrcWKT::Ptr{UInt8},pszDstFilename::Ptr{UInt8},pszDstWKT::Ptr{UInt8},hDstDriver::GDALDriverH,papszCreateOptions::Ptr{Ptr{UInt8}},eResampleAlg::GDALResampleAlg,dfWarpMemoryLimit::Cdouble,dfMaxError::Cdouble,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},psOptions::Ptr{GDALWarpOptions})
     ccall((:GDALCreateAndReprojectImage,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},GDALDriverH,Ptr{Ptr{UInt8}},GDALResampleAlg,Cdouble,Cdouble,GDALProgressFunc,Ptr{Void},Ptr{GDALWarpOptions}),hSrcDS,pszSrcWKT,pszDstFilename,pszDstWKT,hDstDriver,papszCreateOptions,eResampleAlg,dfWarpMemoryLimit,dfMaxError,pfnProgress,pProgressArg,psOptions)
 end
 
+
+"""
+    GDALAutoCreateWarpedVRT(GDALDatasetH hSrcDS,
+                            const char * pszSrcWKT,
+                            const char * pszDstWKT,
+                            GDALResampleAlg eResampleAlg,
+                            double dfMaxError,
+                            const GDALWarpOptions * psOptions) -> GDALDatasetH
+
+Create virtual warped dataset automatically.
+
+### Parameters
+* **hSrcDS**: The source dataset.
+* **pszSrcWKT**: The coordinate system of the source image. If NULL, it will be read from the source image.
+* **pszDstWKT**: The coordinate system to convert to. If NULL no change of coordinate system will take place.
+* **eResampleAlg**: One of GRA_NearestNeighbour, GRA_Bilinear, GRA_Cubic, GRA_CubicSpline, GRA_Lanczos, GRA_Average or GRA_Mode. Controls the sampling method used.
+* **dfMaxError**: Maximum error measured in input pixels that is allowed in approximating the transformation (0.0 for exact calculations).
+* **psOptionsIn**: Additional warp options, normally NULL.
+
+### Returns
+NULL on failure, or a new virtual dataset handle on success.
+"""
 function GDALAutoCreateWarpedVRT(hSrcDS::GDALDatasetH,pszSrcWKT::Ptr{UInt8},pszDstWKT::Ptr{UInt8},eResampleAlg::GDALResampleAlg,dfMaxError::Cdouble,psOptions::Ptr{GDALWarpOptions})
     ccall((:GDALAutoCreateWarpedVRT,libgdal),GDALDatasetH,(GDALDatasetH,Ptr{UInt8},Ptr{UInt8},GDALResampleAlg,Cdouble,Ptr{GDALWarpOptions}),hSrcDS,pszSrcWKT,pszDstWKT,eResampleAlg,dfMaxError,psOptions)
 end
 
+
+"""
+    GDALCreateWarpedVRT(GDALDatasetH hSrcDS,
+                        int nPixels,
+                        int nLines,
+                        double * padfGeoTransform,
+                        GDALWarpOptions * psOptions) -> GDALDatasetH
+
+Create virtual warped dataset.
+
+### Parameters
+* **hSrcDS**: The source dataset.
+* **nPixels**: Width of the virtual warped dataset to create
+* **nLines**: Height of the virtual warped dataset to create
+* **padfGeoTransform**: Geotransform matrix of the virtual warped dataset to create
+* **psOptions**: Warp options. Must be different from NULL.
+
+### Returns
+NULL on failure, or a new virtual dataset handle on success.
+"""
 function GDALCreateWarpedVRT(hSrcDS::GDALDatasetH,nPixels::Cint,nLines::Cint,padfGeoTransform::Ptr{Cdouble},psOptions::Ptr{GDALWarpOptions})
     ccall((:GDALCreateWarpedVRT,libgdal),GDALDatasetH,(GDALDatasetH,Cint,Cint,Ptr{Cdouble},Ptr{GDALWarpOptions}),hSrcDS,nPixels,nLines,padfGeoTransform,psOptions)
 end
 
+
+"""
+    GDALInitializeWarpedVRT(GDALDatasetH hDS,
+                            GDALWarpOptions * psWO) -> CPLErr
+
+Set warp info on virtual warped dataset.
+
+### Parameters
+* **hDS**: dataset previously created with the VRT driver, and a SUBCLASS of "VRTWarpedDataset".
+* **psWO**: the warp options to apply. Note that ownership of the transformation information is taken over by the function though everything else remains the property of the caller.
+
+### Returns
+CE_None on success or CE_Failure if an error occurs.
+"""
 function GDALInitializeWarpedVRT(hDS::GDALDatasetH,psWO::Ptr{GDALWarpOptions})
     ccall((:GDALInitializeWarpedVRT,libgdal),CPLErr,(GDALDatasetH,Ptr{GDALWarpOptions}),hDS,psWO)
 end
 
+
+"""
+    GDALCreateWarpOperation(const GDALWarpOptions *) -> GDALWarpOperationH
+"""
 function GDALCreateWarpOperation(arg1::Ptr{GDALWarpOptions})
     ccall((:GDALCreateWarpOperation,libgdal),GDALWarpOperationH,(Ptr{GDALWarpOptions},),arg1)
 end
 
+
+"""
+    GDALDestroyWarpOperation(GDALWarpOperationH) -> void
+"""
 function GDALDestroyWarpOperation(arg1::GDALWarpOperationH)
     ccall((:GDALDestroyWarpOperation,libgdal),Void,(GDALWarpOperationH,),arg1)
 end
 
+
+"""
+    GDALChunkAndWarpImage(GDALWarpOperationH,
+                          int,
+                          int,
+                          int,
+                          int) -> CPLErr
+"""
 function GDALChunkAndWarpImage(arg1::GDALWarpOperationH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint)
     ccall((:GDALChunkAndWarpImage,libgdal),CPLErr,(GDALWarpOperationH,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALChunkAndWarpMulti(GDALWarpOperationH,
+                          int,
+                          int,
+                          int,
+                          int) -> CPLErr
+"""
 function GDALChunkAndWarpMulti(arg1::GDALWarpOperationH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint)
     ccall((:GDALChunkAndWarpMulti,libgdal),CPLErr,(GDALWarpOperationH,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALWarpRegion(GDALWarpOperationH,
+                   int,
+                   int,
+                   int,
+                   int,
+                   int,
+                   int,
+                   int,
+                   int) -> CPLErr
+"""
 function GDALWarpRegion(arg1::GDALWarpOperationH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint,arg6::Cint,arg7::Cint,arg8::Cint,arg9::Cint)
     ccall((:GDALWarpRegion,libgdal),CPLErr,(GDALWarpOperationH,Cint,Cint,Cint,Cint,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    GDALWarpRegionToBuffer(GDALWarpOperationH,
+                           int,
+                           int,
+                           int,
+                           int,
+                           void *,
+                           GDALDataType,
+                           int,
+                           int,
+                           int,
+                           int) -> CPLErr
+"""
 function GDALWarpRegionToBuffer(arg1::GDALWarpOperationH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint,arg6::Ptr{Void},arg7::GDALDataType,arg8::Cint,arg9::Cint,arg10::Cint,arg11::Cint)
     ccall((:GDALWarpRegionToBuffer,libgdal),CPLErr,(GDALWarpOperationH,Cint,Cint,Cint,Cint,Ptr{Void},GDALDataType,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11)
 end
 
+
+"""
+    GWKGetFilterRadius(GDALResampleAlg eResampleAlg) -> int
+"""
 function GWKGetFilterRadius(eResampleAlg::GDALResampleAlg)
     ccall((:GWKGetFilterRadius,libgdal),Cint,(GDALResampleAlg,),eResampleAlg)
 end
 
+
+"""
+    GWKGetFilterFunc(GDALResampleAlg eResampleAlg) -> FilterFuncType
+"""
 function GWKGetFilterFunc(eResampleAlg::GDALResampleAlg)
     ccall((:GWKGetFilterFunc,libgdal),FilterFuncType,(GDALResampleAlg,),eResampleAlg)
 end
 
+
+"""
+    GWKGetFilterFunc4Values(GDALResampleAlg eResampleAlg) -> FilterFunc4ValuesType
+"""
 function GWKGetFilterFunc4Values(eResampleAlg::GDALResampleAlg)
     ccall((:GWKGetFilterFunc4Values,libgdal),FilterFunc4ValuesType,(GDALResampleAlg,),eResampleAlg)
 end

--- a/src/C/ogr_api.jl
+++ b/src/C/ogr_api.jl
@@ -2,1366 +2,5662 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    OGR_G_CreateFromWkb(unsigned char *,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *,
+                        int) -> OGRErr
+
+Create a geometry object of the appropriate type from it's well known binary representation.
+
+### Parameters
+* **pabyData**: pointer to the input BLOB data.
+* **hSRS**: handle to the spatial reference to be assigned to the created geometry object. This may be NULL.
+* **phGeometry**: the newly created geometry object will be assigned to the indicated handle on return. This will be NULL in case of failure. If not NULL, *phGeometry should be freed with OGR_G_DestroyGeometry() after use.
+* **nBytes**: the number of bytes of data available in pabyData, or -1 if it is not known, but assumed to be sufficient.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function OGR_G_CreateFromWkb(arg1::Ptr{Cuchar},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH},arg4::Cint)
     ccall((:OGR_G_CreateFromWkb,libgdal),OGRErr,(Ptr{Cuchar},OGRSpatialReferenceH,Ptr{OGRGeometryH},Cint),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_CreateFromWkt(char **,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *) -> OGRErr
+
+Create a geometry object of the appropriate type from it's well known text representation.
+
+### Parameters
+* **ppszData**: input zero terminated string containing well known text representation of the geometry to be created. The pointer is updated to point just beyond that last character consumed.
+* **hSRS**: handle to the spatial reference to be assigned to the created geometry object. This may be NULL.
+* **phGeometry**: the newly created geometry object will be assigned to the indicated handle on return. This will be NULL if the method fails. If not NULL, *phGeometry should be freed with OGR_G_DestroyGeometry() after use.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function OGR_G_CreateFromWkt(arg1::Ptr{Ptr{UInt8}},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH})
     ccall((:OGR_G_CreateFromWkt,libgdal),OGRErr,(Ptr{Ptr{UInt8}},OGRSpatialReferenceH,Ptr{OGRGeometryH}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_CreateFromFgf(unsigned char *,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *,
+                        int,
+                        int *) -> OGRErr
+"""
 function OGR_G_CreateFromFgf(arg1::Ptr{Cuchar},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH},arg4::Cint,arg5::Ptr{Cint})
     ccall((:OGR_G_CreateFromFgf,libgdal),OGRErr,(Ptr{Cuchar},OGRSpatialReferenceH,Ptr{OGRGeometryH},Cint,Ptr{Cint}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OGR_G_DestroyGeometry(OGRGeometryH) -> void
+
+Destroy geometry object.
+
+### Parameters
+* **hGeom**: handle to the geometry to delete.
+"""
 function OGR_G_DestroyGeometry(arg1::OGRGeometryH)
     ccall((:OGR_G_DestroyGeometry,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CreateGeometry(OGRwkbGeometryType) -> OGRGeometryH
+
+Create an empty geometry of desired type.
+
+### Parameters
+* **eGeometryType**: the type code of the geometry to be created.
+
+### Returns
+handle to the newly create geometry or NULL on failure. Should be freed with OGR_G_DestroyGeometry() after use.
+"""
 function OGR_G_CreateGeometry(arg1::OGRwkbGeometryType)
     ccall((:OGR_G_CreateGeometry,libgdal),OGRGeometryH,(OGRwkbGeometryType,),arg1)
 end
 
+
+"""
+    OGR_G_ApproximateArcAngles(double dfCenterX,
+                               double dfCenterY,
+                               double dfZ,
+                               double dfPrimaryRadius,
+                               double dfSecondaryAxis,
+                               double dfRotation,
+                               double dfStartAngle,
+                               double dfEndAngle,
+                               double dfMaxAngleStepSizeDegrees) -> OGRGeometryH
+
+Stroke arc to linestring.
+
+### Parameters
+* **dfCenterX**: center X
+* **dfCenterY**: center Y
+* **dfZ**: center Z
+* **dfPrimaryRadius**: X radius of ellipse.
+* **dfSecondaryRadius**: Y radius of ellipse.
+* **dfRotation**: rotation of the ellipse clockwise.
+* **dfStartAngle**: angle to first point on arc (clockwise of X-positive)
+* **dfEndAngle**: angle to last point on arc (clockwise of X-positive)
+* **dfMaxAngleStepSizeDegrees**: the largest step in degrees along the arc, zero to use the default setting.
+
+### Returns
+OGRLineString geometry representing an approximation of the arc.
+"""
 function OGR_G_ApproximateArcAngles(dfCenterX::Cdouble,dfCenterY::Cdouble,dfZ::Cdouble,dfPrimaryRadius::Cdouble,dfSecondaryAxis::Cdouble,dfRotation::Cdouble,dfStartAngle::Cdouble,dfEndAngle::Cdouble,dfMaxAngleStepSizeDegrees::Cdouble)
     ccall((:OGR_G_ApproximateArcAngles,libgdal),OGRGeometryH,(Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),dfCenterX,dfCenterY,dfZ,dfPrimaryRadius,dfSecondaryAxis,dfRotation,dfStartAngle,dfEndAngle,dfMaxAngleStepSizeDegrees)
 end
 
+
+"""
+    OGR_G_ForceToPolygon(OGRGeometryH) -> OGRGeometryH
+
+Convert to polygon.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function OGR_G_ForceToPolygon(arg1::OGRGeometryH)
     ccall((:OGR_G_ForceToPolygon,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ForceToLineString(OGRGeometryH) -> OGRGeometryH
+
+Convert to line string.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function OGR_G_ForceToLineString(arg1::OGRGeometryH)
     ccall((:OGR_G_ForceToLineString,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ForceToMultiPolygon(OGRGeometryH) -> OGRGeometryH
+
+Convert to multipolygon.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function OGR_G_ForceToMultiPolygon(arg1::OGRGeometryH)
     ccall((:OGR_G_ForceToMultiPolygon,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ForceToMultiPoint(OGRGeometryH) -> OGRGeometryH
+
+Convert to multipoint.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function OGR_G_ForceToMultiPoint(arg1::OGRGeometryH)
     ccall((:OGR_G_ForceToMultiPoint,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ForceToMultiLineString(OGRGeometryH) -> OGRGeometryH
+
+Convert to multilinestring.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function OGR_G_ForceToMultiLineString(arg1::OGRGeometryH)
     ccall((:OGR_G_ForceToMultiLineString,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ForceTo(OGRGeometryH hGeom,
+                  OGRwkbGeometryType eTargetType,
+                  char ** papszOptions) -> OGRGeometryH
+
+Convert to another geometry type.
+
+### Parameters
+* **hGeom**: the input geometry - ownership is passed to the method.
+* **eTargetType**: target output geometry type.
+* **papszOptions**: options as a null-terminated list of strings or NULL.
+
+### Returns
+new geometry.
+"""
 function OGR_G_ForceTo(hGeom::OGRGeometryH,eTargetType::OGRwkbGeometryType,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ForceTo,libgdal),OGRGeometryH,(OGRGeometryH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),hGeom,eTargetType,papszOptions)
 end
 
+
+"""
+    OGR_G_GetDimension(OGRGeometryH) -> int
+
+Get the dimension of this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension from.
+
+### Returns
+0 for points, 1 for lines and 2 for surfaces.
+"""
 function OGR_G_GetDimension(arg1::OGRGeometryH)
     ccall((:OGR_G_GetDimension,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetCoordinateDimension(OGRGeometryH) -> int
+
+Get the dimension of the coordinates in this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension of the coordinates from.
+
+### Returns
+in practice this will return 2 or 3. It can also return 0 in the case of an empty point.
+"""
 function OGR_G_GetCoordinateDimension(arg1::OGRGeometryH)
     ccall((:OGR_G_GetCoordinateDimension,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_SetCoordinateDimension(OGRGeometryH,
+                                 int) -> void
+
+Set the coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set the dimension of the coordinates.
+* **nNewDimension**: New coordinate dimension value, either 2 or 3.
+"""
 function OGR_G_SetCoordinateDimension(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_SetCoordinateDimension,libgdal),Void,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Clone(OGRGeometryH) -> OGRGeometryH
+
+Make a copy of this object.
+
+### Parameters
+* **hGeom**: handle on the geometry to clone from.
+
+### Returns
+an handle on the copy of the geometry with the spatial reference system as the original.
+"""
 function OGR_G_Clone(arg1::OGRGeometryH)
     ccall((:OGR_G_Clone,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetEnvelope(OGRGeometryH,
+                      OGREnvelope *) -> void
+
+Computes and returns the bounding envelope for this geometry in the passed psEnvelope structure.
+
+### Parameters
+* **hGeom**: handle of the geometry to get envelope from.
+* **psEnvelope**: the structure in which to place the results.
+"""
 function OGR_G_GetEnvelope(arg1::OGRGeometryH,arg2::Ptr{OGREnvelope})
     ccall((:OGR_G_GetEnvelope,libgdal),Void,(OGRGeometryH,Ptr{OGREnvelope}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetEnvelope3D(OGRGeometryH,
+                        OGREnvelope3D *) -> void
+
+Computes and returns the bounding envelope (3D) for this geometry in the passed psEnvelope structure.
+
+### Parameters
+* **hGeom**: handle of the geometry to get envelope from.
+* **psEnvelope**: the structure in which to place the results.
+"""
 function OGR_G_GetEnvelope3D(arg1::OGRGeometryH,arg2::Ptr{OGREnvelope3D})
     ccall((:OGR_G_GetEnvelope3D,libgdal),Void,(OGRGeometryH,Ptr{OGREnvelope3D}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ImportFromWkb(OGRGeometryH,
+                        unsigned char *,
+                        int) -> OGRErr
+
+Assign geometry from well known binary data.
+
+### Parameters
+* **hGeom**: handle on the geometry to assign the well know binary data to.
+* **pabyData**: the binary input data.
+* **nSize**: the size of pabyData in bytes, or zero if not known.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function OGR_G_ImportFromWkb(arg1::OGRGeometryH,arg2::Ptr{Cuchar},arg3::Cint)
     ccall((:OGR_G_ImportFromWkb,libgdal),OGRErr,(OGRGeometryH,Ptr{Cuchar},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_ExportToWkb(OGRGeometryH,
+                      OGRwkbByteOrder,
+                      unsigned char *) -> OGRErr
+
+Convert a geometry well known binary format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a well know binary data from.
+* **eOrder**: One of wkbXDR or wkbNDR indicating MSB or LSB byte order respectively.
+* **pabyDstBuffer**: a buffer into which the binary representation is written. This buffer must be at least OGR_G_WkbSize() byte in size.
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function OGR_G_ExportToWkb(arg1::OGRGeometryH,arg2::OGRwkbByteOrder,arg3::Ptr{Cuchar})
     ccall((:OGR_G_ExportToWkb,libgdal),OGRErr,(OGRGeometryH,OGRwkbByteOrder,Ptr{Cuchar}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_ExportToIsoWkb(OGRGeometryH,
+                         OGRwkbByteOrder,
+                         unsigned char *) -> OGRErr
+
+Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known binary format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a well know binary data from.
+* **eOrder**: One of wkbXDR or wkbNDR indicating MSB or LSB byte order respectively.
+* **pabyDstBuffer**: a buffer into which the binary representation is written. This buffer must be at least OGR_G_WkbSize() byte in size.
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function OGR_G_ExportToIsoWkb(arg1::OGRGeometryH,arg2::OGRwkbByteOrder,arg3::Ptr{Cuchar})
     ccall((:OGR_G_ExportToIsoWkb,libgdal),OGRErr,(OGRGeometryH,OGRwkbByteOrder,Ptr{Cuchar}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_WkbSize(OGRGeometryH hGeom) -> int
+
+Returns size of related binary representation.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the binary size from.
+
+### Returns
+size of binary representation in bytes.
+"""
 function OGR_G_WkbSize(hGeom::OGRGeometryH)
     ccall((:OGR_G_WkbSize,libgdal),Cint,(OGRGeometryH,),hGeom)
 end
 
+
+"""
+    OGR_G_ImportFromWkt(OGRGeometryH,
+                        char **) -> OGRErr
+
+Assign geometry from well known text data.
+
+### Parameters
+* **hGeom**: handle on the geometry to assign well know text data to.
+* **ppszSrcText**: pointer to a pointer to the source text. The pointer is updated to pointer after the consumed text.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function OGR_G_ImportFromWkt(arg1::OGRGeometryH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ImportFromWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ExportToWkt(OGRGeometryH,
+                      char **) -> OGRErr
+
+Convert a geometry into well known text format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a text format from.
+* **ppszSrcText**: a text buffer is allocated by the program, and assigned to the passed pointer. After use, *ppszDstText should be freed with OGRFree().
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function OGR_G_ExportToWkt(arg1::OGRGeometryH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ExportToWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ExportToIsoWkt(OGRGeometryH,
+                         char **) -> OGRErr
+
+Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a text format from.
+* **ppszSrcText**: a text buffer is allocated by the program, and assigned to the passed pointer. After use, *ppszDstText should be freed with OGRFree().
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function OGR_G_ExportToIsoWkt(arg1::OGRGeometryH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ExportToIsoWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetGeometryType(OGRGeometryH) -> OGRwkbGeometryType
+
+Fetch geometry type.
+
+### Parameters
+* **hGeom**: handle on the geometry to get type from.
+
+### Returns
+the geometry type code.
+"""
 function OGR_G_GetGeometryType(arg1::OGRGeometryH)
     ccall((:OGR_G_GetGeometryType,libgdal),OGRwkbGeometryType,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetGeometryName(OGRGeometryH) -> const char *
+
+Fetch WKT name for geometry type.
+
+### Parameters
+* **hGeom**: handle on the geometry to get name from.
+
+### Returns
+name used for this geometry type in well known text format.
+"""
 function OGR_G_GetGeometryName(arg1::OGRGeometryH)
     ccall((:OGR_G_GetGeometryName,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_DumpReadable(OGRGeometryH,
+                       FILE *,
+                       const char *) -> void
+
+Dump geometry in well known text format to indicated output file.
+
+### Parameters
+* **hGeom**: handle on the geometry to dump.
+* **fp**: the text file to write the geometry to.
+* **pszPrefix**: the prefix to put on each line of output.
+"""
 function OGR_G_DumpReadable(arg1::OGRGeometryH,arg2::Ptr{FILE},arg3::Ptr{UInt8})
     ccall((:OGR_G_DumpReadable,libgdal),Void,(OGRGeometryH,Ptr{FILE},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_FlattenTo2D(OGRGeometryH) -> void
+
+Convert geometry to strictly 2D.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert.
+"""
 function OGR_G_FlattenTo2D(arg1::OGRGeometryH)
     ccall((:OGR_G_FlattenTo2D,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CloseRings(OGRGeometryH) -> void
+
+Force rings to be closed.
+
+### Parameters
+* **hGeom**: handle to the geometry.
+"""
 function OGR_G_CloseRings(arg1::OGRGeometryH)
     ccall((:OGR_G_CloseRings,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CreateFromGML(const char * pszGML) -> OGRGeometryH
+
+Create geometry from GML.
+
+### Parameters
+* **pszGML**: The GML fragment for the geometry.
+
+### Returns
+a geometry on succes, or NULL on error.
+"""
 function OGR_G_CreateFromGML(arg1::Ptr{UInt8})
     ccall((:OGR_G_CreateFromGML,libgdal),OGRGeometryH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OGR_G_ExportToGML(OGRGeometryH hGeometry) -> char *
+
+Convert a geometry into GML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+
+### Returns
+A GML fragment or NULL in case of error.
+"""
 function OGR_G_ExportToGML(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportToGML,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportToGMLEx(OGRGeometryH hGeometry,
+                        char ** papszOptions) -> char *
+
+Convert a geometry into GML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **papszOptions**: NULL-terminated list of options.
+
+### Returns
+A GML fragment or NULL in case of error.
+"""
 function OGR_G_ExportToGMLEx(arg1::OGRGeometryH,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ExportToGMLEx,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,papszOptions)
 end
 
+
+"""
+    OGR_G_CreateFromGMLTree(const CPLXMLNode * psTree) -> OGRGeometryH
+"""
 function OGR_G_CreateFromGMLTree(arg1::Ptr{CPLXMLNode})
     ccall((:OGR_G_CreateFromGMLTree,libgdal),OGRGeometryH,(Ptr{CPLXMLNode},),arg1)
 end
 
+
+"""
+    OGR_G_ExportToGMLTree(OGRGeometryH hGeometry) -> CPLXMLNode *
+"""
 function OGR_G_ExportToGMLTree(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportToGMLTree,libgdal),Ptr{CPLXMLNode},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportEnvelopeToGMLTree(OGRGeometryH hGeometry) -> CPLXMLNode *
+"""
 function OGR_G_ExportEnvelopeToGMLTree(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportEnvelopeToGMLTree,libgdal),Ptr{CPLXMLNode},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportToKML(OGRGeometryH hGeometry,
+                      const char * pszAltitudeMode) -> char *
+
+Convert a geometry into KML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **pszAltitudeMode**: value to write in altitudeMode element, or NULL.
+
+### Returns
+A KML fragment or NULL in case of error.
+"""
 function OGR_G_ExportToKML(arg1::OGRGeometryH,pszAltitudeMode::Ptr{UInt8})
     ccall((:OGR_G_ExportToKML,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{UInt8}),arg1,pszAltitudeMode)
 end
 
+
+"""
+    OGR_G_ExportToJson(OGRGeometryH) -> char *
+
+Convert a geometry into GeoJSON format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+
+### Returns
+A GeoJSON fragment or NULL in case of error.
+"""
 function OGR_G_ExportToJson(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportToJson,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportToJsonEx(OGRGeometryH,
+                         char ** papszOptions) -> char *
+
+Convert a geometry into GeoJSON format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **papszOptions**: a null terminated list of options. For now, only COORDINATE_PRECISION=int_number where int_number is the maximum number of figures after decimal separator to write in coordinates.
+
+### Returns
+A GeoJSON fragment or NULL in case of error.
+"""
 function OGR_G_ExportToJsonEx(arg1::OGRGeometryH,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_ExportToJsonEx,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,papszOptions)
 end
 
+
+"""
+    OGR_G_CreateGeometryFromJson(const char *) -> OGRGeometryH
+"""
 function OGR_G_CreateGeometryFromJson(arg1::Ptr{UInt8})
     ccall((:OGR_G_CreateGeometryFromJson,libgdal),OGRGeometryH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OGR_G_AssignSpatialReference(OGRGeometryH,
+                                 OGRSpatialReferenceH) -> void
+
+Assign spatial reference to this object.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the new spatial reference system.
+* **hSRS**: handle on the new spatial reference system to apply.
+"""
 function OGR_G_AssignSpatialReference(arg1::OGRGeometryH,arg2::OGRSpatialReferenceH)
     ccall((:OGR_G_AssignSpatialReference,libgdal),Void,(OGRGeometryH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetSpatialReference(OGRGeometryH) -> OGRSpatialReferenceH
+
+Returns spatial reference system for geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get spatial reference from.
+
+### Returns
+a reference to the spatial reference geometry.
+"""
 function OGR_G_GetSpatialReference(arg1::OGRGeometryH)
     ccall((:OGR_G_GetSpatialReference,libgdal),OGRSpatialReferenceH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Transform(OGRGeometryH,
+                    OGRCoordinateTransformationH) -> OGRErr
+
+Apply arbitrary coordinate transformation to geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the transform to.
+* **hTransform**: handle on the transformation to apply.
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function OGR_G_Transform(arg1::OGRGeometryH,arg2::OGRCoordinateTransformationH)
     ccall((:OGR_G_Transform,libgdal),OGRErr,(OGRGeometryH,OGRCoordinateTransformationH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_TransformTo(OGRGeometryH,
+                      OGRSpatialReferenceH) -> OGRErr
+
+Transform geometry to new spatial reference system.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the transform to.
+* **hSRS**: handle on the spatial reference system to apply.
+
+### Returns
+OGRERR_NONE on success, or an error code.
+"""
 function OGR_G_TransformTo(arg1::OGRGeometryH,arg2::OGRSpatialReferenceH)
     ccall((:OGR_G_TransformTo,libgdal),OGRErr,(OGRGeometryH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Simplify(OGRGeometryH hThis,
+                   double tolerance) -> OGRGeometryH
+
+Compute a simplified geometry.
+
+### Parameters
+* **hThis**: the geometry.
+* **dTolerance**: the distance tolerance for the simplification.
+
+### Returns
+the simplified geometry or NULL if an error occurs.
+"""
 function OGR_G_Simplify(hThis::OGRGeometryH,tolerance::Cdouble)
     ccall((:OGR_G_Simplify,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),hThis,tolerance)
 end
 
+
+"""
+    OGR_G_SimplifyPreserveTopology(OGRGeometryH hThis,
+                                   double tolerance) -> OGRGeometryH
+
+Simplify the geometry while preserving topology.
+
+### Parameters
+* **hThis**: the geometry.
+* **dTolerance**: the distance tolerance for the simplification.
+
+### Returns
+the simplified geometry or NULL if an error occurs.
+"""
 function OGR_G_SimplifyPreserveTopology(hThis::OGRGeometryH,tolerance::Cdouble)
     ccall((:OGR_G_SimplifyPreserveTopology,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),hThis,tolerance)
 end
 
+
+"""
+    OGR_G_Segmentize(OGRGeometryH hGeom,
+                     double dfMaxLength) -> void
+
+Modify the geometry such it has no segment longer then the given distance.
+
+### Parameters
+* **hGeom**: handle on the geometry to segmentize
+* **dfMaxLength**: the maximum distance between 2 points after segmentization
+"""
 function OGR_G_Segmentize(hGeom::OGRGeometryH,dfMaxLength::Cdouble)
     ccall((:OGR_G_Segmentize,libgdal),Void,(OGRGeometryH,Cdouble),hGeom,dfMaxLength)
 end
 
+
+"""
+    OGR_G_Intersects(OGRGeometryH,
+                     OGRGeometryH) -> int
+
+Do these features intersect?
+
+### Parameters
+* **hGeom**: handle on the first geometry.
+* **hOtherGeom**: handle on the other geometry to test against.
+
+### Returns
+TRUE if the geometries intersect, otherwise FALSE.
+"""
 function OGR_G_Intersects(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Intersects,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Equals(OGRGeometryH,
+                 OGRGeometryH) -> int
+
+Returns TRUE if two geometries are equivalent.
+
+### Parameters
+* **hGeom**: handle on the first geometry.
+* **hOther**: handle on the other geometry to test against.
+
+### Returns
+TRUE if equivalent or FALSE otherwise.
+"""
 function OGR_G_Equals(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Equals,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Disjoint(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for disjointness.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are disjoint, otherwise FALSE.
+"""
 function OGR_G_Disjoint(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Disjoint,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Touches(OGRGeometryH,
+                  OGRGeometryH) -> int
+
+Test for touching.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are touching, otherwise FALSE.
+"""
 function OGR_G_Touches(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Touches,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Crosses(OGRGeometryH,
+                  OGRGeometryH) -> int
+
+Test for crossing.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are crossing, otherwise FALSE.
+"""
 function OGR_G_Crosses(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Crosses,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Within(OGRGeometryH,
+                 OGRGeometryH) -> int
+
+Test for containment.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if hThis is within hOther, otherwise FALSE.
+"""
 function OGR_G_Within(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Within,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Contains(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for containment.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if hThis contains hOther geometry, otherwise FALSE.
+"""
 function OGR_G_Contains(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Contains,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Overlaps(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for overlap.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are overlapping, otherwise FALSE.
+"""
 function OGR_G_Overlaps(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Overlaps,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Boundary(OGRGeometryH) -> OGRGeometryH
+
+Compute boundary.
+
+### Parameters
+* **hTarget**: The Geometry to calculate the boundary of.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function OGR_G_Boundary(arg1::OGRGeometryH)
     ccall((:OGR_G_Boundary,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ConvexHull(OGRGeometryH) -> OGRGeometryH
+
+Compute convex hull.
+
+### Parameters
+* **hTarget**: The Geometry to calculate the convex hull of.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function OGR_G_ConvexHull(arg1::OGRGeometryH)
     ccall((:OGR_G_ConvexHull,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Buffer(OGRGeometryH,
+                 double,
+                 int) -> OGRGeometryH
+
+Compute buffer of geometry.
+
+### Parameters
+* **hTarget**: the geometry.
+* **dfDist**: the buffer distance to be applied. Should be expressed into the same unit as the coordinates of the geometry.
+* **nQuadSegs**: the number of segments used to approximate a 90 degree (quadrant) of curvature.
+
+### Returns
+the newly created geometry, or NULL if an error occurs.
+"""
 function OGR_G_Buffer(arg1::OGRGeometryH,arg2::Cdouble,arg3::Cint)
     ccall((:OGR_G_Buffer,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_Intersection(OGRGeometryH,
+                       OGRGeometryH) -> OGRGeometryH
+
+Compute intersection.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the intersection or NULL if there is no intersection or an error occurs.
+"""
 function OGR_G_Intersection(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Intersection,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Union(OGRGeometryH,
+                OGRGeometryH) -> OGRGeometryH
+
+Compute union.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the union or NULL if an error occurs.
+"""
 function OGR_G_Union(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Union,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_UnionCascaded(OGRGeometryH) -> OGRGeometryH
+
+Compute union using cascading.
+
+### Parameters
+* **hThis**: the geometry.
+
+### Returns
+a new geometry representing the union or NULL if an error occurs.
+"""
 function OGR_G_UnionCascaded(arg1::OGRGeometryH)
     ccall((:OGR_G_UnionCascaded,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_PointOnSurface(OGRGeometryH) -> OGRGeometryH
+
+Returns a point guaranteed to lie on the surface.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+a point guaranteed to lie on the surface or NULL if an error occured.
+"""
 function OGR_G_PointOnSurface(arg1::OGRGeometryH)
     ccall((:OGR_G_PointOnSurface,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Difference(OGRGeometryH,
+                     OGRGeometryH) -> OGRGeometryH
+
+Compute difference.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the difference or NULL if the difference is empty or an error occurs.
+"""
 function OGR_G_Difference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Difference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_SymDifference(OGRGeometryH,
+                        OGRGeometryH) -> OGRGeometryH
+
+Compute symmetric difference.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the symmetric difference or NULL if the difference is empty or an error occurs.
+"""
 function OGR_G_SymDifference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_SymDifference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Distance(OGRGeometryH,
+                   OGRGeometryH) -> double
+
+Compute distance between two geometries.
+
+### Parameters
+* **hFirst**: the first geometry to compare against.
+* **hOther**: the other geometry to compare against.
+
+### Returns
+the distance between the geometries or -1 if an error occurs.
+"""
 function OGR_G_Distance(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Distance,libgdal),Cdouble,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Length(OGRGeometryH hGeom) -> double
+
+Compute length of a geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+the lenght or 0.0 for unsupported geometry types.
+"""
 function OGR_G_Length(arg1::OGRGeometryH)
     ccall((:OGR_G_Length,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Area(OGRGeometryH hGeom) -> double
+
+Compute geometry area.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+the area or 0.0 for unsupported geometry types.
+"""
 function OGR_G_Area(arg1::OGRGeometryH)
     ccall((:OGR_G_Area,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Centroid(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Compute the geometry centroid.
+
+### Returns
+OGRERR_NONE on success or OGRERR_FAILURE on error.
+"""
 function OGR_G_Centroid(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Centroid,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Value(OGRGeometryH hGeom,
+                double dfDistance) -> OGRGeometryH
+
+Fetch point at given distance along curve.
+
+### Parameters
+* **hGeom**: curve geometry.
+* **dfDistance**: distance along the curve at which to sample position. This distance should be between zero and get_Length() for this curve.
+
+### Returns
+a point or NULL.
+"""
 function OGR_G_Value(arg1::OGRGeometryH,dfDistance::Cdouble)
     ccall((:OGR_G_Value,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),arg1,dfDistance)
 end
 
+
+"""
+    OGR_G_Empty(OGRGeometryH) -> void
+
+Clear geometry information.
+
+### Parameters
+* **hGeom**: handle on the geometry to empty.
+"""
 function OGR_G_Empty(arg1::OGRGeometryH)
     ccall((:OGR_G_Empty,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsEmpty(OGRGeometryH) -> int
+
+Test if the geometry is empty.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function OGR_G_IsEmpty(arg1::OGRGeometryH)
     ccall((:OGR_G_IsEmpty,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsValid(OGRGeometryH) -> int
+
+Test if the geometry is valid.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function OGR_G_IsValid(arg1::OGRGeometryH)
     ccall((:OGR_G_IsValid,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsSimple(OGRGeometryH) -> int
+
+Returns TRUE if the geometry is simple.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if object is simple, otherwise FALSE.
+"""
 function OGR_G_IsSimple(arg1::OGRGeometryH)
     ccall((:OGR_G_IsSimple,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsRing(OGRGeometryH) -> int
+
+Test if the geometry is a ring.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function OGR_G_IsRing(arg1::OGRGeometryH)
     ccall((:OGR_G_IsRing,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Polygonize(OGRGeometryH) -> OGRGeometryH
+
+Polygonizes a set of sparse edges.
+
+### Parameters
+* **hTarget**: The Geometry to be polygonized.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function OGR_G_Polygonize(arg1::OGRGeometryH)
     ccall((:OGR_G_Polygonize,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Intersect(OGRGeometryH,
+                    OGRGeometryH) -> int
+"""
 function OGR_G_Intersect(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Intersect,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Equal(OGRGeometryH,
+                OGRGeometryH) -> int
+"""
 function OGR_G_Equal(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Equal,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_SymmetricDifference(OGRGeometryH,
+                              OGRGeometryH) -> OGRGeometryH
+
+Compute symmetric difference (deprecated)
+"""
 function OGR_G_SymmetricDifference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_SymmetricDifference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetArea(OGRGeometryH hGeom) -> double
+
+Compute geometry area (deprecated)
+"""
 function OGR_G_GetArea(arg1::OGRGeometryH)
     ccall((:OGR_G_GetArea,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetBoundary(OGRGeometryH) -> OGRGeometryH
+
+Compute boundary (deprecated)
+"""
 function OGR_G_GetBoundary(arg1::OGRGeometryH)
     ccall((:OGR_G_GetBoundary,libgdal),OGRGeometryH,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetPointCount(OGRGeometryH hGeom) -> int
+
+Fetch number of points from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the number of points.
+
+### Returns
+the number of points.
+"""
 function OGR_G_GetPointCount(arg1::OGRGeometryH)
     ccall((:OGR_G_GetPointCount,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetPoints(OGRGeometryH hGeom,
+                    void * pabyX,
+                    int nXStride,
+                    void * pabyY,
+                    int nYStride,
+                    void * pabyZ,
+                    int nZStride) -> int
+
+Returns all points of line string.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **pabyX**: a buffer of at least (sizeof(double) * nXStride * nPointCount) bytes, may be NULL.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: a buffer of at least (sizeof(double) * nYStride * nPointCount) bytes, may be NULL.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: a buffer of at last size (sizeof(double) * nZStride * nPointCount) bytes, may be NULL.
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+
+### Returns
+the number of points
+"""
 function OGR_G_GetPoints(hGeom::OGRGeometryH,pabyX::Ptr{Void},nXStride::Cint,pabyY::Ptr{Void},nYStride::Cint,pabyZ::Ptr{Void},nZStride::Cint)
     ccall((:OGR_G_GetPoints,libgdal),Cint,(OGRGeometryH,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
 end
 
+
+"""
+    OGR_G_GetX(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the x coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the x coordinate.
+* **i**: point to get the x coordinate.
+
+### Returns
+the X coordinate of this point.
+"""
 function OGR_G_GetX(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_GetX,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetY(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the x coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the y coordinate.
+* **i**: point to get the Y coordinate.
+
+### Returns
+the Y coordinate of this point.
+"""
 function OGR_G_GetY(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_GetY,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetZ(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the z coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the Z coordinate.
+* **i**: point to get the Z coordinate.
+
+### Returns
+the Z coordinate of this point.
+"""
 function OGR_G_GetZ(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_GetZ,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetPoint(OGRGeometryH hGeom,
+                   int i,
+                   double * pdfX,
+                   double * pdfY,
+                   double * pdfZ) -> void
+
+Fetch a point in line string or a point geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **i**: the vertex to fetch, from 0 to getNumPoints()-1, zero for a point.
+* **pdfX**: value of x coordinate.
+* **pdfY**: value of y coordinate.
+* **pdfZ**: value of z coordinate.
+"""
 function OGR_G_GetPoint(arg1::OGRGeometryH,iPoint::Cint,arg2::Ptr{Cdouble},arg3::Ptr{Cdouble},arg4::Ptr{Cdouble})
     ccall((:OGR_G_GetPoint,libgdal),Void,(OGRGeometryH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_SetPointCount(OGRGeometryH hGeom,
+                        int nNewPointCount) -> void
+
+Set number of points in a geometry.
+
+### Parameters
+* **nNewPointCount**: the new number of points for geometry.
+"""
 function OGR_G_SetPointCount(hGeom::OGRGeometryH,nNewPointCount::Cint)
     ccall((:OGR_G_SetPointCount,libgdal),Void,(OGRGeometryH,Cint),hGeom,nNewPointCount)
 end
 
+
+"""
+    OGR_G_SetPoint(OGRGeometryH hGeom,
+                   int i,
+                   double dfX,
+                   double dfY,
+                   double dfZ) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfZ**: input Z coordinate to assign (defaults to zero).
+"""
 function OGR_G_SetPoint(arg1::OGRGeometryH,iPoint::Cint,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble)
     ccall((:OGR_G_SetPoint,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_SetPoint_2D(OGRGeometryH hGeom,
+                      int i,
+                      double dfX,
+                      double dfY) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+"""
 function OGR_G_SetPoint_2D(arg1::OGRGeometryH,iPoint::Cint,arg2::Cdouble,arg3::Cdouble)
     ccall((:OGR_G_SetPoint_2D,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble),arg1,iPoint,arg2,arg3)
 end
 
+
+"""
+    OGR_G_AddPoint(OGRGeometryH hGeom,
+                   double dfX,
+                   double dfY,
+                   double dfZ) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfZ**: z coordinate of point to add.
+"""
 function OGR_G_AddPoint(arg1::OGRGeometryH,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble)
     ccall((:OGR_G_AddPoint,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_AddPoint_2D(OGRGeometryH hGeom,
+                      double dfX,
+                      double dfY) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+"""
 function OGR_G_AddPoint_2D(arg1::OGRGeometryH,arg2::Cdouble,arg3::Cdouble)
     ccall((:OGR_G_AddPoint_2D,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_SetPoints(OGRGeometryH hGeom,
+                    int nPointsIn,
+                    void * pabyX,
+                    int nXStride,
+                    void * pabyY,
+                    int nYStride,
+                    void * pabyZ,
+                    int nZStride) -> void
+
+Assign all points in a point or a line string geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to set the coordinates.
+* **nPointsIn**: number of points being passed in padfX and padfY.
+* **padfX**: list of X coordinates of points being assigned.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **padfY**: list of Y coordinates of points being assigned.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **padfZ**: list of Z coordinates of points being assigned (defaults to NULL for 2D objects).
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+"""
 function OGR_G_SetPoints(hGeom::OGRGeometryH,nPointsIn::Cint,pabyX::Ptr{Void},nXStride::Cint,pabyY::Ptr{Void},nYStride::Cint,pabyZ::Ptr{Void},nZStride::Cint)
     ccall((:OGR_G_SetPoints,libgdal),Void,(OGRGeometryH,Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
 end
 
+
+"""
+    OGR_G_GetGeometryCount(OGRGeometryH hGeom) -> int
+
+Fetch the number of elements in a geometry or number of geometries in container.
+
+### Parameters
+* **hGeom**: single geometry or geometry container from which to get the number of elements.
+
+### Returns
+the number of elements.
+"""
 function OGR_G_GetGeometryCount(arg1::OGRGeometryH)
     ccall((:OGR_G_GetGeometryCount,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetGeometryRef(OGRGeometryH hGeom,
+                         int iSubGeom) -> OGRGeometryH
+
+Fetch geometry from a geometry container.
+
+### Parameters
+* **hGeom**: handle to the geometry container from which to get a geometry from.
+* **iSubGeom**: the index of the geometry to fetch, between 0 and getNumGeometries() - 1.
+
+### Returns
+handle to the requested geometry.
+"""
 function OGR_G_GetGeometryRef(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_GetGeometryRef,libgdal),OGRGeometryH,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_AddGeometry(OGRGeometryH hGeom,
+                      OGRGeometryH hNewSubGeom) -> OGRErr
+
+Add a geometry to a geometry container.
+
+### Parameters
+* **hGeom**: existing geometry container.
+* **hNewSubGeom**: geometry to add to the container.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of existing geometry.
+"""
 function OGR_G_AddGeometry(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_AddGeometry,libgdal),OGRErr,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_AddGeometryDirectly(OGRGeometryH hGeom,
+                              OGRGeometryH hNewSubGeom) -> OGRErr
+
+Add a geometry directly to an existing geometry container.
+
+### Parameters
+* **hGeom**: existing geometry.
+* **hNewSubGeom**: geometry to add to the existing geometry.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of geometry container.
+"""
 function OGR_G_AddGeometryDirectly(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_AddGeometryDirectly,libgdal),OGRErr,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_RemoveGeometry(OGRGeometryH hGeom,
+                         int iGeom,
+                         int bDelete) -> OGRErr
+
+Remove a geometry from an exiting geometry container.
+
+### Parameters
+* **hGeom**: the existing geometry to delete from.
+* **iGeom**: the index of the geometry to delete. A value of -1 is a special flag meaning that all geometries should be removed.
+* **bDelete**: if TRUE the geometry will be destroyed, otherwise it will not. The default is TRUE as the existing geometry is considered to own the geometries in it.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_FAILURE if the index is out of range.
+"""
 function OGR_G_RemoveGeometry(arg1::OGRGeometryH,arg2::Cint,arg3::Cint)
     ccall((:OGR_G_RemoveGeometry,libgdal),OGRErr,(OGRGeometryH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_HasCurveGeometry(OGRGeometryH hGeom,
+                           int bLookForNonLinear) -> int
+
+Returns if this geometry is or has curve geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **bLookForNonLinear**: set it to TRUE to check if the geometry is or contains a CIRCULARSTRING.
+
+### Returns
+TRUE if this geometry is or has curve geometry.
+"""
 function OGR_G_HasCurveGeometry(arg1::OGRGeometryH,bLookForNonLinear::Cint)
     ccall((:OGR_G_HasCurveGeometry,libgdal),Cint,(OGRGeometryH,Cint),arg1,bLookForNonLinear)
 end
 
+
+"""
+    OGR_G_GetLinearGeometry(OGRGeometryH hGeom,
+                            double dfMaxAngleStepSizeDegrees,
+                            char ** papszOptions) -> OGRGeometryH
+
+Return, possibly approximate, linear version of this geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **dfMaxAngleStepSizeDegrees**: the largest step in degrees along the arc, zero to use the default setting.
+* **papszOptions**: options as a null-terminated list of strings or NULL. See OGRGeometryFactory::curveToLineString() for valid options.
+
+### Returns
+a new geometry.
+"""
 function OGR_G_GetLinearGeometry(hGeom::OGRGeometryH,dfMaxAngleStepSizeDegrees::Cdouble,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_GetLinearGeometry,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble,Ptr{Ptr{UInt8}}),hGeom,dfMaxAngleStepSizeDegrees,papszOptions)
 end
 
+
+"""
+    OGR_G_GetCurveGeometry(OGRGeometryH hGeom,
+                           char ** papszOptions) -> OGRGeometryH
+
+Return curve version of this geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **papszOptions**: options as a null-terminated list of strings. Unused for now. Must be set to NULL.
+
+### Returns
+a new geometry.
+"""
 function OGR_G_GetCurveGeometry(hGeom::OGRGeometryH,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_G_GetCurveGeometry,libgdal),OGRGeometryH,(OGRGeometryH,Ptr{Ptr{UInt8}}),hGeom,papszOptions)
 end
 
+
+"""
+    OGRBuildPolygonFromEdges(OGRGeometryH hLinesAsCollection,
+                             int bBestEffort,
+                             int bAutoClose,
+                             double dfTolerance,
+                             OGRErr * peErr) -> OGRGeometryH
+
+Build a ring from a bunch of arcs.
+
+### Parameters
+* **hLines**: handle to an OGRGeometryCollection (or OGRMultiLineString) containing the line string geometries to be built into rings.
+* **bBestEffort**: not yet implemented???.
+* **bAutoClose**: indicates if the ring should be close when first and last points of the ring are the same.
+* **dfTolerance**: tolerance into which two arcs are considered close enough to be joined.
+* **peErr**: OGRERR_NONE on success, or OGRERR_FAILURE on failure.
+
+### Returns
+an handle to the new geometry, a polygon.
+"""
 function OGRBuildPolygonFromEdges(hLinesAsCollection::OGRGeometryH,bBestEffort::Cint,bAutoClose::Cint,dfTolerance::Cdouble,peErr::Ptr{OGRErr})
     ccall((:OGRBuildPolygonFromEdges,libgdal),OGRGeometryH,(OGRGeometryH,Cint,Cint,Cdouble,Ptr{OGRErr}),hLinesAsCollection,bBestEffort,bAutoClose,dfTolerance,peErr)
 end
 
+
+"""
+    OGRSetGenerate_DB2_V72_BYTE_ORDER(int bGenerate_DB2_V72_BYTE_ORDER) -> OGRErr
+
+Special entry point to enable the hack for generating DB2 V7.2 style WKB.
+"""
 function OGRSetGenerate_DB2_V72_BYTE_ORDER(bGenerate_DB2_V72_BYTE_ORDER::Cint)
     ccall((:OGRSetGenerate_DB2_V72_BYTE_ORDER,libgdal),OGRErr,(Cint,),bGenerate_DB2_V72_BYTE_ORDER)
 end
 
+
+"""
+    OGRGetGenerate_DB2_V72_BYTE_ORDER(void) -> int
+"""
 function OGRGetGenerate_DB2_V72_BYTE_ORDER()
     ccall((:OGRGetGenerate_DB2_V72_BYTE_ORDER,libgdal),Cint,())
 end
 
+
+"""
+    OGRSetNonLinearGeometriesEnabledFlag(int bFlag) -> void
+
+Set flag to enable/disable returning non-linear geometries in the C API.
+
+### Parameters
+* **bFlag**: TRUE if non-linear geometries might be returned (default value). FALSE to ask for non-linear geometries to be approximated as linear geometries.
+
+### Returns
+a point or NULL.
+"""
 function OGRSetNonLinearGeometriesEnabledFlag(bFlag::Cint)
     ccall((:OGRSetNonLinearGeometriesEnabledFlag,libgdal),Void,(Cint,),bFlag)
 end
 
+
+"""
+    OGRGetNonLinearGeometriesEnabledFlag(void) -> int
+
+Get flag to enable/disable returning non-linear geometries in the C API.
+"""
 function OGRGetNonLinearGeometriesEnabledFlag()
     ccall((:OGRGetNonLinearGeometriesEnabledFlag,libgdal),Cint,())
 end
 
+
+"""
+    OGR_Fld_Create(const char *,
+                   OGRFieldType) -> OGRFieldDefnH
+
+Create a new field definition.
+
+### Parameters
+* **pszName**: the name of the new field definition.
+* **eType**: the type of the new field definition.
+
+### Returns
+handle to the new field definition.
+"""
 function OGR_Fld_Create(arg1::Ptr{UInt8},arg2::OGRFieldType)
     ccall((:OGR_Fld_Create,libgdal),OGRFieldDefnH,(Ptr{UInt8},OGRFieldType),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_Destroy(OGRFieldDefnH) -> void
+
+Destroy a field definition.
+
+### Parameters
+* **hDefn**: handle to the field definition to destroy.
+"""
 function OGR_Fld_Destroy(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_Destroy,libgdal),Void,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetName(OGRFieldDefnH,
+                    const char *) -> void
+
+Reset the name of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to apply the new name to.
+* **pszName**: the new name to apply.
+"""
 function OGR_Fld_SetName(arg1::OGRFieldDefnH,arg2::Ptr{UInt8})
     ccall((:OGR_Fld_SetName,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetNameRef(OGRFieldDefnH) -> const char *
+
+Fetch name of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+
+### Returns
+the name of the field definition.
+"""
 function OGR_Fld_GetNameRef(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetNameRef,libgdal),Ptr{UInt8},(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_GetType(OGRFieldDefnH) -> OGRFieldType
+
+Fetch type of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get type from.
+
+### Returns
+field type.
+"""
 function OGR_Fld_GetType(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetType,libgdal),OGRFieldType,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetType(OGRFieldDefnH,
+                    OGRFieldType) -> void
+
+Set the type of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set type to.
+* **eType**: the new field type.
+"""
 function OGR_Fld_SetType(arg1::OGRFieldDefnH,arg2::OGRFieldType)
     ccall((:OGR_Fld_SetType,libgdal),Void,(OGRFieldDefnH,OGRFieldType),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetSubType(OGRFieldDefnH) -> OGRFieldSubType
+
+Fetch subtype of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get subtype from.
+
+### Returns
+field subtype.
+"""
 function OGR_Fld_GetSubType(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetSubType,libgdal),OGRFieldSubType,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetSubType(OGRFieldDefnH,
+                       OGRFieldSubType) -> void
+
+Set the subtype of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set type to.
+* **eSubType**: the new field subtype.
+"""
 function OGR_Fld_SetSubType(arg1::OGRFieldDefnH,arg2::OGRFieldSubType)
     ccall((:OGR_Fld_SetSubType,libgdal),Void,(OGRFieldDefnH,OGRFieldSubType),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetJustify(OGRFieldDefnH) -> OGRJustification
+
+Get the justification for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get justification from.
+
+### Returns
+the justification.
+"""
 function OGR_Fld_GetJustify(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetJustify,libgdal),OGRJustification,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetJustify(OGRFieldDefnH,
+                       OGRJustification) -> void
+
+Set the justification for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set justification to.
+* **eJustify**: the new justification.
+"""
 function OGR_Fld_SetJustify(arg1::OGRFieldDefnH,arg2::OGRJustification)
     ccall((:OGR_Fld_SetJustify,libgdal),Void,(OGRFieldDefnH,OGRJustification),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetWidth(OGRFieldDefnH) -> int
+
+Get the formatting width for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get width from.
+
+### Returns
+the width, zero means no specified width.
+"""
 function OGR_Fld_GetWidth(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetWidth,libgdal),Cint,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetWidth(OGRFieldDefnH,
+                     int) -> void
+
+Set the formatting width for this field in characters.
+
+### Parameters
+* **hDefn**: handle to the field definition to set width to.
+* **nNewWidth**: the new width.
+"""
 function OGR_Fld_SetWidth(arg1::OGRFieldDefnH,arg2::Cint)
     ccall((:OGR_Fld_SetWidth,libgdal),Void,(OGRFieldDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetPrecision(OGRFieldDefnH) -> int
+
+Get the formatting precision for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get precision from.
+
+### Returns
+the precision.
+"""
 function OGR_Fld_GetPrecision(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetPrecision,libgdal),Cint,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetPrecision(OGRFieldDefnH,
+                         int) -> void
+
+Set the formatting precision for this field in characters.
+
+### Parameters
+* **hDefn**: handle to the field definition to set precision to.
+* **nPrecision**: the new precision.
+"""
 function OGR_Fld_SetPrecision(arg1::OGRFieldDefnH,arg2::Cint)
     ccall((:OGR_Fld_SetPrecision,libgdal),Void,(OGRFieldDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_Set(OGRFieldDefnH,
+                const char *,
+                OGRFieldType,
+                int,
+                int,
+                OGRJustification) -> void
+
+Set defining parameters for a field in one call.
+
+### Parameters
+* **hDefn**: handle to the field definition to set to.
+* **pszNameIn**: the new name to assign.
+* **eTypeIn**: the new type (one of the OFT values like OFTInteger).
+* **nWidthIn**: the preferred formatting width. Defaults to zero indicating undefined.
+* **nPrecisionIn**: number of decimals places for formatting, defaults to zero indicating undefined.
+* **eJustifyIn**: the formatting justification (OJLeft or OJRight), defaults to OJUndefined.
+"""
 function OGR_Fld_Set(arg1::OGRFieldDefnH,arg2::Ptr{UInt8},arg3::OGRFieldType,arg4::Cint,arg5::Cint,arg6::OGRJustification)
     ccall((:OGR_Fld_Set,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8},OGRFieldType,Cint,Cint,OGRJustification),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_Fld_IsIgnored(OGRFieldDefnH hDefn) -> int
+
+Return whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+ignore state
+"""
 function OGR_Fld_IsIgnored(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsIgnored,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_Fld_SetIgnored(OGRFieldDefnH hDefn,
+                       int) -> void
+
+Set whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **ignore**: ignore state
+"""
 function OGR_Fld_SetIgnored(hDefn::OGRFieldDefnH,arg1::Cint)
     ccall((:OGR_Fld_SetIgnored,libgdal),Void,(OGRFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_IsNullable(OGRFieldDefnH hDefn) -> int
+
+Return whether this field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the field is authorized to be null.
+"""
 function OGR_Fld_IsNullable(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsNullable,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_Fld_SetNullable(OGRFieldDefnH hDefn,
+                        int) -> void
+
+Set whether this field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **bNullableIn**: FALSE if the field must have a not-null constraint.
+"""
 function OGR_Fld_SetNullable(hDefn::OGRFieldDefnH,arg1::Cint)
     ccall((:OGR_Fld_SetNullable,libgdal),Void,(OGRFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_GetDefault(OGRFieldDefnH hDefn) -> const char *
+
+Get default field value.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+
+### Returns
+default field value or NULL.
+"""
 function OGR_Fld_GetDefault(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_GetDefault,libgdal),Ptr{UInt8},(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_Fld_SetDefault(OGRFieldDefnH hDefn,
+                       const char *) -> void
+
+Set default field value.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+* **pszDefault**: new default field value or NULL pointer.
+"""
 function OGR_Fld_SetDefault(hDefn::OGRFieldDefnH,arg1::Ptr{UInt8})
     ccall((:OGR_Fld_SetDefault,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8}),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_IsDefaultDriverSpecific(OGRFieldDefnH hDefn) -> int
+
+Returns whether the default value is driver specific.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the default value is driver specific.
+"""
 function OGR_Fld_IsDefaultDriverSpecific(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsDefaultDriverSpecific,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GetFieldTypeName(OGRFieldType) -> const char *
+
+Fetch human readable name for a field type.
+
+### Parameters
+* **eType**: the field type to get name for.
+
+### Returns
+the name.
+"""
 function OGR_GetFieldTypeName(arg1::OGRFieldType)
     ccall((:OGR_GetFieldTypeName,libgdal),Ptr{UInt8},(OGRFieldType,),arg1)
 end
 
+
+"""
+    OGR_GetFieldSubTypeName(OGRFieldSubType) -> const char *
+
+Fetch human readable name for a field subtype.
+
+### Parameters
+* **eSubType**: the field subtype to get name for.
+
+### Returns
+the name.
+"""
 function OGR_GetFieldSubTypeName(arg1::OGRFieldSubType)
     ccall((:OGR_GetFieldSubTypeName,libgdal),Ptr{UInt8},(OGRFieldSubType,),arg1)
 end
 
+
+"""
+    OGR_AreTypeSubTypeCompatible(OGRFieldType eType,
+                                 OGRFieldSubType eSubType) -> int
+
+Return if type and subtype are compatible.
+
+### Parameters
+* **eType**: the field type.
+* **eSubType**: the field subtype.
+
+### Returns
+TRUE if type and subtype are compatible
+"""
 function OGR_AreTypeSubTypeCompatible(eType::OGRFieldType,eSubType::OGRFieldSubType)
     ccall((:OGR_AreTypeSubTypeCompatible,libgdal),Cint,(OGRFieldType,OGRFieldSubType),eType,eSubType)
 end
 
+
+"""
+    OGR_GFld_Create(const char *,
+                    OGRwkbGeometryType) -> OGRGeomFieldDefnH
+
+Create a new field geometry definition.
+
+### Parameters
+* **pszName**: the name of the new field definition.
+* **eType**: the type of the new field definition.
+
+### Returns
+handle to the new field definition.
+"""
 function OGR_GFld_Create(arg1::Ptr{UInt8},arg2::OGRwkbGeometryType)
     ccall((:OGR_GFld_Create,libgdal),OGRGeomFieldDefnH,(Ptr{UInt8},OGRwkbGeometryType),arg1,arg2)
 end
 
+
+"""
+    OGR_GFld_Destroy(OGRGeomFieldDefnH) -> void
+
+Destroy a geometry field definition.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to destroy.
+"""
 function OGR_GFld_Destroy(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_Destroy,libgdal),Void,(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_SetName(OGRGeomFieldDefnH,
+                     const char *) -> void
+
+Reset the name of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to apply the new name to.
+* **pszName**: the new name to apply.
+"""
 function OGR_GFld_SetName(arg1::OGRGeomFieldDefnH,arg2::Ptr{UInt8})
     ccall((:OGR_GFld_SetName,libgdal),Void,(OGRGeomFieldDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_GFld_GetNameRef(OGRGeomFieldDefnH) -> const char *
+
+Fetch name of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition.
+
+### Returns
+the name of the geometry field definition.
+"""
 function OGR_GFld_GetNameRef(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_GetNameRef,libgdal),Ptr{UInt8},(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_GetType(OGRGeomFieldDefnH) -> OGRwkbGeometryType
+
+Fetch geometry type of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to get type from.
+
+### Returns
+field geometry type.
+"""
 function OGR_GFld_GetType(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_GetType,libgdal),OGRwkbGeometryType,(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_SetType(OGRGeomFieldDefnH,
+                     OGRwkbGeometryType) -> void
+
+Set the geometry type of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to set type to.
+* **eType**: the new field geometry type.
+"""
 function OGR_GFld_SetType(arg1::OGRGeomFieldDefnH,arg2::OGRwkbGeometryType)
     ccall((:OGR_GFld_SetType,libgdal),Void,(OGRGeomFieldDefnH,OGRwkbGeometryType),arg1,arg2)
 end
 
+
+"""
+    OGR_GFld_GetSpatialRef(OGRGeomFieldDefnH) -> OGRSpatialReferenceH
+
+Fetch spatial reference system of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+
+### Returns
+field spatial reference system.
+"""
 function OGR_GFld_GetSpatialRef(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_GetSpatialRef,libgdal),OGRSpatialReferenceH,(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_SetSpatialRef(OGRGeomFieldDefnH,
+                           OGRSpatialReferenceH hSRS) -> void
+
+Set the spatial reference of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+* **hSRS**: the new SRS to apply.
+"""
 function OGR_GFld_SetSpatialRef(arg1::OGRGeomFieldDefnH,hSRS::OGRSpatialReferenceH)
     ccall((:OGR_GFld_SetSpatialRef,libgdal),Void,(OGRGeomFieldDefnH,OGRSpatialReferenceH),arg1,hSRS)
 end
 
+
+"""
+    OGR_GFld_IsNullable(OGRGeomFieldDefnH hDefn) -> int
+
+Return whether this geometry field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the field is authorized to be null.
+"""
 function OGR_GFld_IsNullable(hDefn::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_IsNullable,libgdal),Cint,(OGRGeomFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GFld_SetNullable(OGRGeomFieldDefnH hDefn,
+                         int) -> void
+
+Set whether this geometry field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **bNullableIn**: FALSE if the field must have a not-null constraint.
+"""
 function OGR_GFld_SetNullable(hDefn::OGRGeomFieldDefnH,arg1::Cint)
     ccall((:OGR_GFld_SetNullable,libgdal),Void,(OGRGeomFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_GFld_IsIgnored(OGRGeomFieldDefnH hDefn) -> int
+
+Return whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+
+### Returns
+ignore state
+"""
 function OGR_GFld_IsIgnored(hDefn::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_IsIgnored,libgdal),Cint,(OGRGeomFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GFld_SetIgnored(OGRGeomFieldDefnH hDefn,
+                        int) -> void
+
+Set whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+* **ignore**: ignore state
+"""
 function OGR_GFld_SetIgnored(hDefn::OGRGeomFieldDefnH,arg1::Cint)
     ccall((:OGR_GFld_SetIgnored,libgdal),Void,(OGRGeomFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_FD_Create(const char *) -> OGRFeatureDefnH
+
+Create a new feature definition object to hold the field definitions.
+
+### Parameters
+* **pszName**: the name to be assigned to this layer/class. It does not need to be unique.
+
+### Returns
+handle to the newly created feature definition.
+"""
 function OGR_FD_Create(arg1::Ptr{UInt8})
     ccall((:OGR_FD_Create,libgdal),OGRFeatureDefnH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OGR_FD_Destroy(OGRFeatureDefnH) -> void
+
+Destroy a feature definition object and release all memory associated with it.
+
+### Parameters
+* **hDefn**: handle to the feature definition to be destroyed.
+"""
 function OGR_FD_Destroy(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Destroy,libgdal),Void,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_Release(OGRFeatureDefnH) -> void
+
+Drop a reference, and destroy if unreferenced.
+
+### Parameters
+* **hDefn**: handle to the feature definition to be released.
+"""
 function OGR_FD_Release(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Release,libgdal),Void,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetName(OGRFeatureDefnH) -> const char *
+
+Get name of the OGRFeatureDefn passed as an argument.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the name from.
+
+### Returns
+the name. This name is internal and should not be modified, or freed.
+"""
 function OGR_FD_GetName(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetName,libgdal),Ptr{UInt8},(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetFieldCount(OGRFeatureDefnH) -> int
+
+Fetch number of fields on the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the fields count from.
+
+### Returns
+count of fields.
+"""
 function OGR_FD_GetFieldCount(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetFieldCount,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetFieldDefn(OGRFeatureDefnH,
+                        int) -> OGRFieldDefnH
+
+Fetch field definition of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the field definition from.
+* **iField**: the field to fetch, between 0 and GetFieldCount()-1.
+
+### Returns
+an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
+"""
 function OGR_FD_GetFieldDefn(arg1::OGRFeatureDefnH,arg2::Cint)
     ccall((:OGR_FD_GetFieldDefn,libgdal),OGRFieldDefnH,(OGRFeatureDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_GetFieldIndex(OGRFeatureDefnH,
+                         const char *) -> int
+
+Find field by name.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get field index from.
+* **pszFieldName**: the field name to search for.
+
+### Returns
+the field index, or -1 if no match found.
+"""
 function OGR_FD_GetFieldIndex(arg1::OGRFeatureDefnH,arg2::Ptr{UInt8})
     ccall((:OGR_FD_GetFieldIndex,libgdal),Cint,(OGRFeatureDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_AddFieldDefn(OGRFeatureDefnH,
+                        OGRFieldDefnH) -> void
+
+Add a new field definition to the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to add the field definition to.
+* **hNewField**: handle to the new field definition.
+"""
 function OGR_FD_AddFieldDefn(arg1::OGRFeatureDefnH,arg2::OGRFieldDefnH)
     ccall((:OGR_FD_AddFieldDefn,libgdal),Void,(OGRFeatureDefnH,OGRFieldDefnH),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_DeleteFieldDefn(OGRFeatureDefnH hDefn,
+                           int iField) -> OGRErr
+
+Delete an existing field definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition.
+* **iField**: the index of the field defintion.
+
+### Returns
+OGRERR_NONE in case of success.
+"""
 function OGR_FD_DeleteFieldDefn(hDefn::OGRFeatureDefnH,iField::Cint)
     ccall((:OGR_FD_DeleteFieldDefn,libgdal),OGRErr,(OGRFeatureDefnH,Cint),hDefn,iField)
 end
 
+
+"""
+    OGR_FD_ReorderFieldDefns(OGRFeatureDefnH hDefn,
+                             int * panMap) -> OGRErr
+"""
 function OGR_FD_ReorderFieldDefns(hDefn::OGRFeatureDefnH,panMap::Ptr{Cint})
     ccall((:OGR_FD_ReorderFieldDefns,libgdal),OGRErr,(OGRFeatureDefnH,Ptr{Cint}),hDefn,panMap)
 end
 
+
+"""
+    OGR_FD_GetGeomType(OGRFeatureDefnH) -> OGRwkbGeometryType
+
+Fetch the geometry base type of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the geometry type from.
+
+### Returns
+the base type for all geometry related to this definition.
+"""
 function OGR_FD_GetGeomType(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetGeomType,libgdal),OGRwkbGeometryType,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetGeomType(OGRFeatureDefnH,
+                       OGRwkbGeometryType) -> void
+
+Assign the base geometry type for the passed layer (the same as the feature definition).
+
+### Parameters
+* **hDefn**: handle to the layer or feature definition to set the geometry type to.
+* **eType**: the new type to assign.
+"""
 function OGR_FD_SetGeomType(arg1::OGRFeatureDefnH,arg2::OGRwkbGeometryType)
     ccall((:OGR_FD_SetGeomType,libgdal),Void,(OGRFeatureDefnH,OGRwkbGeometryType),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_IsGeometryIgnored(OGRFeatureDefnH) -> int
+
+Determine whether the geometry can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+ignore state
+"""
 function OGR_FD_IsGeometryIgnored(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_IsGeometryIgnored,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetGeometryIgnored(OGRFeatureDefnH,
+                              int) -> void
+
+Set whether the geometry can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **bIgnore**: ignore state
+"""
 function OGR_FD_SetGeometryIgnored(arg1::OGRFeatureDefnH,arg2::Cint)
     ccall((:OGR_FD_SetGeometryIgnored,libgdal),Void,(OGRFeatureDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_IsStyleIgnored(OGRFeatureDefnH) -> int
+
+Determine whether the style can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on which OGRFeature are based on.
+
+### Returns
+ignore state
+"""
 function OGR_FD_IsStyleIgnored(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_IsStyleIgnored,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetStyleIgnored(OGRFeatureDefnH,
+                           int) -> void
+
+Set whether the style can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **bIgnore**: ignore state
+"""
 function OGR_FD_SetStyleIgnored(arg1::OGRFeatureDefnH,arg2::Cint)
     ccall((:OGR_FD_SetStyleIgnored,libgdal),Void,(OGRFeatureDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_Reference(OGRFeatureDefnH) -> int
+
+Increments the reference count by one.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the updated reference count.
+"""
 function OGR_FD_Reference(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Reference,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_Dereference(OGRFeatureDefnH) -> int
+
+Decrements the reference count by one.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the updated reference count.
+"""
 function OGR_FD_Dereference(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Dereference,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetReferenceCount(OGRFeatureDefnH) -> int
+
+Fetch current reference count.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the current reference count.
+"""
 function OGR_FD_GetReferenceCount(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetReferenceCount,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetGeomFieldCount(OGRFeatureDefnH hFDefn) -> int
+
+Fetch number of geometry fields on the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the fields count from.
+
+### Returns
+count of geometry fields.
+"""
 function OGR_FD_GetGeomFieldCount(hFDefn::OGRFeatureDefnH)
     ccall((:OGR_FD_GetGeomFieldCount,libgdal),Cint,(OGRFeatureDefnH,),hFDefn)
 end
 
+
+"""
+    OGR_FD_GetGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                            int i) -> OGRGeomFieldDefnH
+
+Fetch geometry field definition of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the field definition from.
+* **iGeomField**: the geometry field to fetch, between 0 and GetGeomFieldCount()-1.
+
+### Returns
+an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
+"""
 function OGR_FD_GetGeomFieldDefn(hFDefn::OGRFeatureDefnH,i::Cint)
     ccall((:OGR_FD_GetGeomFieldDefn,libgdal),OGRGeomFieldDefnH,(OGRFeatureDefnH,Cint),hFDefn,i)
 end
 
+
+"""
+    OGR_FD_GetGeomFieldIndex(OGRFeatureDefnH hFDefn,
+                             const char * pszName) -> int
+
+Find geometry field by name.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get field index from.
+* **pszGeomFieldName**: the geometry field name to search for.
+
+### Returns
+the geometry field index, or -1 if no match found.
+"""
 function OGR_FD_GetGeomFieldIndex(hFDefn::OGRFeatureDefnH,pszName::Ptr{UInt8})
     ccall((:OGR_FD_GetGeomFieldIndex,libgdal),Cint,(OGRFeatureDefnH,Ptr{UInt8}),hFDefn,pszName)
 end
 
+
+"""
+    OGR_FD_AddGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                            OGRGeomFieldDefnH hGFldDefn) -> void
+
+Add a new field definition to the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to add the geometry field definition to.
+* **hNewGeomField**: handle to the new field definition.
+"""
 function OGR_FD_AddGeomFieldDefn(hFDefn::OGRFeatureDefnH,hGFldDefn::OGRGeomFieldDefnH)
     ccall((:OGR_FD_AddGeomFieldDefn,libgdal),Void,(OGRFeatureDefnH,OGRGeomFieldDefnH),hFDefn,hGFldDefn)
 end
 
+
+"""
+    OGR_FD_DeleteGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                               int iGeomField) -> OGRErr
+
+Delete an existing geometry field definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition.
+* **iGeomField**: the index of the geometry field defintion.
+
+### Returns
+OGRERR_NONE in case of success.
+"""
 function OGR_FD_DeleteGeomFieldDefn(hFDefn::OGRFeatureDefnH,iGeomField::Cint)
     ccall((:OGR_FD_DeleteGeomFieldDefn,libgdal),OGRErr,(OGRFeatureDefnH,Cint),hFDefn,iGeomField)
 end
 
+
+"""
+    OGR_FD_IsSame(OGRFeatureDefnH hFDefn,
+                  OGRFeatureDefnH hOtherFDefn) -> int
+
+Test if the feature definition is identical to the other one.
+
+### Parameters
+* **hFDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **hOtherFDefn**: handle to the other feature definition to compare to.
+
+### Returns
+TRUE if the feature definition is identical to the other one.
+"""
 function OGR_FD_IsSame(hFDefn::OGRFeatureDefnH,hOtherFDefn::OGRFeatureDefnH)
     ccall((:OGR_FD_IsSame,libgdal),Cint,(OGRFeatureDefnH,OGRFeatureDefnH),hFDefn,hOtherFDefn)
 end
 
+
+"""
+    OGR_F_Create(OGRFeatureDefnH) -> OGRFeatureH
+
+Feature factory.
+
+### Parameters
+* **hDefn**: handle to the feature class (layer) definition to which the feature will adhere.
+
+### Returns
+an handle to the new feature object with null fields and no geometry.
+"""
 function OGR_F_Create(arg1::OGRFeatureDefnH)
     ccall((:OGR_F_Create,libgdal),OGRFeatureH,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_F_Destroy(OGRFeatureH) -> void
+
+Destroy feature.
+
+### Parameters
+* **hFeat**: handle to the feature to destroy.
+"""
 function OGR_F_Destroy(arg1::OGRFeatureH)
     ccall((:OGR_F_Destroy,libgdal),Void,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_GetDefnRef(OGRFeatureH) -> OGRFeatureDefnH
+
+Fetch feature definition.
+
+### Parameters
+* **hFeat**: handle to the feature to get the feature definition from.
+
+### Returns
+an handle to the feature definition object on which feature depends.
+"""
 function OGR_F_GetDefnRef(arg1::OGRFeatureH)
     ccall((:OGR_F_GetDefnRef,libgdal),OGRFeatureDefnH,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_SetGeometryDirectly(OGRFeatureH,
+                              OGRGeometryH) -> OGRErr
+
+Set feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature on which to apply the geometry.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function OGR_F_SetGeometryDirectly(arg1::OGRFeatureH,arg2::OGRGeometryH)
     ccall((:OGR_F_SetGeometryDirectly,libgdal),OGRErr,(OGRFeatureH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetGeometry(OGRFeatureH,
+                      OGRGeometryH) -> OGRErr
+
+Set feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature on which new geometry is applied to.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function OGR_F_SetGeometry(arg1::OGRFeatureH,arg2::OGRGeometryH)
     ccall((:OGR_F_SetGeometry,libgdal),OGRErr,(OGRFeatureH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetGeometryRef(OGRFeatureH) -> OGRGeometryH
+
+Fetch an handle to feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature to get geometry from.
+
+### Returns
+an handle to internal feature geometry. This object should not be modified.
+"""
 function OGR_F_GetGeometryRef(arg1::OGRFeatureH)
     ccall((:OGR_F_GetGeometryRef,libgdal),OGRGeometryH,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_StealGeometry(OGRFeatureH) -> OGRGeometryH
+
+Take away ownership of geometry.
+
+### Returns
+the pointer to the geometry.
+"""
 function OGR_F_StealGeometry(arg1::OGRFeatureH)
     ccall((:OGR_F_StealGeometry,libgdal),OGRGeometryH,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_Clone(OGRFeatureH) -> OGRFeatureH
+
+Duplicate feature.
+
+### Parameters
+* **hFeat**: handle to the feature to clone.
+
+### Returns
+an handle to the new feature, exactly matching this feature.
+"""
 function OGR_F_Clone(arg1::OGRFeatureH)
     ccall((:OGR_F_Clone,libgdal),OGRFeatureH,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_Equal(OGRFeatureH,
+                OGRFeatureH) -> int
+
+Test if two features are the same.
+
+### Parameters
+* **hFeat**: handle to one of the feature.
+* **hOtherFeat**: handle to the other feature to test this one against.
+
+### Returns
+TRUE if they are equal, otherwise FALSE.
+"""
 function OGR_F_Equal(arg1::OGRFeatureH,arg2::OGRFeatureH)
     ccall((:OGR_F_Equal,libgdal),Cint,(OGRFeatureH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldCount(OGRFeatureH) -> int
+
+Fetch number of fields on this feature This will always be the same as the field count for the OGRFeatureDefn.
+
+### Parameters
+* **hFeat**: handle to the feature to get the fields count from.
+
+### Returns
+count of fields.
+"""
 function OGR_F_GetFieldCount(arg1::OGRFeatureH)
     ccall((:OGR_F_GetFieldCount,libgdal),Cint,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_GetFieldDefnRef(OGRFeatureH,
+                          int) -> OGRFieldDefnH
+
+Fetch definition for this field.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **i**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
+"""
 function OGR_F_GetFieldDefnRef(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldDefnRef,libgdal),OGRFieldDefnH,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldIndex(OGRFeatureH,
+                        const char *) -> int
+
+Fetch the field index given field name.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **pszName**: the name of the field to search for.
+
+### Returns
+the field index, or -1 if no matching field is found.
+"""
 function OGR_F_GetFieldIndex(arg1::OGRFeatureH,arg2::Ptr{UInt8})
     ccall((:OGR_F_GetFieldIndex,libgdal),Cint,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_IsFieldSet(OGRFeatureH,
+                     int) -> int
+
+Test if a field has ever been assigned a value or not.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is.
+* **iField**: the field to test.
+
+### Returns
+TRUE if the field has been set, otherwise false.
+"""
 function OGR_F_IsFieldSet(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_IsFieldSet,libgdal),Cint,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_UnsetField(OGRFeatureH,
+                     int) -> void
+
+Clear a field, marking it as unset.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is.
+* **iField**: the field to unset.
+"""
 function OGR_F_UnsetField(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_UnsetField,libgdal),Void,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetRawFieldRef(OGRFeatureH,
+                         int) -> OGRField *
+
+Fetch an handle to the internal field value given the index.
+
+### Parameters
+* **hFeat**: handle to the feature on which field is found.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the returned handle is to an internal data structure, and should not be freed, or modified.
+"""
 function OGR_F_GetRawFieldRef(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetRawFieldRef,libgdal),Ptr{OGRField},(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger(OGRFeatureH,
+                            int) -> int
+
+Fetch field value as integer.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function OGR_F_GetFieldAsInteger(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldAsInteger,libgdal),Cint,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger64(OGRFeatureH,
+                              int) -> GIntBig
+
+Fetch field value as integer 64 bit.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function OGR_F_GetFieldAsInteger64(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldAsInteger64,libgdal),GIntBig,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsDouble(OGRFeatureH,
+                           int) -> double
+
+Fetch field value as a double.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function OGR_F_GetFieldAsDouble(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldAsDouble,libgdal),Cdouble,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsString(OGRFeatureH,
+                           int) -> const char *
+
+Fetch field value as a string.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value. This string is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function OGR_F_GetFieldAsString(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldAsString,libgdal),Ptr{UInt8},(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsIntegerList(OGRFeatureH,
+                                int,
+                                int *) -> const int *
+
+Fetch field value as a list of integers.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of integers) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function OGR_F_GetFieldAsIntegerList(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsIntegerList,libgdal),Ptr{Cint},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger64List(OGRFeatureH,
+                                  int,
+                                  int *) -> const GIntBig *
+
+Fetch field value as a list of 64 bit integers.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of integers) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function OGR_F_GetFieldAsInteger64List(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsInteger64List,libgdal),Ptr{GIntBig},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsDoubleList(OGRFeatureH,
+                               int,
+                               int *) -> const double *
+
+Fetch field value as a list of doubles.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of doubles) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function OGR_F_GetFieldAsDoubleList(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsDoubleList,libgdal),Ptr{Cdouble},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsStringList(OGRFeatureH,
+                               int) -> char **
+
+Fetch field value as a list of strings.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function OGR_F_GetFieldAsStringList(arg1::OGRFeatureH,arg2::Cint)
     ccall((:OGR_F_GetFieldAsStringList,libgdal),Ptr{Ptr{UInt8}},(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsBinary(OGRFeatureH,
+                           int,
+                           int *) -> GByte *
+
+Fetch field value as binary.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnBytes**: location to place count of bytes returned.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function OGR_F_GetFieldAsBinary(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsBinary,libgdal),Ptr{GByte},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsDateTime(OGRFeatureH,
+                             int,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *) -> int
+
+Fetch field value as date and time.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnYear**: (including century)
+* **pnMonth**: (1-12)
+* **pnDay**: (1-31)
+* **pnHour**: (0-23)
+* **pnMinute**: (0-59)
+* **pnSecond**: (0-59)
+* **pnTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function OGR_F_GetFieldAsDateTime(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Cint},arg4::Ptr{Cint},arg5::Ptr{Cint},arg6::Ptr{Cint},arg7::Ptr{Cint},arg8::Ptr{Cint},arg9::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsDateTime,libgdal),Cint,(OGRFeatureH,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_GetFieldAsDateTimeEx(OGRFeatureH hFeat,
+                               int iField,
+                               int * pnYear,
+                               int * pnMonth,
+                               int * pnDay,
+                               int * pnHour,
+                               int * pnMinute,
+                               float * pfSecond,
+                               int * pnTZFlag) -> int
+
+Fetch field value as date and time.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnYear**: (including century)
+* **pnMonth**: (1-12)
+* **pnDay**: (1-31)
+* **pnHour**: (0-23)
+* **pnMinute**: (0-59)
+* **pfSecond**: (0-59 with millisecond accuracy)
+* **pnTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function OGR_F_GetFieldAsDateTimeEx(hFeat::OGRFeatureH,iField::Cint,pnYear::Ptr{Cint},pnMonth::Ptr{Cint},pnDay::Ptr{Cint},pnHour::Ptr{Cint},pnMinute::Ptr{Cint},pfSecond::Ptr{Cfloat},pnTZFlag::Ptr{Cint})
     ccall((:OGR_F_GetFieldAsDateTimeEx,libgdal),Cint,(OGRFeatureH,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat},Ptr{Cint}),hFeat,iField,pnYear,pnMonth,pnDay,pnHour,pnMinute,pfSecond,pnTZFlag)
 end
 
+
+"""
+    OGR_F_SetFieldInteger(OGRFeatureH,
+                          int,
+                          int) -> void
+
+Set field to integer value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **nValue**: the value to assign.
+"""
 function OGR_F_SetFieldInteger(arg1::OGRFeatureH,arg2::Cint,arg3::Cint)
     ccall((:OGR_F_SetFieldInteger,libgdal),Void,(OGRFeatureH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldInteger64(OGRFeatureH,
+                            int,
+                            GIntBig) -> void
+
+Set field to 64 bit integer value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **nValue**: the value to assign.
+"""
 function OGR_F_SetFieldInteger64(arg1::OGRFeatureH,arg2::Cint,arg3::GIntBig)
     ccall((:OGR_F_SetFieldInteger64,libgdal),Void,(OGRFeatureH,Cint,GIntBig),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldDouble(OGRFeatureH,
+                         int,
+                         double) -> void
+
+Set field to double value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **dfValue**: the value to assign.
+"""
 function OGR_F_SetFieldDouble(arg1::OGRFeatureH,arg2::Cint,arg3::Cdouble)
     ccall((:OGR_F_SetFieldDouble,libgdal),Void,(OGRFeatureH,Cint,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldString(OGRFeatureH,
+                         int,
+                         const char *) -> void
+
+Set field to string value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pszValue**: the value to assign.
+"""
 function OGR_F_SetFieldString(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{UInt8})
     ccall((:OGR_F_SetFieldString,libgdal),Void,(OGRFeatureH,Cint,Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldIntegerList(OGRFeatureH,
+                              int,
+                              int,
+                              int *) -> void
+
+Set field to list of integers value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **panValues**: the values to assign.
+"""
 function OGR_F_SetFieldIntegerList(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Ptr{Cint})
     ccall((:OGR_F_SetFieldIntegerList,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{Cint}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldInteger64List(OGRFeatureH,
+                                int,
+                                int,
+                                const GIntBig *) -> void
+
+Set field to list of 64 bit integers value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **panValues**: the values to assign.
+"""
 function OGR_F_SetFieldInteger64List(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Ptr{GIntBig})
     ccall((:OGR_F_SetFieldInteger64List,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{GIntBig}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldDoubleList(OGRFeatureH,
+                             int,
+                             int,
+                             double *) -> void
+
+Set field to list of doubles value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **padfValues**: the values to assign.
+"""
 function OGR_F_SetFieldDoubleList(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Ptr{Cdouble})
     ccall((:OGR_F_SetFieldDoubleList,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{Cdouble}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldStringList(OGRFeatureH,
+                             int,
+                             char **) -> void
+
+Set field to list of strings value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **papszValues**: the values to assign.
+"""
 function OGR_F_SetFieldStringList(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{Ptr{UInt8}})
     ccall((:OGR_F_SetFieldStringList,libgdal),Void,(OGRFeatureH,Cint,Ptr{Ptr{UInt8}}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldRaw(OGRFeatureH,
+                      int,
+                      OGRField *) -> void
+
+Set field.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **psValue**: handle on the value to assign.
+"""
 function OGR_F_SetFieldRaw(arg1::OGRFeatureH,arg2::Cint,arg3::Ptr{OGRField})
     ccall((:OGR_F_SetFieldRaw,libgdal),Void,(OGRFeatureH,Cint,Ptr{OGRField}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldBinary(OGRFeatureH,
+                         int,
+                         int,
+                         GByte *) -> void
+
+Set field to binary data.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nBytes**: the number of bytes in pabyData array.
+* **pabyData**: the data to apply.
+"""
 function OGR_F_SetFieldBinary(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Ptr{GByte})
     ccall((:OGR_F_SetFieldBinary,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{GByte}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldDateTime(OGRFeatureH,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int) -> void
+
+Set field to datetime.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nYear**: (including century)
+* **nMonth**: (1-12)
+* **nDay**: (1-31)
+* **nHour**: (0-23)
+* **nMinute**: (0-59)
+* **nSecond**: (0-59)
+* **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+"""
 function OGR_F_SetFieldDateTime(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint,arg6::Cint,arg7::Cint,arg8::Cint,arg9::Cint)
     ccall((:OGR_F_SetFieldDateTime,libgdal),Void,(OGRFeatureH,Cint,Cint,Cint,Cint,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_SetFieldDateTimeEx(OGRFeatureH,
+                             int,
+                             int,
+                             int,
+                             int,
+                             int,
+                             int,
+                             float,
+                             int) -> void
+
+Set field to datetime.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nYear**: (including century)
+* **nMonth**: (1-12)
+* **nDay**: (1-31)
+* **nHour**: (0-23)
+* **nMinute**: (0-59)
+* **fSecond**: (0-59, with millisecond accuracy)
+* **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+"""
 function OGR_F_SetFieldDateTimeEx(arg1::OGRFeatureH,arg2::Cint,arg3::Cint,arg4::Cint,arg5::Cint,arg6::Cint,arg7::Cint,arg8::Cfloat,arg9::Cint)
     ccall((:OGR_F_SetFieldDateTimeEx,libgdal),Void,(OGRFeatureH,Cint,Cint,Cint,Cint,Cint,Cint,Cfloat,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_GetGeomFieldCount(OGRFeatureH hFeat) -> int
+
+Fetch number of geometry fields on this feature This will always be the same as the geometry field count for the OGRFeatureDefn.
+
+### Parameters
+* **hFeat**: handle to the feature to get the geometry fields count from.
+
+### Returns
+count of geometry fields.
+"""
 function OGR_F_GetGeomFieldCount(hFeat::OGRFeatureH)
     ccall((:OGR_F_GetGeomFieldCount,libgdal),Cint,(OGRFeatureH,),hFeat)
 end
 
+
+"""
+    OGR_F_GetGeomFieldDefnRef(OGRFeatureH hFeat,
+                              int iField) -> OGRGeomFieldDefnH
+
+Fetch definition for this geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **i**: the field to fetch, from 0 to GetGeomFieldCount()-1.
+
+### Returns
+an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
+"""
 function OGR_F_GetGeomFieldDefnRef(hFeat::OGRFeatureH,iField::Cint)
     ccall((:OGR_F_GetGeomFieldDefnRef,libgdal),OGRGeomFieldDefnH,(OGRFeatureH,Cint),hFeat,iField)
 end
 
+
+"""
+    OGR_F_GetGeomFieldIndex(OGRFeatureH hFeat,
+                            const char * pszName) -> int
+
+Fetch the geometry field index given geometry field name.
+
+### Parameters
+* **hFeat**: handle to the feature on which the geometry field is found.
+* **pszName**: the name of the geometry field to search for.
+
+### Returns
+the geometry field index, or -1 if no matching geometry field is found.
+"""
 function OGR_F_GetGeomFieldIndex(hFeat::OGRFeatureH,pszName::Ptr{UInt8})
     ccall((:OGR_F_GetGeomFieldIndex,libgdal),Cint,(OGRFeatureH,Ptr{UInt8}),hFeat,pszName)
 end
 
+
+"""
+    OGR_F_GetGeomFieldRef(OGRFeatureH hFeat,
+                          int iField) -> OGRGeometryH
+
+Fetch an handle to feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature to get geometry from.
+* **iField**: geometry field to get.
+
+### Returns
+an handle to internal feature geometry. This object should not be modified.
+"""
 function OGR_F_GetGeomFieldRef(hFeat::OGRFeatureH,iField::Cint)
     ccall((:OGR_F_GetGeomFieldRef,libgdal),OGRGeometryH,(OGRFeatureH,Cint),hFeat,iField)
 end
 
+
+"""
+    OGR_F_SetGeomFieldDirectly(OGRFeatureH hFeat,
+                               int iField,
+                               OGRGeometryH hGeom) -> OGRErr
+
+Set feature geometry of a specified geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which to apply the geometry.
+* **iField**: geometry field to set.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_FAILURE if the index is invalid, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function OGR_F_SetGeomFieldDirectly(hFeat::OGRFeatureH,iField::Cint,hGeom::OGRGeometryH)
     ccall((:OGR_F_SetGeomFieldDirectly,libgdal),OGRErr,(OGRFeatureH,Cint,OGRGeometryH),hFeat,iField,hGeom)
 end
 
+
+"""
+    OGR_F_SetGeomField(OGRFeatureH hFeat,
+                       int iField,
+                       OGRGeometryH hGeom) -> OGRErr
+
+Set feature geometry of a specified geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which new geometry is applied to.
+* **iField**: geometry field to set.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function OGR_F_SetGeomField(hFeat::OGRFeatureH,iField::Cint,hGeom::OGRGeometryH)
     ccall((:OGR_F_SetGeomField,libgdal),OGRErr,(OGRFeatureH,Cint,OGRGeometryH),hFeat,iField,hGeom)
 end
 
+
+"""
+    OGR_F_GetFID(OGRFeatureH) -> GIntBig
+
+Get feature identifier.
+
+### Parameters
+* **hFeat**: handle to the feature from which to get the feature identifier.
+
+### Returns
+feature id or OGRNullFID if none has been assigned.
+"""
 function OGR_F_GetFID(arg1::OGRFeatureH)
     ccall((:OGR_F_GetFID,libgdal),GIntBig,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_SetFID(OGRFeatureH,
+                 GIntBig) -> OGRErr
+
+Set the feature identifier.
+
+### Parameters
+* **hFeat**: handle to the feature to set the feature id to.
+* **nFID**: the new feature identifier value to assign.
+
+### Returns
+On success OGRERR_NONE, or on failure some other value.
+"""
 function OGR_F_SetFID(arg1::OGRFeatureH,arg2::GIntBig)
     ccall((:OGR_F_SetFID,libgdal),OGRErr,(OGRFeatureH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_F_DumpReadable(OGRFeatureH,
+                       FILE *) -> void
+
+Dump this feature in a human readable form.
+
+### Parameters
+* **hFeat**: handle to the feature to dump.
+* **fpOut**: the stream to write to, such as strout.
+"""
 function OGR_F_DumpReadable(arg1::OGRFeatureH,arg2::Ptr{FILE})
     ccall((:OGR_F_DumpReadable,libgdal),Void,(OGRFeatureH,Ptr{FILE}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetFrom(OGRFeatureH,
+                  OGRFeatureH,
+                  int) -> OGRErr
+
+Set one feature from another.
+
+### Parameters
+* **hFeat**: handle to the feature to set to.
+* **hOtherFeat**: handle to the feature from which geometry, and field values will be copied.
+* **bForgiving**: TRUE if the operation should continue despite lacking output fields matching some of the source fields.
+
+### Returns
+OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
+"""
 function OGR_F_SetFrom(arg1::OGRFeatureH,arg2::OGRFeatureH,arg3::Cint)
     ccall((:OGR_F_SetFrom,libgdal),OGRErr,(OGRFeatureH,OGRFeatureH,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFromWithMap(OGRFeatureH,
+                         OGRFeatureH,
+                         int,
+                         int *) -> OGRErr
+
+Set one feature from another.
+
+### Parameters
+* **hFeat**: handle to the feature to set to.
+* **hOtherFeat**: handle to the feature from which geometry, and field values will be copied.
+* **panMap**: Array of the indices of the destination feature's fields stored at the corresponding index of the source feature's fields. A value of -1 should be used to ignore the source's field. The array should not be NULL and be as long as the number of fields in the source feature.
+* **bForgiving**: TRUE if the operation should continue despite lacking output fields matching some of the source fields.
+
+### Returns
+OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
+"""
 function OGR_F_SetFromWithMap(arg1::OGRFeatureH,arg2::OGRFeatureH,arg3::Cint,arg4::Ptr{Cint})
     ccall((:OGR_F_SetFromWithMap,libgdal),OGRErr,(OGRFeatureH,OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_GetStyleString(OGRFeatureH) -> const char *
+
+Fetch style string for this feature.
+
+### Parameters
+* **hFeat**: handle to the feature to get the style from.
+
+### Returns
+a reference to a representation in string format, or NULL if there isn't one.
+"""
 function OGR_F_GetStyleString(arg1::OGRFeatureH)
     ccall((:OGR_F_GetStyleString,libgdal),Ptr{UInt8},(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_SetStyleString(OGRFeatureH,
+                         const char *) -> void
+
+Set feature style string.
+
+### Parameters
+* **hFeat**: handle to the feature to set style to.
+* **pszStyle**: the style string to apply to this feature, cannot be NULL.
+"""
 function OGR_F_SetStyleString(arg1::OGRFeatureH,arg2::Ptr{UInt8})
     ccall((:OGR_F_SetStyleString,libgdal),Void,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetStyleStringDirectly(OGRFeatureH,
+                                 char *) -> void
+
+Set feature style string.
+
+### Parameters
+* **hFeat**: handle to the feature to set style to.
+* **pszStyle**: the style string to apply to this feature, cannot be NULL.
+"""
 function OGR_F_SetStyleStringDirectly(arg1::OGRFeatureH,arg2::Ptr{UInt8})
     ccall((:OGR_F_SetStyleStringDirectly,libgdal),Void,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetStyleTable(OGRFeatureH) -> OGRStyleTableH
+"""
 function OGR_F_GetStyleTable(arg1::OGRFeatureH)
     ccall((:OGR_F_GetStyleTable,libgdal),OGRStyleTableH,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_SetStyleTableDirectly(OGRFeatureH,
+                                OGRStyleTableH) -> void
+"""
 function OGR_F_SetStyleTableDirectly(arg1::OGRFeatureH,arg2::OGRStyleTableH)
     ccall((:OGR_F_SetStyleTableDirectly,libgdal),Void,(OGRFeatureH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetStyleTable(OGRFeatureH,
+                        OGRStyleTableH) -> void
+"""
 function OGR_F_SetStyleTable(arg1::OGRFeatureH,arg2::OGRStyleTableH)
     ccall((:OGR_F_SetStyleTable,libgdal),Void,(OGRFeatureH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_FillUnsetWithDefault(OGRFeatureH hFeat,
+                               int bNotNullableOnly,
+                               char ** papszOptions) -> void
+
+Fill unset fields with default values that might be defined.
+
+### Parameters
+* **hFeat**: handle to the feature.
+* **bNotNullableOnly**: if we should fill only unset fields with a not-null constraint.
+* **papszOptions**: unused currently. Must be set to NULL.
+"""
 function OGR_F_FillUnsetWithDefault(hFeat::OGRFeatureH,bNotNullableOnly::Cint,papszOptions::Ptr{Ptr{UInt8}})
     ccall((:OGR_F_FillUnsetWithDefault,libgdal),Void,(OGRFeatureH,Cint,Ptr{Ptr{UInt8}}),hFeat,bNotNullableOnly,papszOptions)
 end
 
+
+"""
+    OGR_F_Validate(OGRFeatureH,
+                   int nValidateFlags,
+                   int bEmitError) -> int
+
+Validate that a feature meets constraints of its schema.
+
+### Parameters
+* **hFeat**: handle to the feature to validate.
+* **nValidateFlags**: OGR_F_VAL_ALL or combination of OGR_F_VAL_NULL, OGR_F_VAL_GEOM_TYPE, OGR_F_VAL_WIDTH and OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT with '|' operator
+* **bEmitError**: TRUE if a CPLError() must be emitted when a check fails
+
+### Returns
+TRUE if all enabled validation tests pass.
+"""
 function OGR_F_Validate(arg1::OGRFeatureH,nValidateFlags::Cint,bEmitError::Cint)
     ccall((:OGR_F_Validate,libgdal),Cint,(OGRFeatureH,Cint,Cint),arg1,nValidateFlags,bEmitError)
 end
 
+
+"""
+    OGR_L_GetName(OGRLayerH) -> const char *
+
+Return the layer name.
+
+### Parameters
+* **hLayer**: handle to the layer.
+
+### Returns
+the layer name (must not been freed)
+"""
 function OGR_L_GetName(arg1::OGRLayerH)
     ccall((:OGR_L_GetName,libgdal),Ptr{UInt8},(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetGeomType(OGRLayerH) -> OGRwkbGeometryType
+
+Return the layer geometry type.
+
+### Parameters
+* **hLayer**: handle to the layer.
+
+### Returns
+the geometry type
+"""
 function OGR_L_GetGeomType(arg1::OGRLayerH)
     ccall((:OGR_L_GetGeomType,libgdal),OGRwkbGeometryType,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetSpatialFilter(OGRLayerH) -> OGRGeometryH
+
+This function returns the current spatial filter for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the spatial filter from.
+
+### Returns
+an handle to the spatial filter geometry.
+"""
 function OGR_L_GetSpatialFilter(arg1::OGRLayerH)
     ccall((:OGR_L_GetSpatialFilter,libgdal),OGRGeometryH,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_SetSpatialFilter(OGRLayerH,
+                           OGRGeometryH) -> void
+
+Set a new spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
+"""
 function OGR_L_SetSpatialFilter(arg1::OGRLayerH,arg2::OGRGeometryH)
     ccall((:OGR_L_SetSpatialFilter,libgdal),Void,(OGRLayerH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterRect(OGRLayerH,
+                               double,
+                               double,
+                               double,
+                               double) -> void
+
+Set a new rectangular spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **dfMinX**: the minimum X coordinate for the rectangular region.
+* **dfMinY**: the minimum Y coordinate for the rectangular region.
+* **dfMaxX**: the maximum X coordinate for the rectangular region.
+* **dfMaxY**: the maximum Y coordinate for the rectangular region.
+"""
 function OGR_L_SetSpatialFilterRect(arg1::OGRLayerH,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble,arg5::Cdouble)
     ccall((:OGR_L_SetSpatialFilterRect,libgdal),Void,(OGRLayerH,Cdouble,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterEx(OGRLayerH,
+                             int iGeomField,
+                             OGRGeometryH hGeom) -> void
+
+Set a new spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **iGeomField**: index of the geometry field on which the spatial filter operates.
+* **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
+"""
 function OGR_L_SetSpatialFilterEx(arg1::OGRLayerH,iGeomField::Cint,hGeom::OGRGeometryH)
     ccall((:OGR_L_SetSpatialFilterEx,libgdal),Void,(OGRLayerH,Cint,OGRGeometryH),arg1,iGeomField,hGeom)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterRectEx(OGRLayerH,
+                                 int iGeomField,
+                                 double dfMinX,
+                                 double dfMinY,
+                                 double dfMaxX,
+                                 double dfMaxY) -> void
+
+Set a new rectangular spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **iGeomField**: index of the geometry field on which the spatial filter operates.
+* **dfMinX**: the minimum X coordinate for the rectangular region.
+* **dfMinY**: the minimum Y coordinate for the rectangular region.
+* **dfMaxX**: the maximum X coordinate for the rectangular region.
+* **dfMaxY**: the maximum Y coordinate for the rectangular region.
+"""
 function OGR_L_SetSpatialFilterRectEx(arg1::OGRLayerH,iGeomField::Cint,dfMinX::Cdouble,dfMinY::Cdouble,dfMaxX::Cdouble,dfMaxY::Cdouble)
     ccall((:OGR_L_SetSpatialFilterRectEx,libgdal),Void,(OGRLayerH,Cint,Cdouble,Cdouble,Cdouble,Cdouble),arg1,iGeomField,dfMinX,dfMinY,dfMaxX,dfMaxY)
 end
 
+
+"""
+    OGR_L_SetAttributeFilter(OGRLayerH,
+                             const char *) -> OGRErr
+
+Set a new attribute query.
+
+### Parameters
+* **hLayer**: handle to the layer on which attribute query will be executed.
+* **pszQuery**: query in restricted SQL WHERE format, or NULL to clear the current query.
+
+### Returns
+OGRERR_NONE if successfully installed, or an error code if the query expression is in error, or some other failure occurs.
+"""
 function OGR_L_SetAttributeFilter(arg1::OGRLayerH,arg2::Ptr{UInt8})
     ccall((:OGR_L_SetAttributeFilter,libgdal),OGRErr,(OGRLayerH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_ResetReading(OGRLayerH) -> void
+
+Reset feature reading to start on the first feature.
+
+### Parameters
+* **hLayer**: handle to the layer on which features are read.
+"""
 function OGR_L_ResetReading(arg1::OGRLayerH)
     ccall((:OGR_L_ResetReading,libgdal),Void,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetNextFeature(OGRLayerH) -> OGRFeatureH
+
+Fetch the next available feature from this layer.
+
+### Parameters
+* **hLayer**: handle to the layer from which feature are read.
+
+### Returns
+an handle to a feature, or NULL if no more features are available.
+"""
 function OGR_L_GetNextFeature(arg1::OGRLayerH)
     ccall((:OGR_L_GetNextFeature,libgdal),OGRFeatureH,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_SetNextByIndex(OGRLayerH,
+                         GIntBig) -> OGRErr
+
+Move read cursor to the nIndex'th feature in the current resultset.
+
+### Parameters
+* **hLayer**: handle to the layer
+* **nIndex**: the index indicating how many steps into the result set to seek.
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function OGR_L_SetNextByIndex(arg1::OGRLayerH,arg2::GIntBig)
     ccall((:OGR_L_SetNextByIndex,libgdal),OGRErr,(OGRLayerH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetFeature(OGRLayerH,
+                     GIntBig) -> OGRFeatureH
+
+Fetch a feature by its identifier.
+
+### Parameters
+* **hLayer**: handle to the layer that owned the feature.
+* **nFeatureId**: the feature id of the feature to read.
+
+### Returns
+an handle to a feature now owned by the caller, or NULL on failure.
+"""
 function OGR_L_GetFeature(arg1::OGRLayerH,arg2::GIntBig)
     ccall((:OGR_L_GetFeature,libgdal),OGRFeatureH,(OGRLayerH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetFeature(OGRLayerH,
+                     OGRFeatureH) -> OGRErr
+
+Rewrite an existing feature.
+
+### Parameters
+* **hLayer**: handle to the layer to write the feature.
+* **hFeat**: the feature to write.
+
+### Returns
+OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
+"""
 function OGR_L_SetFeature(arg1::OGRLayerH,arg2::OGRFeatureH)
     ccall((:OGR_L_SetFeature,libgdal),OGRErr,(OGRLayerH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_CreateFeature(OGRLayerH,
+                        OGRFeatureH) -> OGRErr
+
+Create and write a new feature within a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the feature to.
+* **hFeat**: the handle of the feature to write to disk.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_CreateFeature(arg1::OGRLayerH,arg2::OGRFeatureH)
     ccall((:OGR_L_CreateFeature,libgdal),OGRErr,(OGRLayerH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_DeleteFeature(OGRLayerH,
+                        GIntBig) -> OGRErr
+
+Delete feature from layer.
+
+### Parameters
+* **hLayer**: handle to the layer
+* **nFID**: the feature id to be deleted from the layer
+
+### Returns
+OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
+"""
 function OGR_L_DeleteFeature(arg1::OGRLayerH,arg2::GIntBig)
     ccall((:OGR_L_DeleteFeature,libgdal),OGRErr,(OGRLayerH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetLayerDefn(OGRLayerH) -> OGRFeatureDefnH
+
+Fetch the schema information for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the schema information.
+
+### Returns
+an handle to the feature definition.
+"""
 function OGR_L_GetLayerDefn(arg1::OGRLayerH)
     ccall((:OGR_L_GetLayerDefn,libgdal),OGRFeatureDefnH,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetSpatialRef(OGRLayerH) -> OGRSpatialReferenceH
+
+Fetch the spatial reference system for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the spatial reference from.
+
+### Returns
+spatial reference, or NULL if there isn't one.
+"""
 function OGR_L_GetSpatialRef(arg1::OGRLayerH)
     ccall((:OGR_L_GetSpatialRef,libgdal),OGRSpatialReferenceH,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_FindFieldIndex(OGRLayerH,
+                         const char *,
+                         int bExactMatch) -> int
+
+Find the index of field in a layer.
+
+### Returns
+field index, or -1 if the field doesn't exist
+"""
 function OGR_L_FindFieldIndex(arg1::OGRLayerH,arg2::Ptr{UInt8},bExactMatch::Cint)
     ccall((:OGR_L_FindFieldIndex,libgdal),Cint,(OGRLayerH,Ptr{UInt8},Cint),arg1,arg2,bExactMatch)
 end
 
+
+"""
+    OGR_L_GetFeatureCount(OGRLayerH,
+                          int) -> GIntBig
+
+Fetch the feature count in this layer.
+
+### Parameters
+* **hLayer**: handle to the layer that owned the features.
+* **bForce**: Flag indicating whether the count should be computed even if it is expensive.
+
+### Returns
+feature count, -1 if count not known.
+"""
 function OGR_L_GetFeatureCount(arg1::OGRLayerH,arg2::Cint)
     ccall((:OGR_L_GetFeatureCount,libgdal),GIntBig,(OGRLayerH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetExtent(OGRLayerH,
+                    OGREnvelope *,
+                    int) -> OGRErr
+
+Fetch the extent of this layer.
+
+### Parameters
+* **hLayer**: handle to the layer from which to get extent.
+* **psExtent**: the structure in which the extent value will be returned.
+* **bForce**: Flag indicating whether the extent should be computed even if it is expensive.
+
+### Returns
+OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
+"""
 function OGR_L_GetExtent(arg1::OGRLayerH,arg2::Ptr{OGREnvelope},arg3::Cint)
     ccall((:OGR_L_GetExtent,libgdal),OGRErr,(OGRLayerH,Ptr{OGREnvelope},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_L_GetExtentEx(OGRLayerH,
+                      int iGeomField,
+                      OGREnvelope * psExtent,
+                      int bForce) -> OGRErr
+
+Fetch the extent of this layer, on the specified geometry field.
+
+### Parameters
+* **hLayer**: handle to the layer from which to get extent.
+* **iGeomField**: the index of the geometry field on which to compute the extent.
+* **psExtent**: the structure in which the extent value will be returned.
+* **bForce**: Flag indicating whether the extent should be computed even if it is expensive.
+
+### Returns
+OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
+"""
 function OGR_L_GetExtentEx(arg1::OGRLayerH,iGeomField::Cint,psExtent::Ptr{OGREnvelope},bForce::Cint)
     ccall((:OGR_L_GetExtentEx,libgdal),OGRErr,(OGRLayerH,Cint,Ptr{OGREnvelope},Cint),arg1,iGeomField,psExtent,bForce)
 end
 
+
+"""
+    OGR_L_TestCapability(OGRLayerH,
+                         const char *) -> int
+
+Test if this layer supported the named capability.
+
+### Parameters
+* **hLayer**: handle to the layer to get the capability from.
+* **pszCap**: the name of the capability to test.
+
+### Returns
+TRUE if the layer has the requested capability, or FALSE otherwise. OGRLayers will return FALSE for any unrecognised capabilities.
+"""
 function OGR_L_TestCapability(arg1::OGRLayerH,arg2::Ptr{UInt8})
     ccall((:OGR_L_TestCapability,libgdal),Cint,(OGRLayerH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_CreateField(OGRLayerH,
+                      OGRFieldDefnH,
+                      int) -> OGRErr
+
+Create a new field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the field definition.
+* **hField**: handle of the field definition to write to disk.
+* **bApproxOK**: If TRUE, the field may be created in a slightly different form depending on the limitations of the format driver.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_CreateField(arg1::OGRLayerH,arg2::OGRFieldDefnH,arg3::Cint)
     ccall((:OGR_L_CreateField,libgdal),OGRErr,(OGRLayerH,OGRFieldDefnH,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_L_CreateGeomField(OGRLayerH hLayer,
+                          OGRGeomFieldDefnH hFieldDefn,
+                          int bForce) -> OGRErr
+
+Create a new geometry field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the field definition.
+* **hField**: handle of the geometry field definition to write to disk.
+* **bApproxOK**: If TRUE, the field may be created in a slightly different form depending on the limitations of the format driver.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_CreateGeomField(hLayer::OGRLayerH,hFieldDefn::OGRGeomFieldDefnH,bForce::Cint)
     ccall((:OGR_L_CreateGeomField,libgdal),OGRErr,(OGRLayerH,OGRGeomFieldDefnH,Cint),hLayer,hFieldDefn,bForce)
 end
 
+
+"""
+    OGR_L_DeleteField(OGRLayerH,
+                      int iField) -> OGRErr
+
+Create a new field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iField**: index of the field to delete.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_DeleteField(arg1::OGRLayerH,iField::Cint)
     ccall((:OGR_L_DeleteField,libgdal),OGRErr,(OGRLayerH,Cint),arg1,iField)
 end
 
+
+"""
+    OGR_L_ReorderFields(OGRLayerH,
+                        int * panMap) -> OGRErr
+
+Reorder all the fields of a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **panMap**: an array of GetLayerDefn()->OGRFeatureDefn::GetFieldCount() elements which is a permutation of [0, GetLayerDefn()->OGRFeatureDefn::GetFieldCount()-1].
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_ReorderFields(arg1::OGRLayerH,panMap::Ptr{Cint})
     ccall((:OGR_L_ReorderFields,libgdal),OGRErr,(OGRLayerH,Ptr{Cint}),arg1,panMap)
 end
 
+
+"""
+    OGR_L_ReorderField(OGRLayerH,
+                       int iOldFieldPos,
+                       int iNewFieldPos) -> OGRErr
+
+Reorder an existing field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iOldFieldPos**: previous position of the field to move. Must be in the range [0,GetFieldCount()-1].
+* **iNewFieldPos**: new position of the field to move. Must be in the range [0,GetFieldCount()-1].
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_ReorderField(arg1::OGRLayerH,iOldFieldPos::Cint,iNewFieldPos::Cint)
     ccall((:OGR_L_ReorderField,libgdal),OGRErr,(OGRLayerH,Cint,Cint),arg1,iOldFieldPos,iNewFieldPos)
 end
 
+
+"""
+    OGR_L_AlterFieldDefn(OGRLayerH,
+                         int iField,
+                         OGRFieldDefnH hNewFieldDefn,
+                         int nFlags) -> OGRErr
+
+Alter the definition of an existing field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iField**: index of the field whose definition must be altered.
+* **hNewFieldDefn**: new field definition
+* **nFlags**: combination of ALTER_NAME_FLAG, ALTER_TYPE_FLAG, ALTER_WIDTH_PRECISION_FLAG, ALTER_NULLABLE_FLAG and ALTER_DEFAULT_FLAG to indicate which of the name and/or type and/or width and precision fields and/or nullability from the new field definition must be taken into account.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_AlterFieldDefn(arg1::OGRLayerH,iField::Cint,hNewFieldDefn::OGRFieldDefnH,nFlags::Cint)
     ccall((:OGR_L_AlterFieldDefn,libgdal),OGRErr,(OGRLayerH,Cint,OGRFieldDefnH,Cint),arg1,iField,hNewFieldDefn,nFlags)
 end
 
+
+"""
+    OGR_L_StartTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, StartTransaction creates a transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_StartTransaction(arg1::OGRLayerH)
     ccall((:OGR_L_StartTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_CommitTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, CommitTransaction commits a transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_CommitTransaction(arg1::OGRLayerH)
     ccall((:OGR_L_CommitTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_RollbackTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, RollbackTransaction will roll back a datasource to its state before the start of the current transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function OGR_L_RollbackTransaction(arg1::OGRLayerH)
     ccall((:OGR_L_RollbackTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_Reference(OGRLayerH) -> int
+"""
 function OGR_L_Reference(arg1::OGRLayerH)
     ccall((:OGR_L_Reference,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_Dereference(OGRLayerH) -> int
+"""
 function OGR_L_Dereference(arg1::OGRLayerH)
     ccall((:OGR_L_Dereference,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetRefCount(OGRLayerH) -> int
+"""
 function OGR_L_GetRefCount(arg1::OGRLayerH)
     ccall((:OGR_L_GetRefCount,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_SyncToDisk(OGRLayerH) -> OGRErr
+
+Flush pending changes to disk.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE if no error occurs (even if nothing is done) or an error code.
+"""
 function OGR_L_SyncToDisk(arg1::OGRLayerH)
     ccall((:OGR_L_SyncToDisk,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetFeaturesRead(OGRLayerH) -> GIntBig
+"""
 function OGR_L_GetFeaturesRead(arg1::OGRLayerH)
     ccall((:OGR_L_GetFeaturesRead,libgdal),GIntBig,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetFIDColumn(OGRLayerH) -> const char *
+
+This method returns the name of the underlying database column being used as the FID column, or "" if not supported.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+fid column name.
+"""
 function OGR_L_GetFIDColumn(arg1::OGRLayerH)
     ccall((:OGR_L_GetFIDColumn,libgdal),Ptr{UInt8},(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetGeometryColumn(OGRLayerH) -> const char *
+
+This method returns the name of the underlying database column being used as the geometry column, or "" if not supported.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+geometry column name.
+"""
 function OGR_L_GetGeometryColumn(arg1::OGRLayerH)
     ccall((:OGR_L_GetGeometryColumn,libgdal),Ptr{UInt8},(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetStyleTable(OGRLayerH) -> OGRStyleTableH
+"""
 function OGR_L_GetStyleTable(arg1::OGRLayerH)
     ccall((:OGR_L_GetStyleTable,libgdal),OGRStyleTableH,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_SetStyleTableDirectly(OGRLayerH,
+                                OGRStyleTableH) -> void
+"""
 function OGR_L_SetStyleTableDirectly(arg1::OGRLayerH,arg2::OGRStyleTableH)
     ccall((:OGR_L_SetStyleTableDirectly,libgdal),Void,(OGRLayerH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetStyleTable(OGRLayerH,
+                        OGRStyleTableH) -> void
+"""
 function OGR_L_SetStyleTable(arg1::OGRLayerH,arg2::OGRStyleTableH)
     ccall((:OGR_L_SetStyleTable,libgdal),Void,(OGRLayerH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetIgnoredFields(OGRLayerH,
+                           const char **) -> OGRErr
+
+Set which fields can be omitted when retrieving features from the layer.
+
+### Parameters
+* **papszFields**: an array of field names terminated by NULL item. If NULL is passed, the ignored list is cleared.
+
+### Returns
+OGRERR_NONE if all field names have been resolved (even if the driver does not support this method)
+"""
 function OGR_L_SetIgnoredFields(arg1::OGRLayerH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OGR_L_SetIgnoredFields,libgdal),OGRErr,(OGRLayerH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_Intersection(OGRLayerH,
+                       OGRLayerH,
+                       OGRLayerH,
+                       char **,
+                       GDALProgressFunc,
+                       void *) -> OGRErr
+
+Intersection of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Intersection(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Intersection,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Union(OGRLayerH,
+                OGRLayerH,
+                OGRLayerH,
+                char **,
+                GDALProgressFunc,
+                void *) -> OGRErr
+
+Union of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Union(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Union,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_SymDifference(OGRLayerH,
+                        OGRLayerH,
+                        OGRLayerH,
+                        char **,
+                        GDALProgressFunc,
+                        void *) -> OGRErr
+
+Symmetrical difference of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_SymDifference(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_SymDifference,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Identity(OGRLayerH,
+                   OGRLayerH,
+                   OGRLayerH,
+                   char **,
+                   GDALProgressFunc,
+                   void *) -> OGRErr
+
+Identify the features of this layer with the ones from the identity layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Identity(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Identity,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Update(OGRLayerH,
+                 OGRLayerH,
+                 OGRLayerH,
+                 char **,
+                 GDALProgressFunc,
+                 void *) -> OGRErr
+
+Update this layer with features from the update layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Update(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Update,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Clip(OGRLayerH,
+               OGRLayerH,
+               OGRLayerH,
+               char **,
+               GDALProgressFunc,
+               void *) -> OGRErr
+
+Clip off areas that are not covered by the method layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Clip(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Clip,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Erase(OGRLayerH,
+                OGRLayerH,
+                OGRLayerH,
+                char **,
+                GDALProgressFunc,
+                void *) -> OGRErr
+
+Remove areas that are covered by the method layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function OGR_L_Erase(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Ptr{Ptr{UInt8}},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Erase,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_DS_Destroy(OGRDataSourceH) -> void
+
+Closes opened datasource and releases allocated resources.
+
+### Parameters
+* **hDataSource**: handle to allocated datasource object.
+"""
 function OGR_DS_Destroy(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Destroy,libgdal),Void,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetName(OGRDataSourceH) -> const char *
+
+Returns the name of the data source.
+
+### Parameters
+* **hDS**: handle to the data source to get the name from.
+
+### Returns
+pointer to an internal name string which should not be modified or freed by the caller.
+"""
 function OGR_DS_GetName(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetName,libgdal),Ptr{UInt8},(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetLayerCount(OGRDataSourceH) -> int
+
+Get the number of layers in this data source.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the number of layers.
+
+### Returns
+layer count.
+"""
 function OGR_DS_GetLayerCount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetLayerCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetLayer(OGRDataSourceH,
+                    int) -> OGRLayerH
+
+Fetch a layer by index.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the layer.
+* **iLayer**: a layer number between 0 and OGR_DS_GetLayerCount()-1.
+
+### Returns
+an handle to the layer, or NULL if iLayer is out of range or an error occurs.
+"""
 function OGR_DS_GetLayer(arg1::OGRDataSourceH,arg2::Cint)
     ccall((:OGR_DS_GetLayer,libgdal),OGRLayerH,(OGRDataSourceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_GetLayerByName(OGRDataSourceH,
+                          const char *) -> OGRLayerH
+
+Fetch a layer by name.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the layer.
+* **pszLayerName**: Layer the layer name of the layer to fetch.
+
+### Returns
+an handle to the layer, or NULL if the layer is not found or an error occurs.
+"""
 function OGR_DS_GetLayerByName(arg1::OGRDataSourceH,arg2::Ptr{UInt8})
     ccall((:OGR_DS_GetLayerByName,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_DeleteLayer(OGRDataSourceH,
+                       int) -> OGRErr
+
+Delete the indicated layer from the datasource.
+
+### Parameters
+* **hDS**: handle to the datasource
+* **iLayer**: the index of the layer to delete.
+
+### Returns
+OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
+"""
 function OGR_DS_DeleteLayer(arg1::OGRDataSourceH,arg2::Cint)
     ccall((:OGR_DS_DeleteLayer,libgdal),OGRErr,(OGRDataSourceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_GetDriver(OGRDataSourceH) -> OGRSFDriverH
+
+Returns the driver that the dataset was opened with.
+
+### Parameters
+* **hDS**: handle to the datasource
+
+### Returns
+NULL if driver info is not available, or pointer to a driver owned by the OGRSFDriverManager.
+"""
 function OGR_DS_GetDriver(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetDriver,libgdal),OGRSFDriverH,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_CreateLayer(OGRDataSourceH,
+                       const char *,
+                       OGRSpatialReferenceH,
+                       OGRwkbGeometryType,
+                       char **) -> OGRLayerH
+
+This function attempts to create a new layer on the data source with the indicated name, coordinate system, geometry type.
+
+### Parameters
+* **hDS**: The dataset handle.
+* **pszName**: the name for the new layer. This should ideally not match any existing layer on the datasource.
+* **hSpatialRef**: handle to the coordinate system to use for the new layer, or NULL if no coordinate system is available.
+* **eType**: the geometry type for the layer. Use wkbUnknown if there are no constraints on the types geometry to be written.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRLayer handle on success.
+"""
 function OGR_DS_CreateLayer(arg1::OGRDataSourceH,arg2::Ptr{UInt8},arg3::OGRSpatialReferenceH,arg4::OGRwkbGeometryType,arg5::Ptr{Ptr{UInt8}})
     ccall((:OGR_DS_CreateLayer,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8},OGRSpatialReferenceH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OGR_DS_CopyLayer(OGRDataSourceH,
+                     OGRLayerH,
+                     const char *,
+                     char **) -> OGRLayerH
+
+Duplicate an existing layer.
+
+### Parameters
+* **hDS**: handle to the data source where to create the new layer
+* **hSrcLayer**: handle to the source layer.
+* **pszNewName**: the name of the layer to create.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+an handle to the layer, or NULL if an error occurs.
+"""
 function OGR_DS_CopyLayer(arg1::OGRDataSourceH,arg2::OGRLayerH,arg3::Ptr{UInt8},arg4::Ptr{Ptr{UInt8}})
     ccall((:OGR_DS_CopyLayer,libgdal),OGRLayerH,(OGRDataSourceH,OGRLayerH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_DS_TestCapability(OGRDataSourceH,
+                          const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDS**: handle to the data source against which to test the capability.
+* **pszCapability**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function OGR_DS_TestCapability(arg1::OGRDataSourceH,arg2::Ptr{UInt8})
     ccall((:OGR_DS_TestCapability,libgdal),Cint,(OGRDataSourceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_ExecuteSQL(OGRDataSourceH,
+                      const char *,
+                      OGRGeometryH,
+                      const char *) -> OGRLayerH
+
+Execute an SQL statement against the data store.
+
+### Parameters
+* **hDS**: handle to the data source on which the SQL query is executed.
+* **pszSQLCommand**: the SQL statement to execute.
+* **hSpatialFilter**: handle to a geometry which represents a spatial filter. Can be NULL.
+* **pszDialect**: allows control of the statement dialect. If set to NULL, the OGR SQL engine will be used, except for RDBMS drivers that will use their dedicated SQL engine, unless OGRSQL is explicitly passed as the dialect. Starting with OGR 1.10, the SQLITE dialect can also be used.
+
+### Returns
+an handle to a OGRLayer containing the results of the query. Deallocate with OGR_DS_ReleaseResultSet().
+"""
 function OGR_DS_ExecuteSQL(arg1::OGRDataSourceH,arg2::Ptr{UInt8},arg3::OGRGeometryH,arg4::Ptr{UInt8})
     ccall((:OGR_DS_ExecuteSQL,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8},OGRGeometryH,Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_DS_ReleaseResultSet(OGRDataSourceH,
+                            OGRLayerH) -> void
+
+Release results of OGR_DS_ExecuteSQL().
+
+### Parameters
+* **hDS**: an handle to the data source on which was executed an SQL query.
+* **hLayer**: handle to the result of a previous OGR_DS_ExecuteSQL() call.
+"""
 function OGR_DS_ReleaseResultSet(arg1::OGRDataSourceH,arg2::OGRLayerH)
     ccall((:OGR_DS_ReleaseResultSet,libgdal),Void,(OGRDataSourceH,OGRLayerH),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_Reference(OGRDataSourceH) -> int
+"""
 function OGR_DS_Reference(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Reference,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_Dereference(OGRDataSourceH) -> int
+"""
 function OGR_DS_Dereference(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Dereference,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetRefCount(OGRDataSourceH) -> int
+"""
 function OGR_DS_GetRefCount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetRefCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetSummaryRefCount(OGRDataSourceH) -> int
+"""
 function OGR_DS_GetSummaryRefCount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetSummaryRefCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_SyncToDisk(OGRDataSourceH) -> OGRErr
+"""
 function OGR_DS_SyncToDisk(arg1::OGRDataSourceH)
     ccall((:OGR_DS_SyncToDisk,libgdal),OGRErr,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetStyleTable(OGRDataSourceH) -> OGRStyleTableH
+"""
 function OGR_DS_GetStyleTable(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetStyleTable,libgdal),OGRStyleTableH,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_SetStyleTableDirectly(OGRDataSourceH,
+                                 OGRStyleTableH) -> void
+"""
 function OGR_DS_SetStyleTableDirectly(arg1::OGRDataSourceH,arg2::OGRStyleTableH)
     ccall((:OGR_DS_SetStyleTableDirectly,libgdal),Void,(OGRDataSourceH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_SetStyleTable(OGRDataSourceH,
+                         OGRStyleTableH) -> void
+"""
 function OGR_DS_SetStyleTable(arg1::OGRDataSourceH,arg2::OGRStyleTableH)
     ccall((:OGR_DS_SetStyleTable,libgdal),Void,(OGRDataSourceH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_Dr_GetName(OGRSFDriverH) -> const char *
+
+Fetch name of driver (file format).
+
+### Parameters
+* **hDriver**: handle to the the driver to get the name from.
+
+### Returns
+driver name. This is an internal string and should not be modified or freed.
+"""
 function OGR_Dr_GetName(arg1::OGRSFDriverH)
     ccall((:OGR_Dr_GetName,libgdal),Ptr{UInt8},(OGRSFDriverH,),arg1)
 end
 
+
+"""
+    OGR_Dr_Open(OGRSFDriverH,
+                const char *,
+                int) -> OGRDataSourceH
+
+Attempt to open file with this driver.
+
+### Parameters
+* **hDriver**: handle to the driver that is used to open file.
+* **pszName**: the name of the file, or data source to try and open.
+* **bUpdate**: TRUE if update access is required, otherwise FALSE (the default).
+
+### Returns
+NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
+"""
 function OGR_Dr_Open(arg1::OGRSFDriverH,arg2::Ptr{UInt8},arg3::Cint)
     ccall((:OGR_Dr_Open,libgdal),OGRDataSourceH,(OGRSFDriverH,Ptr{UInt8},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_Dr_TestCapability(OGRSFDriverH,
+                          const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDriver**: handle to the driver to test the capability against.
+* **pszCap**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function OGR_Dr_TestCapability(arg1::OGRSFDriverH,arg2::Ptr{UInt8})
     ccall((:OGR_Dr_TestCapability,libgdal),Cint,(OGRSFDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_Dr_CreateDataSource(OGRSFDriverH,
+                            const char *,
+                            char **) -> OGRDataSourceH
+
+This function attempts to create a new data source based on the passed driver.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source creation is based.
+* **pszName**: the name for the new data source. UTF-8 encoded.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRDataSource handle on success.
+"""
 function OGR_Dr_CreateDataSource(arg1::OGRSFDriverH,arg2::Ptr{UInt8},arg3::Ptr{Ptr{UInt8}})
     ccall((:OGR_Dr_CreateDataSource,libgdal),OGRDataSourceH,(OGRSFDriverH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_Dr_CopyDataSource(OGRSFDriverH,
+                          OGRDataSourceH,
+                          const char *,
+                          char **) -> OGRDataSourceH
+
+This function creates a new datasource by copying all the layers from the source datasource.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source creation is based.
+* **hSrcDS**: source datasource
+* **pszNewName**: the name for the new data source.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRDataSource handle on success.
+"""
 function OGR_Dr_CopyDataSource(arg1::OGRSFDriverH,arg2::OGRDataSourceH,arg3::Ptr{UInt8},arg4::Ptr{Ptr{UInt8}})
     ccall((:OGR_Dr_CopyDataSource,libgdal),OGRDataSourceH,(OGRSFDriverH,OGRDataSourceH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_Dr_DeleteDataSource(OGRSFDriverH,
+                            const char *) -> OGRErr
+
+Delete a datasource.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source deletion is based.
+* **pszDataSource**: the name of the datasource to delete.
+
+### Returns
+OGRERR_NONE on success, and OGRERR_UNSUPPORTED_OPERATION if this is not supported by this driver.
+"""
 function OGR_Dr_DeleteDataSource(arg1::OGRSFDriverH,arg2::Ptr{UInt8})
     ccall((:OGR_Dr_DeleteDataSource,libgdal),OGRErr,(OGRSFDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGROpen(const char *,
+            int,
+            OGRSFDriverH *) -> OGRDataSourceH
+
+Open a file / data source with one of the registered drivers.
+
+### Parameters
+* **pszName**: the name of the file, or data source to open.
+* **bUpdate**: FALSE for read-only access (the default) or TRUE for read-write access.
+* **pahDriverList**: if non-NULL, this argument will be updated with a pointer to the driver which was used to open the data source.
+
+### Returns
+NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
+"""
 function OGROpen(arg1::Ptr{UInt8},arg2::Cint,arg3::Ptr{OGRSFDriverH})
     ccall((:OGROpen,libgdal),OGRDataSourceH,(Ptr{UInt8},Cint,Ptr{OGRSFDriverH}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGROpenShared(const char *,
+                  int,
+                  OGRSFDriverH *) -> OGRDataSourceH
+"""
 function OGROpenShared(arg1::Ptr{UInt8},arg2::Cint,arg3::Ptr{OGRSFDriverH})
     ccall((:OGROpenShared,libgdal),OGRDataSourceH,(Ptr{UInt8},Cint,Ptr{OGRSFDriverH}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGRReleaseDataSource(OGRDataSourceH) -> OGRErr
+
+Drop a reference to this datasource, and if the reference count drops to zero close (destroy) the datasource.
+
+### Parameters
+* **hDS**: handle to the data source to release
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function OGRReleaseDataSource(arg1::OGRDataSourceH)
     ccall((:OGRReleaseDataSource,libgdal),OGRErr,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGRRegisterDriver(OGRSFDriverH) -> void
+"""
 function OGRRegisterDriver(arg1::OGRSFDriverH)
     ccall((:OGRRegisterDriver,libgdal),Void,(OGRSFDriverH,),arg1)
 end
 
+
+"""
+    OGRDeregisterDriver(OGRSFDriverH) -> void
+"""
 function OGRDeregisterDriver(arg1::OGRSFDriverH)
     ccall((:OGRDeregisterDriver,libgdal),Void,(OGRSFDriverH,),arg1)
 end
 
+
+"""
+    OGRGetDriverCount(void) -> int
+
+Fetch the number of registered drivers.
+
+### Returns
+the drivers count.
+"""
 function OGRGetDriverCount()
     ccall((:OGRGetDriverCount,libgdal),Cint,())
 end
 
+
+"""
+    OGRGetDriver(int) -> OGRSFDriverH
+
+Fetch the indicated driver.
+
+### Parameters
+* **iDriver**: the driver index, from 0 to GetDriverCount()-1.
+
+### Returns
+handle to the driver, or NULL if iDriver is out of range.
+"""
 function OGRGetDriver(arg1::Cint)
     ccall((:OGRGetDriver,libgdal),OGRSFDriverH,(Cint,),arg1)
 end
 
+
+"""
+    OGRGetDriverByName(const char *) -> OGRSFDriverH
+
+Fetch the indicated driver.
+
+### Parameters
+* **pszName**: the driver name
+
+### Returns
+the driver, or NULL if no driver with that name is found
+"""
 function OGRGetDriverByName(arg1::Ptr{UInt8})
     ccall((:OGRGetDriverByName,libgdal),OGRSFDriverH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OGRGetOpenDSCount(void) -> int
+"""
 function OGRGetOpenDSCount()
     ccall((:OGRGetOpenDSCount,libgdal),Cint,())
 end
 
+
+"""
+    OGRGetOpenDS(int iDS) -> OGRDataSourceH
+"""
 function OGRGetOpenDS(iDS::Cint)
     ccall((:OGRGetOpenDS,libgdal),OGRDataSourceH,(Cint,),iDS)
 end
 
+
+"""
+    OGRRegisterAll(void) -> void
+
+Register all drivers.
+"""
 function OGRRegisterAll()
     ccall((:OGRRegisterAll,libgdal),Void,())
 end
 
+
+"""
+    OGRCleanupAll(void) -> void
+
+Cleanup all OGR related resources.
+"""
 function OGRCleanupAll()
     ccall((:OGRCleanupAll,libgdal),Void,())
 end
 
+
+"""
+    OGR_SM_Create(OGRStyleTableH hStyleTable) -> OGRStyleMgrH
+
+OGRStyleMgr factory.
+
+### Parameters
+* **hStyleTable**: pointer to OGRStyleTable or NULL if not working with a style table.
+
+### Returns
+an handle to the new style manager object.
+"""
 function OGR_SM_Create(hStyleTable::OGRStyleTableH)
     ccall((:OGR_SM_Create,libgdal),OGRStyleMgrH,(OGRStyleTableH,),hStyleTable)
 end
 
+
+"""
+    OGR_SM_Destroy(OGRStyleMgrH hSM) -> void
+
+Destroy Style Manager.
+
+### Parameters
+* **hSM**: handle to the style manager to destroy.
+"""
 function OGR_SM_Destroy(hSM::OGRStyleMgrH)
     ccall((:OGR_SM_Destroy,libgdal),Void,(OGRStyleMgrH,),hSM)
 end
 
+
+"""
+    OGR_SM_InitFromFeature(OGRStyleMgrH hSM,
+                           OGRFeatureH hFeat) -> const char *
+
+Initialize style manager from the style string of a feature.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **hFeat**: handle to the new feature from which to read the style.
+
+### Returns
+a reference to the style string read from the feature, or NULL in case of error.
+"""
 function OGR_SM_InitFromFeature(hSM::OGRStyleMgrH,hFeat::OGRFeatureH)
     ccall((:OGR_SM_InitFromFeature,libgdal),Ptr{UInt8},(OGRStyleMgrH,OGRFeatureH),hSM,hFeat)
 end
 
+
+"""
+    OGR_SM_InitStyleString(OGRStyleMgrH hSM,
+                           const char * pszStyleString) -> int
+
+Initialize style manager from the style string.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleString**: the style string to use (can be NULL).
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function OGR_SM_InitStyleString(hSM::OGRStyleMgrH,pszStyleString::Ptr{UInt8})
     ccall((:OGR_SM_InitStyleString,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8}),hSM,pszStyleString)
 end
 
+
+"""
+    OGR_SM_GetPartCount(OGRStyleMgrH hSM,
+                        const char * pszStyleString) -> int
+
+Get the number of parts in a style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleString**: (optional) the style string on which to operate. If NULL then the current style string stored in the style manager is used.
+
+### Returns
+the number of parts (style tools) in the style.
+"""
 function OGR_SM_GetPartCount(hSM::OGRStyleMgrH,pszStyleString::Ptr{UInt8})
     ccall((:OGR_SM_GetPartCount,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8}),hSM,pszStyleString)
 end
 
+
+"""
+    OGR_SM_GetPart(OGRStyleMgrH hSM,
+                   int nPartId,
+                   const char * pszStyleString) -> OGRStyleToolH
+
+Fetch a part (style tool) from the current style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **nPartId**: the part number (0-based index).
+* **pszStyleString**: (optional) the style string on which to operate. If NULL then the current style string stored in the style manager is used.
+
+### Returns
+OGRStyleToolH of the requested part (style tools) or NULL on error.
+"""
 function OGR_SM_GetPart(hSM::OGRStyleMgrH,nPartId::Cint,pszStyleString::Ptr{UInt8})
     ccall((:OGR_SM_GetPart,libgdal),OGRStyleToolH,(OGRStyleMgrH,Cint,Ptr{UInt8}),hSM,nPartId,pszStyleString)
 end
 
+
+"""
+    OGR_SM_AddPart(OGRStyleMgrH hSM,
+                   OGRStyleToolH hST) -> int
+
+Add a part (style tool) to the current style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **hST**: the style tool defining the part to add.
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function OGR_SM_AddPart(hSM::OGRStyleMgrH,hST::OGRStyleToolH)
     ccall((:OGR_SM_AddPart,libgdal),Cint,(OGRStyleMgrH,OGRStyleToolH),hSM,hST)
 end
 
+
+"""
+    OGR_SM_AddStyle(OGRStyleMgrH hSM,
+                    const char * pszStyleName,
+                    const char * pszStyleString) -> int
+
+Add a style to the current style table.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleName**: the name of the style to add.
+* **pszStyleString**: the style string to use, or NULL to use the style stored in the manager.
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function OGR_SM_AddStyle(hSM::OGRStyleMgrH,pszStyleName::Ptr{UInt8},pszStyleString::Ptr{UInt8})
     ccall((:OGR_SM_AddStyle,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8},Ptr{UInt8}),hSM,pszStyleName,pszStyleString)
 end
 
+
+"""
+    OGR_ST_Create(OGRSTClassId eClassId) -> OGRStyleToolH
+
+OGRStyleTool factory.
+
+### Parameters
+* **eClassId**: subclass of style tool to create. One of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or OGRSTCLabel (4).
+
+### Returns
+an handle to the new style tool object or NULL if the creation failed.
+"""
 function OGR_ST_Create(eClassId::OGRSTClassId)
     ccall((:OGR_ST_Create,libgdal),OGRStyleToolH,(OGRSTClassId,),eClassId)
 end
 
+
+"""
+    OGR_ST_Destroy(OGRStyleToolH hST) -> void
+
+Destroy Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool to destroy.
+"""
 function OGR_ST_Destroy(hST::OGRStyleToolH)
     ccall((:OGR_ST_Destroy,libgdal),Void,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_GetType(OGRStyleToolH hST) -> OGRSTClassId
+
+Determine type of Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style tool type, one of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
+"""
 function OGR_ST_GetType(hST::OGRStyleToolH)
     ccall((:OGR_ST_GetType,libgdal),OGRSTClassId,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_GetUnit(OGRStyleToolH hST) -> OGRSTUnitId
+
+Get Style Tool units.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style tool units.
+"""
 function OGR_ST_GetUnit(hST::OGRStyleToolH)
     ccall((:OGR_ST_GetUnit,libgdal),OGRSTUnitId,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_SetUnit(OGRStyleToolH hST,
+                   OGRSTUnitId eUnit,
+                   double dfGroundPaperScale) -> void
+
+Set Style Tool units.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eUnit**: the new unit.
+* **dfGroundPaperScale**: ground to paper scale factor.
+"""
 function OGR_ST_SetUnit(hST::OGRStyleToolH,eUnit::OGRSTUnitId,dfGroundPaperScale::Cdouble)
     ccall((:OGR_ST_SetUnit,libgdal),Void,(OGRStyleToolH,OGRSTUnitId,Cdouble),hST,eUnit,dfGroundPaperScale)
 end
 
+
+"""
+    OGR_ST_GetParamStr(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> const char *
+
+Get Style Tool parameter value as string.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as string and sets bValueIsNull.
+"""
 function OGR_ST_GetParamStr(hST::OGRStyleToolH,eParam::Cint,bValueIsNull::Ptr{Cint})
     ccall((:OGR_ST_GetParamStr,libgdal),Ptr{UInt8},(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull)
 end
 
+
+"""
+    OGR_ST_GetParamNum(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> int
+
+Get Style Tool parameter value as an integer.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as integer and sets bValueIsNull.
+"""
 function OGR_ST_GetParamNum(hST::OGRStyleToolH,eParam::Cint,bValueIsNull::Ptr{Cint})
     ccall((:OGR_ST_GetParamNum,libgdal),Cint,(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull)
 end
 
+
+"""
+    OGR_ST_GetParamDbl(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> double
+
+Get Style Tool parameter value as a double.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as double and sets bValueIsNull.
+"""
 function OGR_ST_GetParamDbl(hST::OGRStyleToolH,eParam::Cint,bValueIsNull::Ptr{Cint})
     ccall((:OGR_ST_GetParamDbl,libgdal),Cdouble,(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull)
 end
 
+
+"""
+    OGR_ST_SetParamStr(OGRStyleToolH hST,
+                       int eParam,
+                       const char * pszValue) -> void
+
+Set Style Tool parameter value from a string.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **pszValue**: the new parameter value
+"""
 function OGR_ST_SetParamStr(hST::OGRStyleToolH,eParam::Cint,pszValue::Ptr{UInt8})
     ccall((:OGR_ST_SetParamStr,libgdal),Void,(OGRStyleToolH,Cint,Ptr{UInt8}),hST,eParam,pszValue)
 end
 
+
+"""
+    OGR_ST_SetParamNum(OGRStyleToolH hST,
+                       int eParam,
+                       int nValue) -> void
+
+Set Style Tool parameter value from an integer.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **nValue**: the new parameter value
+"""
 function OGR_ST_SetParamNum(hST::OGRStyleToolH,eParam::Cint,nValue::Cint)
     ccall((:OGR_ST_SetParamNum,libgdal),Void,(OGRStyleToolH,Cint,Cint),hST,eParam,nValue)
 end
 
+
+"""
+    OGR_ST_SetParamDbl(OGRStyleToolH hST,
+                       int eParam,
+                       double dfValue) -> void
+
+Set Style Tool parameter value from a double.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **dfValue**: the new parameter value
+"""
 function OGR_ST_SetParamDbl(hST::OGRStyleToolH,eParam::Cint,dfValue::Cdouble)
     ccall((:OGR_ST_SetParamDbl,libgdal),Void,(OGRStyleToolH,Cint,Cdouble),hST,eParam,dfValue)
 end
 
+
+"""
+    OGR_ST_GetStyleString(OGRStyleToolH hST) -> const char *
+
+Get the style string for this Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style string for this style tool or "" if the hST is invalid.
+"""
 function OGR_ST_GetStyleString(hST::OGRStyleToolH)
     ccall((:OGR_ST_GetStyleString,libgdal),Ptr{UInt8},(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_GetRGBFromString(OGRStyleToolH hST,
+                            const char * pszColor,
+                            int * pnRed,
+                            int * pnGreen,
+                            int * pnBlue,
+                            int * pnAlpha) -> int
+
+Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **pszColor**: the color to parse
+* **pnRed**: pointer to an int in which the red value will be returned
+* **pnGreen**: pointer to an int in which the green value will be returned
+* **pnBlue**: pointer to an int in which the blue value will be returned
+* **pnAlpha**: pointer to an int in which the (optional) alpha value will be returned
+
+### Returns
+TRUE if the color could be succesfully parsed, or FALSE in case of errors.
+"""
 function OGR_ST_GetRGBFromString(hST::OGRStyleToolH,pszColor::Ptr{UInt8},pnRed::Ptr{Cint},pnGreen::Ptr{Cint},pnBlue::Ptr{Cint},pnAlpha::Ptr{Cint})
     ccall((:OGR_ST_GetRGBFromString,libgdal),Cint,(OGRStyleToolH,Ptr{UInt8},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),hST,pszColor,pnRed,pnGreen,pnBlue,pnAlpha)
 end
 
+
+"""
+    OGR_STBL_Create(void) -> OGRStyleTableH
+
+OGRStyleTable factory.
+
+### Returns
+an handle to the new style table object.
+"""
 function OGR_STBL_Create()
     ccall((:OGR_STBL_Create,libgdal),OGRStyleTableH,())
 end
 
+
+"""
+    OGR_STBL_Destroy(OGRStyleTableH hSTBL) -> void
+
+Destroy Style Table.
+
+### Parameters
+* **hSTBL**: handle to the style table to destroy.
+"""
 function OGR_STBL_Destroy(hSTBL::OGRStyleTableH)
     ccall((:OGR_STBL_Destroy,libgdal),Void,(OGRStyleTableH,),hSTBL)
 end
 
+
+"""
+    OGR_STBL_AddStyle(OGRStyleTableH hStyleTable,
+                      const char * pszName,
+                      const char * pszStyleString) -> int
+
+Add a new style in the table.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszName**: the name the style to add.
+* **pszStyleString**: the style string to add.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function OGR_STBL_AddStyle(hStyleTable::OGRStyleTableH,pszName::Ptr{UInt8},pszStyleString::Ptr{UInt8})
     ccall((:OGR_STBL_AddStyle,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8},Ptr{UInt8}),hStyleTable,pszName,pszStyleString)
 end
 
+
+"""
+    OGR_STBL_SaveStyleTable(OGRStyleTableH hStyleTable,
+                            const char * pszFilename) -> int
+
+Save a style table to a file.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszFilename**: the name of the file to save to.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function OGR_STBL_SaveStyleTable(hStyleTable::OGRStyleTableH,pszFilename::Ptr{UInt8})
     ccall((:OGR_STBL_SaveStyleTable,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszFilename)
 end
 
+
+"""
+    OGR_STBL_LoadStyleTable(OGRStyleTableH hStyleTable,
+                            const char * pszFilename) -> int
+
+Load a style table from a file.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszFilename**: the name of the file to load from.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function OGR_STBL_LoadStyleTable(hStyleTable::OGRStyleTableH,pszFilename::Ptr{UInt8})
     ccall((:OGR_STBL_LoadStyleTable,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszFilename)
 end
 
+
+"""
+    OGR_STBL_Find(OGRStyleTableH hStyleTable,
+                  const char * pszName) -> const char *
+
+Get a style string by name.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszName**: the name of the style string to find.
+
+### Returns
+the style string matching the name or NULL if not found or error.
+"""
 function OGR_STBL_Find(hStyleTable::OGRStyleTableH,pszName::Ptr{UInt8})
     ccall((:OGR_STBL_Find,libgdal),Ptr{UInt8},(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszName)
 end
 
+
+"""
+    OGR_STBL_ResetStyleStringReading(OGRStyleTableH hStyleTable) -> void
+
+Reset the next style pointer to 0.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+"""
 function OGR_STBL_ResetStyleStringReading(hStyleTable::OGRStyleTableH)
     ccall((:OGR_STBL_ResetStyleStringReading,libgdal),Void,(OGRStyleTableH,),hStyleTable)
 end
 
+
+"""
+    OGR_STBL_GetNextStyle(OGRStyleTableH hStyleTable) -> const char *
+
+Get the next style string from the table.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+
+### Returns
+the next style string or NULL on error.
+"""
 function OGR_STBL_GetNextStyle(hStyleTable::OGRStyleTableH)
     ccall((:OGR_STBL_GetNextStyle,libgdal),Ptr{UInt8},(OGRStyleTableH,),hStyleTable)
 end
 
+
+"""
+    OGR_STBL_GetLastStyleName(OGRStyleTableH hStyleTable) -> const char *
+
+Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+
+### Returns
+the Name of the last style string or NULL on error.
+"""
 function OGR_STBL_GetLastStyleName(hStyleTable::OGRStyleTableH)
     ccall((:OGR_STBL_GetLastStyleName,libgdal),Ptr{UInt8},(OGRStyleTableH,),hStyleTable)
 end

--- a/src/C/ogr_core.jl
+++ b/src/C/ogr_core.jl
@@ -2,90 +2,316 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    OGRMalloc(size_t) -> void *
+"""
 function OGRMalloc(arg1::Csize_t)
     ccall((:OGRMalloc,libgdal),Ptr{Void},(Csize_t,),arg1)
 end
 
+
+"""
+    OGRCalloc(size_t,
+              size_t) -> void *
+"""
 function OGRCalloc(arg1::Csize_t,arg2::Csize_t)
     ccall((:OGRCalloc,libgdal),Ptr{Void},(Csize_t,Csize_t),arg1,arg2)
 end
 
+
+"""
+    OGRRealloc(void *,
+               size_t) -> void *
+"""
 function OGRRealloc(arg1::Ptr{Void},arg2::Csize_t)
     ccall((:OGRRealloc,libgdal),Ptr{Void},(Ptr{Void},Csize_t),arg1,arg2)
 end
 
+
+"""
+    OGRStrdup(const char *) -> char *
+"""
 function OGRStrdup(arg1::Ptr{UInt8})
     ccall((:OGRStrdup,libgdal),Ptr{UInt8},(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OGRFree(void *) -> void
+"""
 function OGRFree(arg1::Ptr{Void})
     ccall((:OGRFree,libgdal),Void,(Ptr{Void},),arg1)
 end
 
+
+"""
+    OGRGeometryTypeToName(OGRwkbGeometryType eType) -> const char *
+
+Fetch a human readable name corresponding to an OGRwkbGeometryType value.
+
+### Parameters
+* **eType**: the geometry type.
+
+### Returns
+internal human readable string, or NULL on failure.
+"""
 function OGRGeometryTypeToName(eType::OGRwkbGeometryType)
     ccall((:OGRGeometryTypeToName,libgdal),Ptr{UInt8},(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGRMergeGeometryTypes(OGRwkbGeometryType eMain,
+                          OGRwkbGeometryType eExtra) -> OGRwkbGeometryType
+
+Find common geometry type.
+
+### Parameters
+* **eMain**: the first input geometry type.
+* **eExtra**: the second input geometry type.
+
+### Returns
+the merged geometry type.
+"""
 function OGRMergeGeometryTypes(eMain::OGRwkbGeometryType,eExtra::OGRwkbGeometryType)
     ccall((:OGRMergeGeometryTypes,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,OGRwkbGeometryType),eMain,eExtra)
 end
 
+
+"""
+    OGRMergeGeometryTypesEx(OGRwkbGeometryType eMain,
+                            OGRwkbGeometryType eExtra,
+                            int bAllowPromotingToCurves) -> OGRwkbGeometryType
+
+Find common geometry type.
+
+### Parameters
+* **eMain**: the first input geometry type.
+* **eExtra**: the second input geometry type.
+* **bAllowPromotingToCurves**: determine if promotion to curve type must be done.
+
+### Returns
+the merged geometry type.
+"""
 function OGRMergeGeometryTypesEx(eMain::OGRwkbGeometryType,eExtra::OGRwkbGeometryType,bAllowPromotingToCurves::Cint)
     ccall((:OGRMergeGeometryTypesEx,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,OGRwkbGeometryType,Cint),eMain,eExtra,bAllowPromotingToCurves)
 end
 
+
+"""
+    OGR_GT_Flatten(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the 2D geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+2D geometry type corresponding to the passed geometry type.
+"""
 function OGR_GT_Flatten(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_Flatten,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGR_GT_SetZ(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the 3D geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+3D geometry type corresponding to the passed geometry type.
+"""
 function OGR_GT_SetZ(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_SetZ,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGR_GT_SetModifier(OGRwkbGeometryType eType,
+                       int bSetZ,
+                       int bSetM) -> OGRwkbGeometryType
+"""
 function OGR_GT_SetModifier(eType::OGRwkbGeometryType,bSetZ::Cint,bSetM::Cint)
     ccall((:OGR_GT_SetModifier,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,Cint,Cint),eType,bSetZ,bSetM)
 end
 
+
+"""
+    OGR_GT_HasZ(OGRwkbGeometryType eType) -> int
+
+Return if the geometry type is a 3D geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+TRUE if the geometry type is a 3D geometry type.
+"""
 function OGR_GT_HasZ(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_HasZ,libgdal),Cint,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGR_GT_IsSubClassOf(OGRwkbGeometryType eType,
+                        OGRwkbGeometryType eSuperType) -> int
+
+Returns if a type is a subclass of another one.
+
+### Parameters
+* **eType**: Type.
+* **eSuperType**: Super type
+
+### Returns
+TRUE if eType is a subclass of eSuperType.
+"""
 function OGR_GT_IsSubClassOf(eType::OGRwkbGeometryType,eSuperType::OGRwkbGeometryType)
     ccall((:OGR_GT_IsSubClassOf,libgdal),Cint,(OGRwkbGeometryType,OGRwkbGeometryType),eType,eSuperType)
 end
 
+
+"""
+    OGR_GT_IsCurve(OGRwkbGeometryType) -> int
+
+Return if a geometry type is an instance of Curve.
+
+### Parameters
+* **eGeomType**: the geometry type
+
+### Returns
+TRUE if the geometry type is an instance of Curve
+"""
 function OGR_GT_IsCurve(arg1::OGRwkbGeometryType)
     ccall((:OGR_GT_IsCurve,libgdal),Cint,(OGRwkbGeometryType,),arg1)
 end
 
+
+"""
+    OGR_GT_IsSurface(OGRwkbGeometryType) -> int
+
+Return if a geometry type is an instance of Surface.
+
+### Parameters
+* **eGeomType**: the geometry type
+
+### Returns
+TRUE if the geometry type is an instance of Surface
+"""
 function OGR_GT_IsSurface(arg1::OGRwkbGeometryType)
     ccall((:OGR_GT_IsSurface,libgdal),Cint,(OGRwkbGeometryType,),arg1)
 end
 
+
+"""
+    OGR_GT_IsNonLinear(OGRwkbGeometryType) -> int
+
+Return if a geometry type is a non-linear geometry type.
+
+### Parameters
+* **eGeomType**: the geometry type
+
+### Returns
+TRUE if the geometry type is a non-linear geometry type.
+"""
 function OGR_GT_IsNonLinear(arg1::OGRwkbGeometryType)
     ccall((:OGR_GT_IsNonLinear,libgdal),Cint,(OGRwkbGeometryType,),arg1)
 end
 
+
+"""
+    OGR_GT_GetCollection(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the collection type that can contain the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+the collection type that can contain the passed geometry type or wkbUnknown
+"""
 function OGR_GT_GetCollection(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_GetCollection,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGR_GT_GetCurve(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the curve geometry type that can contain the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+the curve type that can contain the passed geometry type
+"""
 function OGR_GT_GetCurve(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_GetCurve,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGR_GT_GetLinear(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the non-curve geometry type that can contain the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+the non-curve type that can contain the passed geometry type
+"""
 function OGR_GT_GetLinear(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_GetLinear,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
 end
 
+
+"""
+    OGRParseDate(const char * pszInput,
+                 OGRField * psOutput,
+                 int nOptions) -> int
+"""
 function OGRParseDate(pszInput::Ptr{UInt8},psOutput::Ptr{OGRField},nOptions::Cint)
     ccall((:OGRParseDate,libgdal),Cint,(Ptr{UInt8},Ptr{OGRField},Cint),pszInput,psOutput,nOptions)
 end
 
+
+"""
+    GDALVersionInfo(const char *) -> const char *
+
+Get runtime version information.
+
+### Parameters
+* **pszRequest**: the type of version info desired, as listed above.
+
+### Returns
+an internal string containing the requested information.
+"""
 function GDALVersionInfo(arg1::Ptr{UInt8})
     ccall((:GDALVersionInfo,libgdal),Ptr{UInt8},(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALCheckVersion(int nVersionMajor,
+                     int nVersionMinor,
+                     const char * pszCallingComponentName) -> int
+
+Return TRUE if GDAL library version at runtime matches nVersionMajor.nVersionMinor.
+
+### Parameters
+* **nVersionMajor**: Major version to be tested against
+* **nVersionMinor**: Minor version to be tested against
+* **pszCallingComponentName**: If not NULL, in case of version mismatch, the method will issue a failure mentionning the name of the calling component.
+
+### Returns
+TRUE if GDAL library version at runtime matches nVersionMajor.nVersionMinor, FALSE otherwise.
+"""
 function GDALCheckVersion(nVersionMajor::Cint,nVersionMinor::Cint,pszCallingComponentName::Ptr{UInt8})
     ccall((:GDALCheckVersion,libgdal),Cint,(Cint,Cint,Ptr{UInt8}),nVersionMajor,nVersionMinor,pszCallingComponentName)
 end

--- a/src/C/ogr_srs_api.jl
+++ b/src/C/ogr_srs_api.jl
@@ -2,578 +2,1831 @@
 # Automatically generated using Clang.jl wrap_c, version 0.0.0
 
 
+
+"""
+    OSRAxisEnumToName(OGRAxisOrientation eOrientation) -> const char *
+
+Return the string representation for the OGRAxisOrientation enumeration.
+
+### Returns
+an internal string
+"""
 function OSRAxisEnumToName(eOrientation::OGRAxisOrientation)
     ccall((:OSRAxisEnumToName,libgdal),Ptr{UInt8},(OGRAxisOrientation,),eOrientation)
 end
 
+
+"""
+    OSRNewSpatialReference(const char *) -> OGRSpatialReferenceH
+
+Constructor.
+"""
 function OSRNewSpatialReference(arg1::Ptr{UInt8})
     ccall((:OSRNewSpatialReference,libgdal),OGRSpatialReferenceH,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    OSRCloneGeogCS(OGRSpatialReferenceH) -> OGRSpatialReferenceH
+
+Make a duplicate of the GEOGCS node of this OGRSpatialReference object.
+"""
 function OSRCloneGeogCS(arg1::OGRSpatialReferenceH)
     ccall((:OSRCloneGeogCS,libgdal),OGRSpatialReferenceH,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRClone(OGRSpatialReferenceH) -> OGRSpatialReferenceH
+
+Make a duplicate of this OGRSpatialReference.
+"""
 function OSRClone(arg1::OGRSpatialReferenceH)
     ccall((:OSRClone,libgdal),OGRSpatialReferenceH,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRDestroySpatialReference(OGRSpatialReferenceH) -> void
+
+OGRSpatialReference destructor.
+
+### Parameters
+* **hSRS**: the object to delete
+"""
 function OSRDestroySpatialReference(arg1::OGRSpatialReferenceH)
     ccall((:OSRDestroySpatialReference,libgdal),Void,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRReference(OGRSpatialReferenceH) -> int
+
+Increments the reference count by one.
+"""
 function OSRReference(arg1::OGRSpatialReferenceH)
     ccall((:OSRReference,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRDereference(OGRSpatialReferenceH) -> int
+
+Decrements the reference count by one.
+"""
 function OSRDereference(arg1::OGRSpatialReferenceH)
     ccall((:OSRDereference,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRRelease(OGRSpatialReferenceH) -> void
+
+Decrements the reference count by one, and destroy if zero.
+"""
 function OSRRelease(arg1::OGRSpatialReferenceH)
     ccall((:OSRRelease,libgdal),Void,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRValidate(OGRSpatialReferenceH) -> OGRErr
+
+Validate SRS tokens.
+"""
 function OSRValidate(arg1::OGRSpatialReferenceH)
     ccall((:OSRValidate,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRFixupOrdering(OGRSpatialReferenceH) -> OGRErr
+
+Correct parameter ordering to match CT Specification.
+"""
 function OSRFixupOrdering(arg1::OGRSpatialReferenceH)
     ccall((:OSRFixupOrdering,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRFixup(OGRSpatialReferenceH) -> OGRErr
+
+Fixup as needed.
+"""
 function OSRFixup(arg1::OGRSpatialReferenceH)
     ccall((:OSRFixup,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRStripCTParms(OGRSpatialReferenceH) -> OGRErr
+
+Strip OGC CT Parameters.
+"""
 function OSRStripCTParms(arg1::OGRSpatialReferenceH)
     ccall((:OSRStripCTParms,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRImportFromEPSG(OGRSpatialReferenceH hSRS,
+                      int nCode) -> OGRErr
+
+Initialize SRS based on EPSG GCS or PCS code.
+"""
 function OSRImportFromEPSG(arg1::OGRSpatialReferenceH,arg2::Cint)
     ccall((:OSRImportFromEPSG,libgdal),OGRErr,(OGRSpatialReferenceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromEPSGA(OGRSpatialReferenceH hSRS,
+                       int nCode) -> OGRErr
+
+Initialize SRS based on EPSG GCS or PCS code.
+"""
 function OSRImportFromEPSGA(arg1::OGRSpatialReferenceH,arg2::Cint)
     ccall((:OSRImportFromEPSGA,libgdal),OGRErr,(OGRSpatialReferenceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromWkt(OGRSpatialReferenceH,
+                     char **) -> OGRErr
+
+Import from WKT string.
+"""
 function OSRImportFromWkt(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRImportFromWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromProj4(OGRSpatialReferenceH,
+                       const char *) -> OGRErr
+
+Import PROJ.4 coordinate string.
+"""
 function OSRImportFromProj4(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8})
     ccall((:OSRImportFromProj4,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromESRI(OGRSpatialReferenceH,
+                      char **) -> OGRErr
+
+Import coordinate system from ESRI .prj format(s).
+"""
 function OSRImportFromESRI(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRImportFromESRI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromPCI(OGRSpatialReferenceH hSRS,
+                     const char *,
+                     const char *,
+                     double *) -> OGRErr
+
+Import coordinate system from PCI projection definition.
+"""
 function OSRImportFromPCI(hSRS::OGRSpatialReferenceH,arg1::Ptr{UInt8},arg2::Ptr{UInt8},arg3::Ptr{Cdouble})
     ccall((:OSRImportFromPCI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),hSRS,arg1,arg2,arg3)
 end
 
+
+"""
+    OSRImportFromUSGS(OGRSpatialReferenceH,
+                      long,
+                      long,
+                      double *,
+                      long) -> OGRErr
+
+Import coordinate system from USGS projection definition.
+"""
 function OSRImportFromUSGS(arg1::OGRSpatialReferenceH,arg2::Clong,arg3::Clong,arg4::Ptr{Cdouble},arg5::Clong)
     ccall((:OSRImportFromUSGS,libgdal),OGRErr,(OGRSpatialReferenceH,Clong,Clong,Ptr{Cdouble},Clong),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRImportFromXML(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Import coordinate system from XML format (GML only currently).
+"""
 function OSRImportFromXML(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8})
     ccall((:OSRImportFromXML,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromDict(OGRSpatialReferenceH,
+                      const char *,
+                      const char *) -> OGRErr
+"""
 function OSRImportFromDict(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Ptr{UInt8})
     ccall((:OSRImportFromDict,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRImportFromPanorama(OGRSpatialReferenceH,
+                          long,
+                          long,
+                          long,
+                          double *) -> OGRErr
+"""
 function OSRImportFromPanorama(arg1::OGRSpatialReferenceH,arg2::Clong,arg3::Clong,arg4::Clong,arg5::Ptr{Cdouble})
     ccall((:OSRImportFromPanorama,libgdal),OGRErr,(OGRSpatialReferenceH,Clong,Clong,Clong,Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRImportFromOzi(OGRSpatialReferenceH,
+                     const char *const *) -> OGRErr
+
+Import coordinate system from OziExplorer projection definition.
+
+### Parameters
+* **hSRS**: spatial reference object.
+* **papszLines**: Map file lines. This is an array of strings containing the whole OziExplorer .MAP file. The array is terminated by a NULL pointer.
+
+### Returns
+OGRERR_NONE on success or an error code in case of failure.
+"""
 function OSRImportFromOzi(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRImportFromOzi,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromMICoordSys(OGRSpatialReferenceH,
+                            const char *) -> OGRErr
+
+Import Mapinfo style CoordSys definition.
+"""
 function OSRImportFromMICoordSys(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8})
     ccall((:OSRImportFromMICoordSys,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromERM(OGRSpatialReferenceH,
+                     const char *,
+                     const char *,
+                     const char *) -> OGRErr
+
+Create OGR WKT from ERMapper projection definitions.
+"""
 function OSRImportFromERM(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Ptr{UInt8},arg4::Ptr{UInt8})
     ccall((:OSRImportFromERM,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRImportFromUrl(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Set spatial reference from a URL.
+"""
 function OSRImportFromUrl(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8})
     ccall((:OSRImportFromUrl,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToWkt(OGRSpatialReferenceH,
+                   char **) -> OGRErr
+
+Convert this SRS into WKT format.
+"""
 function OSRExportToWkt(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRExportToWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToPrettyWkt(OGRSpatialReferenceH,
+                         char **,
+                         int) -> OGRErr
+
+Convert this SRS into a a nicely formatted WKT string for display to a person.
+"""
 function OSRExportToPrettyWkt(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}},arg3::Cint)
     ccall((:OSRExportToPrettyWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRExportToProj4(OGRSpatialReferenceH,
+                     char **) -> OGRErr
+
+Export coordinate system in PROJ.4 format.
+"""
 function OSRExportToProj4(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRExportToProj4,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToPCI(OGRSpatialReferenceH,
+                   char **,
+                   char **,
+                   double **) -> OGRErr
+
+Export coordinate system in PCI projection definition.
+"""
 function OSRExportToPCI(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}},arg3::Ptr{Ptr{UInt8}},arg4::Ptr{Ptr{Cdouble}})
     ccall((:OSRExportToPCI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Ptr{Cdouble}}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRExportToUSGS(OGRSpatialReferenceH,
+                    long *,
+                    long *,
+                    double **,
+                    long *) -> OGRErr
+
+Export coordinate system in USGS GCTP projection definition.
+"""
 function OSRExportToUSGS(arg1::OGRSpatialReferenceH,arg2::Ptr{Clong},arg3::Ptr{Clong},arg4::Ptr{Ptr{Cdouble}},arg5::Ptr{Clong})
     ccall((:OSRExportToUSGS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Clong},Ptr{Clong},Ptr{Ptr{Cdouble}},Ptr{Clong}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRExportToXML(OGRSpatialReferenceH,
+                   char **,
+                   const char *) -> OGRErr
+
+Export coordinate system in XML format.
+"""
 function OSRExportToXML(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}},arg3::Ptr{UInt8})
     ccall((:OSRExportToXML,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRExportToPanorama(OGRSpatialReferenceH,
+                        long *,
+                        long *,
+                        long *,
+                        long *,
+                        double *) -> OGRErr
+"""
 function OSRExportToPanorama(arg1::OGRSpatialReferenceH,arg2::Ptr{Clong},arg3::Ptr{Clong},arg4::Ptr{Clong},arg5::Ptr{Clong},arg6::Ptr{Cdouble})
     ccall((:OSRExportToPanorama,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OSRExportToMICoordSys(OGRSpatialReferenceH,
+                          char **) -> OGRErr
+
+Export coordinate system in Mapinfo style CoordSys format.
+"""
 function OSRExportToMICoordSys(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRExportToMICoordSys,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToERM(OGRSpatialReferenceH,
+                   char *,
+                   char *,
+                   char *) -> OGRErr
+
+Convert coordinate system to ERMapper format.
+"""
 function OSRExportToERM(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Ptr{UInt8},arg4::Ptr{UInt8})
     ccall((:OSRExportToERM,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRMorphToESRI(OGRSpatialReferenceH) -> OGRErr
+
+Convert in place to ESRI WKT format.
+"""
 function OSRMorphToESRI(arg1::OGRSpatialReferenceH)
     ccall((:OSRMorphToESRI,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRMorphFromESRI(OGRSpatialReferenceH) -> OGRErr
+
+Convert in place from ESRI WKT format.
+"""
 function OSRMorphFromESRI(arg1::OGRSpatialReferenceH)
     ccall((:OSRMorphFromESRI,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRSetAttrValue(OGRSpatialReferenceH hSRS,
+                    const char * pszNodePath,
+                    const char * pszNewNodeValue) -> OGRErr
+
+Set attribute value in spatial reference.
+"""
 function OSRSetAttrValue(hSRS::OGRSpatialReferenceH,pszNodePath::Ptr{UInt8},pszNewNodeValue::Ptr{UInt8})
     ccall((:OSRSetAttrValue,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8}),hSRS,pszNodePath,pszNewNodeValue)
 end
 
+
+"""
+    OSRGetAttrValue(OGRSpatialReferenceH hSRS,
+                    const char * pszName,
+                    int iChild) -> const char *
+
+Fetch indicated attribute of named node.
+"""
 function OSRGetAttrValue(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8},iChild::Cint)
     ccall((:OSRGetAttrValue,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8},Cint),hSRS,pszName,iChild)
 end
 
+
+"""
+    OSRSetAngularUnits(OGRSpatialReferenceH,
+                       const char *,
+                       double) -> OGRErr
+
+Set the angular units for the geographic coordinate system.
+"""
 function OSRSetAngularUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Cdouble)
     ccall((:OSRSetAngularUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetAngularUnits(OGRSpatialReferenceH,
+                       char **) -> double
+
+Fetch angular geographic coordinate system units.
+"""
 function OSRGetAngularUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRGetAngularUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRSetLinearUnits(OGRSpatialReferenceH,
+                      const char *,
+                      double) -> OGRErr
+
+Set the linear units for the projection.
+"""
 function OSRSetLinearUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Cdouble)
     ccall((:OSRSetLinearUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRSetTargetLinearUnits(OGRSpatialReferenceH,
+                            const char *,
+                            const char *,
+                            double) -> OGRErr
+
+Set the linear units for the target node.
+"""
 function OSRSetTargetLinearUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Ptr{UInt8},arg4::Cdouble)
     ccall((:OSRSetTargetLinearUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRSetLinearUnitsAndUpdateParameters(OGRSpatialReferenceH,
+                                         const char *,
+                                         double) -> OGRErr
+
+Set the linear units for the projection.
+"""
 function OSRSetLinearUnitsAndUpdateParameters(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Cdouble)
     ccall((:OSRSetLinearUnitsAndUpdateParameters,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetLinearUnits(OGRSpatialReferenceH,
+                      char **) -> double
+
+Fetch linear projection units.
+"""
 function OSRGetLinearUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRGetLinearUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRGetTargetLinearUnits(OGRSpatialReferenceH,
+                            const char *,
+                            char **) -> double
+
+Fetch linear projection units.
+"""
 function OSRGetTargetLinearUnits(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Ptr{Ptr{UInt8}})
     ccall((:OSRGetTargetLinearUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetPrimeMeridian(OGRSpatialReferenceH,
+                        char **) -> double
+
+Fetch prime meridian info.
+"""
 function OSRGetPrimeMeridian(arg1::OGRSpatialReferenceH,arg2::Ptr{Ptr{UInt8}})
     ccall((:OSRGetPrimeMeridian,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRIsGeographic(OGRSpatialReferenceH) -> int
+
+Check if geographic coordinate system.
+"""
 function OSRIsGeographic(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsGeographic,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsLocal(OGRSpatialReferenceH) -> int
+
+Check if local coordinate system.
+"""
 function OSRIsLocal(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsLocal,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsProjected(OGRSpatialReferenceH) -> int
+
+Check if projected coordinate system.
+"""
 function OSRIsProjected(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsProjected,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsCompound(OGRSpatialReferenceH) -> int
+
+Check if the coordinate system is compound.
+"""
 function OSRIsCompound(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsCompound,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsGeocentric(OGRSpatialReferenceH) -> int
+
+Check if geocentric coordinate system.
+"""
 function OSRIsGeocentric(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsGeocentric,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsVertical(OGRSpatialReferenceH) -> int
+
+Check if vertical coordinate system.
+"""
 function OSRIsVertical(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsVertical,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsSameGeogCS(OGRSpatialReferenceH,
+                    OGRSpatialReferenceH) -> int
+
+Do the GeogCS'es match?
+"""
 function OSRIsSameGeogCS(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSameGeogCS,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRIsSameVertCS(OGRSpatialReferenceH,
+                    OGRSpatialReferenceH) -> int
+
+Do the VertCS'es match?
+"""
 function OSRIsSameVertCS(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSameVertCS,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRIsSame(OGRSpatialReferenceH,
+              OGRSpatialReferenceH) -> int
+
+Do these two spatial references describe the same system ?
+"""
 function OSRIsSame(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSame,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRSetLocalCS(OGRSpatialReferenceH hSRS,
+                  const char * pszName) -> OGRErr
+
+Set the user visible LOCAL_CS name.
+"""
 function OSRSetLocalCS(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8})
     ccall((:OSRSetLocalCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetProjCS(OGRSpatialReferenceH hSRS,
+                 const char * pszName) -> OGRErr
+
+Set the user visible PROJCS name.
+"""
 function OSRSetProjCS(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8})
     ccall((:OSRSetProjCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetGeocCS(OGRSpatialReferenceH hSRS,
+                 const char * pszName) -> OGRErr
+
+Set the user visible PROJCS name.
+"""
 function OSRSetGeocCS(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8})
     ccall((:OSRSetGeocCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetWellKnownGeogCS(OGRSpatialReferenceH hSRS,
+                          const char * pszName) -> OGRErr
+
+Set a GeogCS based on well known name.
+"""
 function OSRSetWellKnownGeogCS(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8})
     ccall((:OSRSetWellKnownGeogCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetFromUserInput(OGRSpatialReferenceH hSRS,
+                        const char *) -> OGRErr
+
+Set spatial reference from various text formats.
+"""
 function OSRSetFromUserInput(hSRS::OGRSpatialReferenceH,arg1::Ptr{UInt8})
     ccall((:OSRSetFromUserInput,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,arg1)
 end
 
+
+"""
+    OSRCopyGeogCSFrom(OGRSpatialReferenceH hSRS,
+                      OGRSpatialReferenceH hSrcSRS) -> OGRErr
+
+Copy GEOGCS from another OGRSpatialReference.
+"""
 function OSRCopyGeogCSFrom(hSRS::OGRSpatialReferenceH,hSrcSRS::OGRSpatialReferenceH)
     ccall((:OSRCopyGeogCSFrom,libgdal),OGRErr,(OGRSpatialReferenceH,OGRSpatialReferenceH),hSRS,hSrcSRS)
 end
 
+
+"""
+    OSRSetTOWGS84(OGRSpatialReferenceH hSRS,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double) -> OGRErr
+
+Set the Bursa-Wolf conversion to WGS84.
+"""
 function OSRSetTOWGS84(hSRS::OGRSpatialReferenceH,arg1::Cdouble,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble,arg5::Cdouble,arg6::Cdouble,arg7::Cdouble)
     ccall((:OSRSetTOWGS84,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,arg1,arg2,arg3,arg4,arg5,arg6,arg7)
 end
 
+
+"""
+    OSRGetTOWGS84(OGRSpatialReferenceH hSRS,
+                  double *,
+                  int) -> OGRErr
+
+Fetch TOWGS84 parameters, if available.
+"""
 function OSRGetTOWGS84(hSRS::OGRSpatialReferenceH,arg1::Ptr{Cdouble},arg2::Cint)
     ccall((:OSRGetTOWGS84,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Cdouble},Cint),hSRS,arg1,arg2)
 end
 
+
+"""
+    OSRSetCompoundCS(OGRSpatialReferenceH hSRS,
+                     const char * pszName,
+                     OGRSpatialReferenceH hHorizSRS,
+                     OGRSpatialReferenceH hVertSRS) -> OGRErr
+
+Setup a compound coordinate system.
+"""
 function OSRSetCompoundCS(hSRS::OGRSpatialReferenceH,pszName::Ptr{UInt8},hHorizSRS::OGRSpatialReferenceH,hVertSRS::OGRSpatialReferenceH)
     ccall((:OSRSetCompoundCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},OGRSpatialReferenceH,OGRSpatialReferenceH),hSRS,pszName,hHorizSRS,hVertSRS)
 end
 
+
+"""
+    OSRSetGeogCS(OGRSpatialReferenceH hSRS,
+                 const char * pszGeogName,
+                 const char * pszDatumName,
+                 const char * pszEllipsoidName,
+                 double dfSemiMajor,
+                 double dfInvFlattening,
+                 const char * pszPMName,
+                 double dfPMOffset,
+                 const char * pszUnits,
+                 double dfConvertToRadians) -> OGRErr
+
+Set geographic coordinate system.
+"""
 function OSRSetGeogCS(hSRS::OGRSpatialReferenceH,pszGeogName::Ptr{UInt8},pszDatumName::Ptr{UInt8},pszEllipsoidName::Ptr{UInt8},dfSemiMajor::Cdouble,dfInvFlattening::Cdouble,pszPMName::Ptr{UInt8},dfPMOffset::Cdouble,pszUnits::Ptr{UInt8},dfConvertToRadians::Cdouble)
     ccall((:OSRSetGeogCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Cdouble,Cdouble,Ptr{UInt8},Cdouble,Ptr{UInt8},Cdouble),hSRS,pszGeogName,pszDatumName,pszEllipsoidName,dfSemiMajor,dfInvFlattening,pszPMName,dfPMOffset,pszUnits,dfConvertToRadians)
 end
 
+
+"""
+    OSRSetVertCS(OGRSpatialReferenceH hSRS,
+                 const char * pszVertCSName,
+                 const char * pszVertDatumName,
+                 int nVertDatumType) -> OGRErr
+
+Setup the vertical coordinate system.
+"""
 function OSRSetVertCS(hSRS::OGRSpatialReferenceH,pszVertCSName::Ptr{UInt8},pszVertDatumName::Ptr{UInt8},nVertDatumType::Cint)
     ccall((:OSRSetVertCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cint),hSRS,pszVertCSName,pszVertDatumName,nVertDatumType)
 end
 
+
+"""
+    OSRGetSemiMajor(OGRSpatialReferenceH,
+                    OGRErr *) -> double
+
+Get spheroid semi major axis.
+"""
 function OSRGetSemiMajor(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetSemiMajor,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRGetSemiMinor(OGRSpatialReferenceH,
+                    OGRErr *) -> double
+
+Get spheroid semi minor axis.
+"""
 function OSRGetSemiMinor(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetSemiMinor,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRGetInvFlattening(OGRSpatialReferenceH,
+                        OGRErr *) -> double
+
+Get spheroid inverse flattening.
+"""
 function OSRGetInvFlattening(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetInvFlattening,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRSetAuthority(OGRSpatialReferenceH hSRS,
+                    const char * pszTargetKey,
+                    const char * pszAuthority,
+                    int nCode) -> OGRErr
+
+Set the authority for a node.
+"""
 function OSRSetAuthority(hSRS::OGRSpatialReferenceH,pszTargetKey::Ptr{UInt8},pszAuthority::Ptr{UInt8},nCode::Cint)
     ccall((:OSRSetAuthority,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cint),hSRS,pszTargetKey,pszAuthority,nCode)
 end
 
+
+"""
+    OSRGetAuthorityCode(OGRSpatialReferenceH hSRS,
+                        const char * pszTargetKey) -> const char *
+
+Get the authority code for a node.
+"""
 function OSRGetAuthorityCode(hSRS::OGRSpatialReferenceH,pszTargetKey::Ptr{UInt8})
     ccall((:OSRGetAuthorityCode,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszTargetKey)
 end
 
+
+"""
+    OSRGetAuthorityName(OGRSpatialReferenceH hSRS,
+                        const char * pszTargetKey) -> const char *
+
+Get the authority name for a node.
+"""
 function OSRGetAuthorityName(hSRS::OGRSpatialReferenceH,pszTargetKey::Ptr{UInt8})
     ccall((:OSRGetAuthorityName,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszTargetKey)
 end
 
+
+"""
+    OSRSetProjection(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Set a projection name.
+"""
 function OSRSetProjection(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8})
     ccall((:OSRSetProjection,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRSetProjParm(OGRSpatialReferenceH,
+                   const char *,
+                   double) -> OGRErr
+
+Set a projection parameter value.
+"""
 function OSRSetProjParm(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Cdouble)
     ccall((:OSRSetProjParm,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetProjParm(OGRSpatialReferenceH hSRS,
+                   const char * pszParmName,
+                   double dfDefault,
+                   OGRErr *) -> double
+
+Fetch a projection parameter value.
+"""
 function OSRGetProjParm(hSRS::OGRSpatialReferenceH,pszParmName::Ptr{UInt8},dfDefault::Cdouble,arg1::Ptr{OGRErr})
     ccall((:OSRGetProjParm,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Ptr{OGRErr}),hSRS,pszParmName,dfDefault,arg1)
 end
 
+
+"""
+    OSRSetNormProjParm(OGRSpatialReferenceH,
+                       const char *,
+                       double) -> OGRErr
+
+Set a projection parameter with a normalized value.
+"""
 function OSRSetNormProjParm(arg1::OGRSpatialReferenceH,arg2::Ptr{UInt8},arg3::Cdouble)
     ccall((:OSRSetNormProjParm,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetNormProjParm(OGRSpatialReferenceH hSRS,
+                       const char * pszParmName,
+                       double dfDefault,
+                       OGRErr *) -> double
+
+This function is the same as OGRSpatialReference::
+"""
 function OSRGetNormProjParm(hSRS::OGRSpatialReferenceH,pszParmName::Ptr{UInt8},dfDefault::Cdouble,arg1::Ptr{OGRErr})
     ccall((:OSRGetNormProjParm,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Ptr{OGRErr}),hSRS,pszParmName,dfDefault,arg1)
 end
 
+
+"""
+    OSRSetUTM(OGRSpatialReferenceH hSRS,
+              int nZone,
+              int bNorth) -> OGRErr
+
+Set UTM projection definition.
+"""
 function OSRSetUTM(hSRS::OGRSpatialReferenceH,nZone::Cint,bNorth::Cint)
     ccall((:OSRSetUTM,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint),hSRS,nZone,bNorth)
 end
 
+
+"""
+    OSRGetUTMZone(OGRSpatialReferenceH hSRS,
+                  int * pbNorth) -> int
+
+Get utm zone information.
+"""
 function OSRGetUTMZone(hSRS::OGRSpatialReferenceH,pbNorth::Ptr{Cint})
     ccall((:OSRGetUTMZone,libgdal),Cint,(OGRSpatialReferenceH,Ptr{Cint}),hSRS,pbNorth)
 end
 
+
+"""
+    OSRSetStatePlane(OGRSpatialReferenceH hSRS,
+                     int nZone,
+                     int bNAD83) -> OGRErr
+
+Set State Plane projection definition.
+"""
 function OSRSetStatePlane(hSRS::OGRSpatialReferenceH,nZone::Cint,bNAD83::Cint)
     ccall((:OSRSetStatePlane,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint),hSRS,nZone,bNAD83)
 end
 
+
+"""
+    OSRSetStatePlaneWithUnits(OGRSpatialReferenceH hSRS,
+                              int nZone,
+                              int bNAD83,
+                              const char * pszOverrideUnitName,
+                              double dfOverrideUnit) -> OGRErr
+
+Set State Plane projection definition.
+"""
 function OSRSetStatePlaneWithUnits(hSRS::OGRSpatialReferenceH,nZone::Cint,bNAD83::Cint,pszOverrideUnitName::Ptr{UInt8},dfOverrideUnit::Cdouble)
     ccall((:OSRSetStatePlaneWithUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint,Ptr{UInt8},Cdouble),hSRS,nZone,bNAD83,pszOverrideUnitName,dfOverrideUnit)
 end
 
+
+"""
+    OSRAutoIdentifyEPSG(OGRSpatialReferenceH hSRS) -> OGRErr
+
+Set EPSG authority info if possible.
+"""
 function OSRAutoIdentifyEPSG(hSRS::OGRSpatialReferenceH)
     ccall((:OSRAutoIdentifyEPSG,libgdal),OGRErr,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSREPSGTreatsAsLatLong(OGRSpatialReferenceH hSRS) -> int
+
+This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having lat/long coordinate ordering.
+"""
 function OSREPSGTreatsAsLatLong(hSRS::OGRSpatialReferenceH)
     ccall((:OSREPSGTreatsAsLatLong,libgdal),Cint,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH hSRS) -> int
+
+This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having northing/easting coordinate ordering.
+"""
 function OSREPSGTreatsAsNorthingEasting(hSRS::OGRSpatialReferenceH)
     ccall((:OSREPSGTreatsAsNorthingEasting,libgdal),Cint,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSRGetAxis(OGRSpatialReferenceH hSRS,
+               const char * pszTargetKey,
+               int iAxis,
+               OGRAxisOrientation * peOrientation) -> const char *
+
+Fetch the orientation of one axis.
+"""
 function OSRGetAxis(hSRS::OGRSpatialReferenceH,pszTargetKey::Ptr{UInt8},iAxis::Cint,peOrientation::Ptr{OGRAxisOrientation})
     ccall((:OSRGetAxis,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8},Cint,Ptr{OGRAxisOrientation}),hSRS,pszTargetKey,iAxis,peOrientation)
 end
 
+
+"""
+    OSRSetAxes(const char * pszTargetKey,
+               const char * pszXAxisName,
+               OGRAxisOrientation eXAxisOrientation,
+               const char * pszYAxisName,
+               OGRAxisOrientation eYAxisOrientation) -> OGRErr
+"""
 function OSRSetAxes(pszTargetKey::Ptr{UInt8},pszXAxisName::Ptr{UInt8},eXAxisOrientation::OGRAxisOrientation,pszYAxisName::Ptr{UInt8},eYAxisOrientation::OGRAxisOrientation)
     ccall((:OSRSetAxes,libgdal),OGRErr,(Ptr{UInt8},Ptr{UInt8},OGRAxisOrientation,Ptr{UInt8},OGRAxisOrientation),pszTargetKey,pszXAxisName,eXAxisOrientation,pszYAxisName,eYAxisOrientation)
 end
 
+
+"""
+    OSRSetACEA(OGRSpatialReferenceH hSRS,
+               double dfStdP1,
+               double dfStdP2,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Albers Conic Equal Area.
+"""
 function OSRSetACEA(hSRS::OGRSpatialReferenceH,dfStdP1::Cdouble,dfStdP2::Cdouble,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetACEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetAE(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Azimuthal Equidistant.
+"""
 function OSRSetAE(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetAE,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetBonne(OGRSpatialReferenceH hSRS,
+                double dfStandardParallel,
+                double dfCentralMeridian,
+                double dfFalseEasting,
+                double dfFalseNorthing) -> OGRErr
+
+Bonne.
+"""
 function OSRSetBonne(hSRS::OGRSpatialReferenceH,dfStandardParallel::Cdouble,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetBonne,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStandardParallel,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetCEA(OGRSpatialReferenceH hSRS,
+              double dfStdP1,
+              double dfCentralMeridian,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Cylindrical Equal Area.
+"""
 function OSRSetCEA(hSRS::OGRSpatialReferenceH,dfStdP1::Cdouble,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetCEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetCS(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Cassini-Soldner.
+"""
 function OSRSetCS(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetCS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEC(OGRSpatialReferenceH hSRS,
+             double dfStdP1,
+             double dfStdP2,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Equidistant Conic.
+"""
 function OSRSetEC(hSRS::OGRSpatialReferenceH,dfStdP1::Cdouble,dfStdP2::Cdouble,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckert(OGRSpatialReferenceH hSRS,
+                 int nVariation,
+                 double dfCentralMeridian,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Eckert I-VI.
+"""
 function OSRSetEckert(hSRS::OGRSpatialReferenceH,nVariation::Cint,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEckert,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cdouble,Cdouble,Cdouble),hSRS,nVariation,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckertIV(OGRSpatialReferenceH hSRS,
+                   double dfCentralMeridian,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Eckert IV.
+"""
 function OSRSetEckertIV(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEckertIV,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckertVI(OGRSpatialReferenceH hSRS,
+                   double dfCentralMeridian,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Eckert VI.
+"""
 function OSRSetEckertVI(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEckertVI,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEquirectangular(OGRSpatialReferenceH hSRS,
+                          double dfCenterLat,
+                          double dfCenterLong,
+                          double dfFalseEasting,
+                          double dfFalseNorthing) -> OGRErr
+
+Equirectangular.
+"""
 function OSRSetEquirectangular(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEquirectangular,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEquirectangular2(OGRSpatialReferenceH hSRS,
+                           double dfCenterLat,
+                           double dfCenterLong,
+                           double dfPseudoStdParallel1,
+                           double dfFalseEasting,
+                           double dfFalseNorthing) -> OGRErr
+
+Equirectangular generalized form.
+"""
 function OSRSetEquirectangular2(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfPseudoStdParallel1::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetEquirectangular2,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfPseudoStdParallel1,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGS(OGRSpatialReferenceH hSRS,
+             double dfCentralMeridian,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Gall Stereograpic.
+"""
 function OSRSetGS(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetGS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGH(OGRSpatialReferenceH hSRS,
+             double dfCentralMeridian,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Goode Homolosine.
+"""
 function OSRSetGH(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetGH,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetIGH(OGRSpatialReferenceH hSRS) -> OGRErr
+
+Interrupted Goode Homolosine.
+"""
 function OSRSetIGH(hSRS::OGRSpatialReferenceH)
     ccall((:OSRSetIGH,libgdal),OGRErr,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSRSetGEOS(OGRSpatialReferenceH hSRS,
+               double dfCentralMeridian,
+               double dfSatelliteHeight,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+GEOS - Geostationary Satellite View.
+"""
 function OSRSetGEOS(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfSatelliteHeight::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetGEOS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfSatelliteHeight,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGaussSchreiberTMercator(OGRSpatialReferenceH hSRS,
+                                  double dfCenterLat,
+                                  double dfCenterLong,
+                                  double dfScale,
+                                  double dfFalseEasting,
+                                  double dfFalseNorthing) -> OGRErr
+
+Gauss Schreiber Transverse Mercator.
+"""
 function OSRSetGaussSchreiberTMercator(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetGaussSchreiberTMercator,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGnomonic(OGRSpatialReferenceH hSRS,
+                   double dfCenterLat,
+                   double dfCenterLong,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Gnomonic.
+"""
 function OSRSetGnomonic(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetGnomonic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOM(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfAzimuth,
+             double dfRectToSkew,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Oblique Mercator (aka HOM (variant B)
+"""
 function OSRSetOM(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfAzimuth::Cdouble,dfRectToSkew::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetOM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfRectToSkew,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetHOM(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfAzimuth,
+              double dfRectToSkew,
+              double dfScale,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Hotine Oblique Mercator using azimuth angle.
+"""
 function OSRSetHOM(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfAzimuth::Cdouble,dfRectToSkew::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetHOM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfRectToSkew,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetHOM2PNO(OGRSpatialReferenceH hSRS,
+                  double dfCenterLat,
+                  double dfLat1,
+                  double dfLong1,
+                  double dfLat2,
+                  double dfLong2,
+                  double dfScale,
+                  double dfFalseEasting,
+                  double dfFalseNorthing) -> OGRErr
+
+Hotine Oblique Mercator using two points on centerline.
+"""
 function OSRSetHOM2PNO(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfLat1::Cdouble,dfLong1::Cdouble,dfLat2::Cdouble,dfLong2::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetHOM2PNO,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfLat1,dfLong1,dfLat2,dfLong2,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetIWMPolyconic(OGRSpatialReferenceH hSRS,
+                       double dfLat1,
+                       double dfLat2,
+                       double dfCenterLong,
+                       double dfFalseEasting,
+                       double dfFalseNorthing) -> OGRErr
+
+International Map of the World Polyconic.
+"""
 function OSRSetIWMPolyconic(hSRS::OGRSpatialReferenceH,dfLat1::Cdouble,dfLat2::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetIWMPolyconic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfLat1,dfLat2,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetKrovak(OGRSpatialReferenceH hSRS,
+                 double dfCenterLat,
+                 double dfCenterLong,
+                 double dfAzimuth,
+                 double dfPseudoStdParallelLat,
+                 double dfScale,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Krovak Oblique Conic Conformal.
+"""
 function OSRSetKrovak(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfAzimuth::Cdouble,dfPseudoStdParallelLat::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetKrovak,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfPseudoStdParallelLat,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLAEA(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Lambert Azimuthal Equal-Area.
+"""
 function OSRSetLAEA(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetLAEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCC(OGRSpatialReferenceH hSRS,
+              double dfStdP1,
+              double dfStdP2,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic.
+"""
 function OSRSetLCC(hSRS::OGRSpatialReferenceH,dfStdP1::Cdouble,dfStdP2::Cdouble,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetLCC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCC1SP(OGRSpatialReferenceH hSRS,
+                 double dfCenterLat,
+                 double dfCenterLong,
+                 double dfScale,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic 1SP.
+"""
 function OSRSetLCC1SP(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetLCC1SP,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCCB(OGRSpatialReferenceH hSRS,
+               double dfStdP1,
+               double dfStdP2,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic (Belgium)
+"""
 function OSRSetLCCB(hSRS::OGRSpatialReferenceH,dfStdP1::Cdouble,dfStdP2::Cdouble,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetLCCB,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMC(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Miller Cylindrical.
+"""
 function OSRSetMC(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetMC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMercator(OGRSpatialReferenceH hSRS,
+                   double dfCenterLat,
+                   double dfCenterLong,
+                   double dfScale,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Mercator.
+"""
 function OSRSetMercator(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetMercator,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMollweide(OGRSpatialReferenceH hSRS,
+                    double dfCentralMeridian,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Mollweide.
+"""
 function OSRSetMollweide(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetMollweide,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetNZMG(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+New Zealand Map Grid.
+"""
 function OSRSetNZMG(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetNZMG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOS(OGRSpatialReferenceH hSRS,
+             double dfOriginLat,
+             double dfCMeridian,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Oblique Stereographic.
+"""
 function OSRSetOS(hSRS::OGRSpatialReferenceH,dfOriginLat::Cdouble,dfCMeridian::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetOS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfOriginLat,dfCMeridian,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOrthographic(OGRSpatialReferenceH hSRS,
+                       double dfCenterLat,
+                       double dfCenterLong,
+                       double dfFalseEasting,
+                       double dfFalseNorthing) -> OGRErr
+
+Orthographic.
+"""
 function OSRSetOrthographic(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetOrthographic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetPolyconic(OGRSpatialReferenceH hSRS,
+                    double dfCenterLat,
+                    double dfCenterLong,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Polyconic.
+"""
 function OSRSetPolyconic(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetPolyconic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetPS(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Polar Stereographic.
+"""
 function OSRSetPS(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetPS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetRobinson(OGRSpatialReferenceH hSRS,
+                   double dfCenterLong,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Robinson.
+"""
 function OSRSetRobinson(hSRS::OGRSpatialReferenceH,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetRobinson,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetSinusoidal(OGRSpatialReferenceH hSRS,
+                     double dfCenterLong,
+                     double dfFalseEasting,
+                     double dfFalseNorthing) -> OGRErr
+
+Sinusoidal.
+"""
 function OSRSetSinusoidal(hSRS::OGRSpatialReferenceH,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetSinusoidal,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetStereographic(OGRSpatialReferenceH hSRS,
+                        double dfCenterLat,
+                        double dfCenterLong,
+                        double dfScale,
+                        double dfFalseEasting,
+                        double dfFalseNorthing) -> OGRErr
+
+Stereographic.
+"""
 function OSRSetStereographic(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetStereographic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetSOC(OGRSpatialReferenceH hSRS,
+              double dfLatitudeOfOrigin,
+              double dfCentralMeridian,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Swiss Oblique Cylindrical.
+"""
 function OSRSetSOC(hSRS::OGRSpatialReferenceH,dfLatitudeOfOrigin::Cdouble,dfCentralMeridian::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetSOC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfLatitudeOfOrigin,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTM(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator.
+"""
 function OSRSetTM(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetTM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMVariant(OGRSpatialReferenceH hSRS,
+                    const char * pszVariantName,
+                    double dfCenterLat,
+                    double dfCenterLong,
+                    double dfScale,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator variant.
+"""
 function OSRSetTMVariant(hSRS::OGRSpatialReferenceH,pszVariantName::Ptr{UInt8},dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetTMVariant,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,pszVariantName,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMG(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Tunesia Mining Grid.
+"""
 function OSRSetTMG(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetTMG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMSO(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfScale,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator (South Oriented)
+"""
 function OSRSetTMSO(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble,dfScale::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetTMSO,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetVDG(OGRSpatialReferenceH hSRS,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+VanDerGrinten.
+"""
 function OSRSetVDG(hSRS::OGRSpatialReferenceH,dfCenterLong::Cdouble,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetVDG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetWagner(OGRSpatialReferenceH hSRS,
+                 int nVariation,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Wagner I  VII.
+"""
 function OSRSetWagner(hSRS::OGRSpatialReferenceH,nVariation::Cint,dfFalseEasting::Cdouble,dfFalseNorthing::Cdouble)
     ccall((:OSRSetWagner,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cdouble,Cdouble),hSRS,nVariation,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetQSC(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong) -> OGRErr
+
+Quadrilateralized Spherical Cube.
+"""
 function OSRSetQSC(hSRS::OGRSpatialReferenceH,dfCenterLat::Cdouble,dfCenterLong::Cdouble)
     ccall((:OSRSetQSC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong)
 end
 
+
+"""
+    OSRCalcInvFlattening(double dfSemiMajor,
+                         double dfSemiMinor) -> double
+
+Compute inverse flattening from semi-major and semi-minor axis.
+
+### Parameters
+* **dfSemiMajor**: Semi-major axis length.
+* **dfSemiMinor**: Semi-minor axis length.
+
+### Returns
+inverse flattening, or 0 if both axis are equal.
+"""
 function OSRCalcInvFlattening(dfSemiMajor::Cdouble,dfSemiMinor::Cdouble)
     ccall((:OSRCalcInvFlattening,libgdal),Cdouble,(Cdouble,Cdouble),dfSemiMajor,dfSemiMinor)
 end
 
+
+"""
+    OSRCalcSemiMinorFromInvFlattening(double dfSemiMajor,
+                                      double dfInvFlattening) -> double
+
+Compute semi-minor axis from semi-major axis and inverse flattening.
+
+### Parameters
+* **dfSemiMajor**: Semi-major axis length.
+* **dfInvFlattening**: Inverse flattening or 0 for sphere.
+
+### Returns
+semi-minor axis
+"""
 function OSRCalcSemiMinorFromInvFlattening(dfSemiMajor::Cdouble,dfInvFlattening::Cdouble)
     ccall((:OSRCalcSemiMinorFromInvFlattening,libgdal),Cdouble,(Cdouble,Cdouble),dfSemiMajor,dfInvFlattening)
 end
 
+
+"""
+    OSRCleanup(void) -> void
+
+Cleanup cached SRS related memory.
+"""
 function OSRCleanup()
     ccall((:OSRCleanup,libgdal),Void,())
 end
 
+
+"""
+    OCTNewCoordinateTransformation(OGRSpatialReferenceH hSourceSRS,
+                                   OGRSpatialReferenceH hTargetSRS) -> OGRCoordinateTransformationH
+
+Create transformation object.
+
+### Parameters
+* **hSourceSRS**: source spatial reference system.
+* **hTargetSRS**: target spatial reference system.
+
+### Returns
+NULL on failure or a ready to use transformation object.
+"""
 function OCTNewCoordinateTransformation(hSourceSRS::OGRSpatialReferenceH,hTargetSRS::OGRSpatialReferenceH)
     ccall((:OCTNewCoordinateTransformation,libgdal),OGRCoordinateTransformationH,(OGRSpatialReferenceH,OGRSpatialReferenceH),hSourceSRS,hTargetSRS)
 end
 
+
+"""
+    OCTDestroyCoordinateTransformation(OGRCoordinateTransformationH) -> void
+
+OGRCoordinateTransformation destructor.
+
+### Parameters
+* **hCT**: the object to delete
+"""
 function OCTDestroyCoordinateTransformation(arg1::OGRCoordinateTransformationH)
     ccall((:OCTDestroyCoordinateTransformation,libgdal),Void,(OGRCoordinateTransformationH,),arg1)
 end
 
+
+"""
+    OCTTransform(OGRCoordinateTransformationH hCT,
+                 int nCount,
+                 double * x,
+                 double * y,
+                 double * z) -> int
+"""
 function OCTTransform(hCT::OGRCoordinateTransformationH,nCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble})
     ccall((:OCTTransform,libgdal),Cint,(OGRCoordinateTransformationH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),hCT,nCount,x,y,z)
 end
 
+
+"""
+    OCTTransformEx(OGRCoordinateTransformationH hCT,
+                   int nCount,
+                   double * x,
+                   double * y,
+                   double * z,
+                   int * pabSuccess) -> int
+"""
 function OCTTransformEx(hCT::OGRCoordinateTransformationH,nCount::Cint,x::Ptr{Cdouble},y::Ptr{Cdouble},z::Ptr{Cdouble},pabSuccess::Ptr{Cint})
     ccall((:OCTTransformEx,libgdal),Cint,(OGRCoordinateTransformationH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),hCT,nCount,x,y,z,pabSuccess)
 end
 
+
+"""
+    OCTProj4Normalize(const char * pszProj4Src) -> char *
+"""
 function OCTProj4Normalize(pszProj4Src::Ptr{UInt8})
     ccall((:OCTProj4Normalize,libgdal),Ptr{UInt8},(Ptr{UInt8},),pszProj4Src)
 end
 
+
+"""
+    OCTCleanupProjMutex(void) -> void
+"""
 function OCTCleanupProjMutex()
     ccall((:OCTCleanupProjMutex,libgdal),Void,())
 end
 
+
+"""
+    OPTGetProjectionMethods() -> char **
+
+Fetch list of possible projection methods.
+
+### Returns
+Returns NULL terminated list of projection methods. This should be freed with CSLDestroy() when no longer needed.
+"""
 function OPTGetProjectionMethods()
     ccall((:OPTGetProjectionMethods,libgdal),Ptr{Ptr{UInt8}},())
 end
 
+
+"""
+    OPTGetParameterList(const char * pszProjectionMethod,
+                        char ** ppszUserName) -> char **
+
+Fetch the parameters for a given projection method.
+
+### Parameters
+* **pszProjectionMethod**: internal name of projection methods to fetch the parameters for, such as "Transverse_Mercator" (SRS_PT_TRANSVERSE_MERCATOR).
+* **ppszUserName**: pointer in which to return a user visible name for the projection name. The returned string should not be modified or freed by the caller. Legal to pass in NULL if user name not required.
+
+### Returns
+returns a NULL terminated list of internal parameter names that should be freed by the caller when no longer needed. Returns NULL if projection method is unknown.
+"""
 function OPTGetParameterList(pszProjectionMethod::Ptr{UInt8},ppszUserName::Ptr{Ptr{UInt8}})
     ccall((:OPTGetParameterList,libgdal),Ptr{Ptr{UInt8}},(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszProjectionMethod,ppszUserName)
 end
 
+
+"""
+    OPTGetParameterInfo(const char * pszProjectionMethod,
+                        const char * pszParameterName,
+                        char ** ppszUserName,
+                        char ** ppszType,
+                        double * pdfDefaultValue) -> int
+
+Fetch information about a single parameter of a projection method.
+
+### Parameters
+* **pszProjectionMethod**: name of projection method for which the parameter applies. Not currently used, but in the future this could affect defaults. This is the internal projection method name, such as "Tranverse_Mercator".
+* **pszParameterName**: name of the parameter to fetch information about. This is the internal name such as "central_meridian" (SRS_PP_CENTRAL_MERIDIAN).
+* **ppszUserName**: location at which to return the user visible name for the parameter. This pointer may be NULL to skip the user name. The returned name should not be modified or freed.
+* **ppszType**: location at which to return the parameter type for the parameter. This pointer may be NULL to skip. The returned type should not be modified or freed. The type values are described above.
+* **pdfDefaultValue**: location at which to put the default value for this parameter. The pointer may be NULL.
+
+### Returns
+TRUE if parameter found, or FALSE otherwise.
+"""
 function OPTGetParameterInfo(pszProjectionMethod::Ptr{UInt8},pszParameterName::Ptr{UInt8},ppszUserName::Ptr{Ptr{UInt8}},ppszType::Ptr{Ptr{UInt8}},pdfDefaultValue::Ptr{Cdouble})
     ccall((:OPTGetParameterInfo,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Cdouble}),pszProjectionMethod,pszParameterName,ppszUserName,ppszType,pdfDefaultValue)
 end

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -1,220 +1,1036 @@
+
+
+"""
+    GDALComputeMedianCutPCT(GDALRasterBandH hRed,
+                            GDALRasterBandH hGreen,
+                            GDALRasterBandH hBlue,
+                            int(*)(int, int, void *) pfnIncludePixel,
+                            int nColors,
+                            GDALColorTableH hColorTable,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressArg) -> int
+
+Compute optimal PCT for RGB image.
+
+### Parameters
+* **hRed**: Red input band.
+* **hGreen**: Green input band.
+* **hBlue**: Blue input band.
+* **pfnIncludePixel**: function used to test which pixels should be included in the analysis. At this time this argument is ignored and all pixels are utilized. This should normally be NULL.
+* **nColors**: the desired number of colors to be returned (2-256).
+* **hColorTable**: the colors will be returned in this color table object.
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+returns CE_None on success or CE_Failure if an error occurs.
+"""
 function computemediancutpct(hRed::GDALRasterBandH,hGreen::GDALRasterBandH,hBlue::GDALRasterBandH,pfnIncludePixel::Ptr{Void},nColors::Integer,hColorTable::GDALColorTableH,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALComputeMedianCutPCT,libgdal),Cint,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,Ptr{Void},Cint,GDALColorTableH,GDALProgressFunc,Ptr{Void}),hRed,hGreen,hBlue,pfnIncludePixel,nColors,hColorTable,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALDitherRGB2PCT(GDALRasterBandH hRed,
+                      GDALRasterBandH hGreen,
+                      GDALRasterBandH hBlue,
+                      GDALRasterBandH hTarget,
+                      GDALColorTableH hColorTable,
+                      GDALProgressFunc pfnProgress,
+                      void * pProgressArg) -> int
+
+24bit to 8bit conversion with dithering.
+
+### Parameters
+* **hRed**: Red input band.
+* **hGreen**: Green input band.
+* **hBlue**: Blue input band.
+* **hTarget**: Output band.
+* **hColorTable**: the color table to use with the output band.
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure if an error occurs.
+"""
 function ditherrgb2pct(hRed::GDALRasterBandH,hGreen::GDALRasterBandH,hBlue::GDALRasterBandH,hTarget::GDALRasterBandH,hColorTable::GDALColorTableH,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALDitherRGB2PCT,libgdal),Cint,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALColorTableH,GDALProgressFunc,Ptr{Void}),hRed,hGreen,hBlue,hTarget,hColorTable,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALChecksumImage(GDALRasterBandH hBand,
+                      int nXOff,
+                      int nYOff,
+                      int nXSize,
+                      int nYSize) -> int
+
+Compute checksum for image region.
+
+### Parameters
+* **hBand**: the raster band to read from.
+* **nXOff**: pixel offset of window to read.
+* **nYOff**: line offset of window to read.
+* **nXSize**: pixel size of window to read.
+* **nYSize**: line size of window to read.
+
+### Returns
+Checksum value.
+"""
 function checksumimage(hBand::GDALRasterBandH,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer)
     ccall((:GDALChecksumImage,libgdal),Cint,(GDALRasterBandH,Cint,Cint,Cint,Cint),hBand,nXOff,nYOff,nXSize,nYSize)
 end
 
+
+"""
+    GDALComputeProximity(GDALRasterBandH hSrcBand,
+                         GDALRasterBandH hProximityBand,
+                         char ** papszOptions,
+                         GDALProgressFunc pfnProgress,
+                         void * pProgressArg) -> CPLErr
+
+Compute the proximity of all pixels in the image to a set of pixels in the source image.
+"""
 function computeproximity(hSrcBand::GDALRasterBandH,hProximityBand::GDALRasterBandH,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALComputeProximity,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hProximityBand,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALFillNodata(GDALRasterBandH hTargetBand,
+                   GDALRasterBandH hMaskBand,
+                   double dfMaxSearchDist,
+                   int bDeprecatedOption,
+                   int nSmoothingIterations,
+                   char ** papszOptions,
+                   GDALProgressFunc pfnProgress,
+                   void * pProgressArg) -> CPLErr
+
+Fill selected raster regions by interpolation from the edges.
+
+### Parameters
+* **hTargetBand**: the raster band to be modified in place.
+* **hMaskBand**: a mask band indicating pixels to be interpolated (zero valued
+* **dfMaxSearchDist**: the maximum number of pixels to search in all directions to find values to interpolate from.
+* **bDeprecatedOption**: unused argument, should be zero.
+* **nSmoothingIterations**: the number of 3x3 smoothing filter passes to run (0 or more).
+* **papszOptions**: additional name=value options in a string list (the temporary file driver can be specified like TEMP_FILE_DRIVER=MEM).
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure if something goes wrong.
+"""
 function fillnodata(hTargetBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,dfMaxSearchDist::Real,bDeprecatedOption::Integer,nSmoothingIterations::Integer,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALFillNodata,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Cdouble,Cint,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hTargetBand,hMaskBand,dfMaxSearchDist,bDeprecatedOption,nSmoothingIterations,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALPolygonize(GDALRasterBandH hSrcBand,
+                   GDALRasterBandH hMaskBand,
+                   OGRLayerH hOutLayer,
+                   int iPixValField,
+                   char ** papszOptions,
+                   GDALProgressFunc pfnProgress,
+                   void * pProgressArg) -> CPLErr
+
+Create polygon coverage from raster data.
+
+### Parameters
+* **hSrcBand**: the source raster band to be processed.
+* **hMaskBand**: an optional mask band. All pixels in the mask band with a value other than zero will be considered suitable for collection as polygons.
+* **hOutLayer**: the vector feature layer to which the polygons should be written.
+* **iPixValField**: the attribute field index indicating the feature attribute into which the pixel value of the polygon should be written.
+* **papszOptions**: a name/value list of additional options 
+"8CONNECTED": May be set to "8" to use 8 connectedness. Otherwise 4 connectedness will be applied to the algorithm
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure on a failure.
+"""
 function polygonize(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hOutLayer::OGRLayerH,iPixValField::Integer,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALPolygonize,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,OGRLayerH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hOutLayer,iPixValField,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALFPolygonize(GDALRasterBandH hSrcBand,
+                    GDALRasterBandH hMaskBand,
+                    OGRLayerH hOutLayer,
+                    int iPixValField,
+                    char ** papszOptions,
+                    GDALProgressFunc pfnProgress,
+                    void * pProgressArg) -> CPLErr
+
+Create polygon coverage from raster data.
+
+### Parameters
+* **hSrcBand**: the source raster band to be processed.
+* **hMaskBand**: an optional mask band. All pixels in the mask band with a value other than zero will be considered suitable for collection as polygons.
+* **hOutLayer**: the vector feature layer to which the polygons should be written.
+* **iPixValField**: the attribute field index indicating the feature attribute into which the pixel value of the polygon should be written.
+* **papszOptions**: a name/value list of additional options 
+"8CONNECTED": May be set to "8" to use 8 connectedness. Otherwise 4 connectedness will be applied to the algorithm
+* **pfnProgress**: callback for reporting algorithm progress matching the GDALProgressFunc() semantics. May be NULL.
+* **pProgressArg**: callback argument passed to pfnProgress.
+
+### Returns
+CE_None on success or CE_Failure on a failure.
+"""
 function fpolygonize(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hOutLayer::OGRLayerH,iPixValField::Integer,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALFPolygonize,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,OGRLayerH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hOutLayer,iPixValField,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALSieveFilter(GDALRasterBandH hSrcBand,
+                    GDALRasterBandH hMaskBand,
+                    GDALRasterBandH hDstBand,
+                    int nSizeThreshold,
+                    int nConnectedness,
+                    char ** papszOptions,
+                    GDALProgressFunc pfnProgress,
+                    void * pProgressArg) -> CPLErr
+"""
 function sievefilter(hSrcBand::GDALRasterBandH,hMaskBand::GDALRasterBandH,hDstBand::GDALRasterBandH,nSizeThreshold::Integer,nConnectedness::Integer,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALSieveFilter,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,Cint,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hMaskBand,hDstBand,nSizeThreshold,nConnectedness,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALDestroyTransformer(void * pTransformerArg) -> void
+"""
 function destroytransformer(pTransformerArg::Ptr{Void})
     ccall((:GDALDestroyTransformer,libgdal),Void,(Ptr{Void},),pTransformerArg)
 end
 
+
+"""
+    GDALUseTransformer(void * pTranformerArg,
+                       int bDstToSrc,
+                       int nPointCount,
+                       double * x,
+                       double * y,
+                       double * z,
+                       int * panSuccess) -> int
+"""
 function usetransformer(pTranformerArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALUseTransformer,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTranformerArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateSimilarTransformer(void * psTransformerArg,
+                                 double dfSrcRatioX,
+                                 double dfSrcRatioY) -> void *
+"""
 function createsimilartransformer(psTransformerArg::Ptr{Void},dfSrcRatioX::Real,dfSrcRatioY::Real)
     ccall((:GDALCreateSimilarTransformer,libgdal),Ptr{Void},(Ptr{Void},Cdouble,Cdouble),psTransformerArg,dfSrcRatioX,dfSrcRatioY)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer(GDALDatasetH hSrcDS,
+                                    const char * pszSrcWKT,
+                                    GDALDatasetH hDstDS,
+                                    const char * pszDstWKT,
+                                    int bGCPUseOK,
+                                    double dfGCPErrorThreshold,
+                                    int nOrder) -> void *
+"""
 function creategenimgprojtransformer(hSrcDS::GDALDatasetH,pszSrcWKT::AbstractString,hDstDS::GDALDatasetH,pszDstWKT::AbstractString,bGCPUseOK::Integer,dfGCPErrorThreshold::Real,nOrder::Integer)
     ccall((:GDALCreateGenImgProjTransformer,libgdal),Ptr{Void},(GDALDatasetH,Ptr{UInt8},GDALDatasetH,Ptr{UInt8},Cint,Cdouble,Cint),hSrcDS,pszSrcWKT,hDstDS,pszDstWKT,bGCPUseOK,dfGCPErrorThreshold,nOrder)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS,
+                                     GDALDatasetH hDstDS,
+                                     char ** papszOptions) -> void *
+
+Create image to image transformer.
+
+### Parameters
+* **hSrcDS**: source dataset, or NULL.
+* **hDstDS**: destination dataset (or NULL).
+* **papszOptions**: NULL-terminated list of string options (or NULL).
+
+### Returns
+handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
+"""
 function creategenimgprojtransformer2(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,papszOptions::Vector{UTF8String})
     ccall((:GDALCreateGenImgProjTransformer2,libgdal),Ptr{Void},(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}}),hSrcDS,hDstDS,papszOptions)
 end
 
+
+"""
+    GDALCreateGenImgProjTransformer3(const char * pszSrcWKT,
+                                     const double * padfSrcGeoTransform,
+                                     const char * pszDstWKT,
+                                     const double * padfDstGeoTransform) -> void *
+
+Create image to image transformer.
+
+### Parameters
+* **pszSrcWKT**: source WKT (or NULL).
+* **padfSrcGeoTransform**: source geotransform (or NULL).
+* **pszDstWKT**: destination WKT (or NULL).
+* **padfDstGeoTransform**: destination geotransform (or NULL).
+
+### Returns
+handle suitable for use GDALGenImgProjTransform(), and to be deallocated with GDALDestroyGenImgProjTransformer() or NULL on failure.
+"""
 function creategenimgprojtransformer3(pszSrcWKT::AbstractString,padfSrcGeoTransform::Vector{Float64},pszDstWKT::AbstractString,padfDstGeoTransform::Vector{Float64})
     ccall((:GDALCreateGenImgProjTransformer3,libgdal),Ptr{Void},(Ptr{UInt8},Ptr{Cdouble},Ptr{UInt8},Ptr{Cdouble}),pszSrcWKT,padfSrcGeoTransform,pszDstWKT,padfDstGeoTransform)
 end
 
+
+"""
+    GDALSetGenImgProjTransformerDstGeoTransform(void *,
+                                                const double *) -> void
+
+Set GenImgProj output geotransform.
+
+### Parameters
+* **hTransformArg**: the handle to update.
+* **padfGeoTransform**: the destination geotransform to apply (six doubles).
+"""
 function setgenimgprojtransformerdstgeotransform(arg1::Ptr{Void},arg2::Vector{Float64})
     ccall((:GDALSetGenImgProjTransformerDstGeoTransform,libgdal),Void,(Ptr{Void},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALDestroyGenImgProjTransformer(void *) -> void
+
+GenImgProjTransformer deallocator.
+
+### Parameters
+* **hTransformArg**: the handle to deallocate.
+"""
 function destroygenimgprojtransformer(arg1::Ptr{Void})
     ccall((:GDALDestroyGenImgProjTransformer,libgdal),Void,(Ptr{Void},),arg1)
 end
 
+
+"""
+    GDALGenImgProjTransform(void * pTransformArg,
+                            int bDstToSrc,
+                            int nPointCount,
+                            double * x,
+                            double * y,
+                            double * z,
+                            int * panSuccess) -> int
+
+Perform general image reprojection transformation.
+"""
 function genimgprojtransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALGenImgProjTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALSetTransformerDstGeoTransform(void *,
+                                      const double *) -> void
+"""
 function settransformerdstgeotransform(arg1::Ptr{Void},arg2::Vector{Float64})
     ccall((:GDALSetTransformerDstGeoTransform,libgdal),Void,(Ptr{Void},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALCreateReprojectionTransformer(const char * pszSrcWKT,
+                                      const char * pszDstWKT) -> void *
+
+Create reprojection transformer.
+
+### Parameters
+* **pszSrcWKT**: the coordinate system for the source coordinate system.
+* **pszDstWKT**: the coordinate system for the destination coordinate system.
+
+### Returns
+Handle for use with GDALReprojectionTransform(), or NULL if the system fails to initialize the reprojection.
+"""
 function createreprojectiontransformer(pszSrcWKT::AbstractString,pszDstWKT::AbstractString)
     ccall((:GDALCreateReprojectionTransformer,libgdal),Ptr{Void},(Ptr{UInt8},Ptr{UInt8}),pszSrcWKT,pszDstWKT)
 end
 
+
+"""
+    GDALDestroyReprojectionTransformer(void *) -> void
+
+Destroy reprojection transformation.
+
+### Parameters
+* **pTransformArg**: the transformation handle returned by GDALCreateReprojectionTransformer().
+"""
 function destroyreprojectiontransformer(arg1::Ptr{Void})
     ccall((:GDALDestroyReprojectionTransformer,libgdal),Void,(Ptr{Void},),arg1)
 end
 
+
+"""
+    GDALReprojectionTransform(void * pTransformArg,
+                              int bDstToSrc,
+                              int nPointCount,
+                              double * x,
+                              double * y,
+                              double * z,
+                              int * panSuccess) -> int
+
+Perform reprojection transformation.
+"""
 function reprojectiontransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALReprojectionTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateGCPTransformer(int nGCPCount,
+                             const GDAL_GCP * pasGCPList,
+                             int nReqOrder,
+                             int bReversed) -> void *
+
+Create GCP based polynomial transformer.
+
+### Parameters
+* **nGCPCount**: the number of GCPs in pasGCPList.
+* **pasGCPList**: an array of GCPs to be used as input.
+* **nReqOrder**: the requested polynomial order. It should be 1, 2 or 3.
+* **bReversed**: set it to TRUE to compute the reversed transformation.
+
+### Returns
+the transform argument or NULL if creation fails.
+"""
 function creategcptransformer(nGCPCount::Integer,pasGCPList::Ptr{GDAL_GCP},nReqOrder::Integer,bReversed::Integer)
     ccall((:GDALCreateGCPTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint,Cint),nGCPCount,pasGCPList,nReqOrder,bReversed)
 end
 
+
+"""
+    GDALCreateGCPRefineTransformer(int nGCPCount,
+                                   const GDAL_GCP * pasGCPList,
+                                   int nReqOrder,
+                                   int bReversed,
+                                   double tolerance,
+                                   int minimumGcps) -> void *
+"""
 function creategcprefinetransformer(nGCPCount::Integer,pasGCPList::Ptr{GDAL_GCP},nReqOrder::Integer,bReversed::Integer,tolerance::Real,minimumGcps::Integer)
     ccall((:GDALCreateGCPRefineTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint,Cint,Cdouble,Cint),nGCPCount,pasGCPList,nReqOrder,bReversed,tolerance,minimumGcps)
 end
 
+
+"""
+    GDALDestroyGCPTransformer(void * pTransformArg) -> void
+
+Destroy GCP transformer.
+
+### Parameters
+* **pTransformArg**: the transform arg previously returned by GDALCreateGCPTransformer().
+"""
 function destroygcptransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyGCPTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALGCPTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+
+Transforms point based on GCP derived polynomial model.
+
+### Parameters
+* **pTransformArg**: return value from GDALCreateGCPTransformer().
+* **bDstToSrc**: TRUE if transformation is from the destination (georeferenced) coordinates to pixel/line or FALSE when transforming from pixel/line to georeferenced coordinates.
+* **nPointCount**: the number of values in the x, y and z arrays.
+* **x**: array containing the X values to be transformed.
+* **y**: array containing the Y values to be transformed.
+* **z**: array containing the Z values to be transformed.
+* **panSuccess**: array in which a flag indicating success (TRUE) or failure (FALSE) of the transformation are placed.
+
+### Returns
+TRUE.
+"""
 function gcptransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALGCPTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateTPSTransformer(int nGCPCount,
+                             const GDAL_GCP * pasGCPList,
+                             int bReversed) -> void *
+
+Create Thin Plate Spline transformer from GCPs.
+
+### Parameters
+* **nGCPCount**: the number of GCPs in pasGCPList.
+* **pasGCPList**: an array of GCPs to be used as input.
+* **bReversed**: set it to TRUE to compute the reversed transformation.
+
+### Returns
+the transform argument or NULL if creation fails.
+"""
 function createtpstransformer(nGCPCount::Integer,pasGCPList::Ptr{GDAL_GCP},bReversed::Integer)
     ccall((:GDALCreateTPSTransformer,libgdal),Ptr{Void},(Cint,Ptr{GDAL_GCP},Cint),nGCPCount,pasGCPList,bReversed)
 end
 
+
+"""
+    GDALDestroyTPSTransformer(void * pTransformArg) -> void
+
+Destroy TPS transformer.
+
+### Parameters
+* **pTransformArg**: the transform arg previously returned by GDALCreateTPSTransformer().
+"""
 function destroytpstransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyTPSTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALTPSTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+"""
 function tpstransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALTPSTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    RPCInfoToMD(GDALRPCInfo * psRPCInfo) -> char **
+"""
 function rpcinfotomd(psRPCInfo::Ptr{GDALRPCInfo})
     bytestring(unsafe_load(ccall((:RPCInfoToMD,libgdal),Ptr{Ptr{UInt8}},(Ptr{GDALRPCInfo},),psRPCInfo)))
 end
 
+
+"""
+    GDALCreateRPCTransformer(GDALRPCInfo * psRPC,
+                             int bReversed,
+                             double dfPixErrThreshold,
+                             char ** papszOptions) -> void *
+
+Create an RPC based transformer.
+
+### Parameters
+* **psRPCInfo**: Definition of the RPC parameters.
+* **bReversed**: If true "forward" transformation will be lat/long to pixel/line instead of the normal pixel/line to lat/long.
+* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations).
+* **papszOptions**: Other transformer options (ie. RPC_HEIGHT=<z>).
+
+### Returns
+transformer callback data (deallocate with GDALDestroyTransformer()).
+"""
 function createrpctransformer(psRPC::Ptr{GDALRPCInfo},bReversed::Integer,dfPixErrThreshold::Real,papszOptions::Vector{UTF8String})
     ccall((:GDALCreateRPCTransformer,libgdal),Ptr{Void},(Ptr{GDALRPCInfo},Cint,Cdouble,Ptr{Ptr{UInt8}}),psRPC,bReversed,dfPixErrThreshold,papszOptions)
 end
 
+
+"""
+    GDALDestroyRPCTransformer(void * pTransformArg) -> void
+"""
 function destroyrpctransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyRPCTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALRPCTransform(void * pTransformArg,
+                     int bDstToSrc,
+                     int nPointCount,
+                     double * x,
+                     double * y,
+                     double * z,
+                     int * panSuccess) -> int
+"""
 function rpctransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALRPCTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateGeoLocTransformer(GDALDatasetH hBaseDS,
+                                char ** papszGeolocationInfo,
+                                int bReversed) -> void *
+"""
 function creategeoloctransformer(hBaseDS::GDALDatasetH,papszGeolocationInfo::Vector{UTF8String},bReversed::Integer)
     ccall((:GDALCreateGeoLocTransformer,libgdal),Ptr{Void},(GDALDatasetH,Ptr{Ptr{UInt8}},Cint),hBaseDS,papszGeolocationInfo,bReversed)
 end
 
+
+"""
+    GDALDestroyGeoLocTransformer(void * pTransformArg) -> void
+"""
 function destroygeoloctransformer(pTransformArg::Ptr{Void})
     ccall((:GDALDestroyGeoLocTransformer,libgdal),Void,(Ptr{Void},),pTransformArg)
 end
 
+
+"""
+    GDALGeoLocTransform(void * pTransformArg,
+                        int bDstToSrc,
+                        int nPointCount,
+                        double * x,
+                        double * y,
+                        double * z,
+                        int * panSuccess) -> int
+"""
 function geoloctransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALGeoLocTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALCreateApproxTransformer(GDALTransformerFunc pfnRawTransformer,
+                                void * pRawTransformerArg,
+                                double dfMaxError) -> void *
+
+Create an approximating transformer.
+
+### Parameters
+* **pfnBaseTransformer**: the high precision transformer which should be approximated.
+* **pBaseTransformArg**: the callback argument for the high precision transformer.
+* **dfMaxError**: the maximum cartesian error in the "output" space that is to be accepted in the linear approximation.
+
+### Returns
+callback pointer suitable for use with GDALApproxTransform(). It should be deallocated with GDALDestroyApproxTransformer().
+"""
 function createapproxtransformer(pfnRawTransformer::GDALTransformerFunc,pRawTransformerArg::Ptr{Void},dfMaxError::Real)
     ccall((:GDALCreateApproxTransformer,libgdal),Ptr{Void},(GDALTransformerFunc,Ptr{Void},Cdouble),pfnRawTransformer,pRawTransformerArg,dfMaxError)
 end
 
+
+"""
+    GDALApproxTransformerOwnsSubtransformer(void * pCBData,
+                                            int bOwnFlag) -> void
+"""
 function approxtransformerownssubtransformer(pCBData::Ptr{Void},bOwnFlag::Integer)
     ccall((:GDALApproxTransformerOwnsSubtransformer,libgdal),Void,(Ptr{Void},Cint),pCBData,bOwnFlag)
 end
 
+
+"""
+    GDALDestroyApproxTransformer(void * pApproxArg) -> void
+
+Cleanup approximate transformer.
+
+### Parameters
+* **pCBData**: callback data originally returned by GDALCreateApproxTransformer().
+"""
 function destroyapproxtransformer(pApproxArg::Ptr{Void})
     ccall((:GDALDestroyApproxTransformer,libgdal),Void,(Ptr{Void},),pApproxArg)
 end
 
+
+"""
+    GDALApproxTransform(void * pTransformArg,
+                        int bDstToSrc,
+                        int nPointCount,
+                        double * x,
+                        double * y,
+                        double * z,
+                        int * panSuccess) -> int
+
+Perform approximate transformation.
+"""
 function approxtransform(pTransformArg::Ptr{Void},bDstToSrc::Integer,nPointCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},panSuccess::Vector{Cint})
     ccall((:GDALApproxTransform,libgdal),Cint,(Ptr{Void},Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),pTransformArg,bDstToSrc,nPointCount,x,y,z,panSuccess)
 end
 
+
+"""
+    GDALSimpleImageWarp(GDALDatasetH hSrcDS,
+                        GDALDatasetH hDstDS,
+                        int nBandCount,
+                        int * panBandList,
+                        GDALTransformerFunc pfnTransform,
+                        void * pTransformArg,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg,
+                        char ** papszWarpOptions) -> int
+
+Perform simple image warp.
+
+### Parameters
+* **hSrcDS**: the source image dataset.
+* **hDstDS**: the destination image dataset.
+* **nBandCount**: the number of bands to be warped. If zero, all bands will be processed.
+* **panBandList**: the list of bands to translate.
+* **pfnTransform**: the transformation function to call. See GDALTransformerFunc().
+* **pTransformArg**: the callback handle to pass to pfnTransform.
+* **pfnProgress**: the function used to report progress. See GDALProgressFunc().
+* **pProgressArg**: the callback handle to pass to pfnProgress.
+* **papszWarpOptions**: additional options controlling the warp.
+
+### Returns
+TRUE if the operation completes, or FALSE if an error occurs.
+"""
 function simpleimagewarp(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,nBandCount::Integer,panBandList::Vector{Cint},pfnTransform::GDALTransformerFunc,pTransformArg::Ptr{Void},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},papszWarpOptions::Vector{UTF8String})
     ccall((:GDALSimpleImageWarp,libgdal),Cint,(GDALDatasetH,GDALDatasetH,Cint,Ptr{Cint},GDALTransformerFunc,Ptr{Void},GDALProgressFunc,Ptr{Void},Ptr{Ptr{UInt8}}),hSrcDS,hDstDS,nBandCount,panBandList,pfnTransform,pTransformArg,pfnProgress,pProgressArg,papszWarpOptions)
 end
 
+
+"""
+    GDALSuggestedWarpOutput(GDALDatasetH hSrcDS,
+                            GDALTransformerFunc pfnTransformer,
+                            void * pTransformArg,
+                            double * padfGeoTransformOut,
+                            int * pnPixels,
+                            int * pnLines) -> CPLErr
+
+Suggest output file size.
+
+### Parameters
+* **hSrcDS**: the input image (it is assumed the whole input images is being transformed).
+* **pfnTransformer**: the transformer function.
+* **pTransformArg**: the callback data for the transformer function.
+* **padfGeoTransformOut**: the array of six doubles in which the suggested geotransform is returned.
+* **pnPixels**: int in which the suggest pixel width of output is returned.
+* **pnLines**: int in which the suggest pixel height of output is returned.
+
+### Returns
+CE_None if successful or CE_Failure otherwise.
+"""
 function suggestedwarpoutput(hSrcDS::GDALDatasetH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeoTransformOut::Vector{Float64},pnPixels::Vector{Cint},pnLines::Vector{Cint})
     ccall((:GDALSuggestedWarpOutput,libgdal),CPLErr,(GDALDatasetH,GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Cint},Ptr{Cint}),hSrcDS,pfnTransformer,pTransformArg,padfGeoTransformOut,pnPixels,pnLines)
 end
 
+
+"""
+    GDALSuggestedWarpOutput2(GDALDatasetH hSrcDS,
+                             GDALTransformerFunc pfnTransformer,
+                             void * pTransformArg,
+                             double * padfGeoTransformOut,
+                             int * pnPixels,
+                             int * pnLines,
+                             double * padfExtents,
+                             int nOptions) -> CPLErr
+"""
 function suggestedwarpoutput2(hSrcDS::GDALDatasetH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeoTransformOut::Vector{Float64},pnPixels::Vector{Cint},pnLines::Vector{Cint},padfExtents::Vector{Float64},nOptions::Integer)
     ccall((:GDALSuggestedWarpOutput2,libgdal),CPLErr,(GDALDatasetH,GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Cint},Ptr{Cint},Ptr{Cdouble},Cint),hSrcDS,pfnTransformer,pTransformArg,padfGeoTransformOut,pnPixels,pnLines,padfExtents,nOptions)
 end
 
+
+"""
+    GDALSerializeTransformer(GDALTransformerFunc pfnFunc,
+                             void * pTransformArg) -> CPLXMLNode *
+"""
 function serializetransformer(pfnFunc::GDALTransformerFunc,pTransformArg::Ptr{Void})
     ccall((:GDALSerializeTransformer,libgdal),Ptr{CPLXMLNode},(GDALTransformerFunc,Ptr{Void}),pfnFunc,pTransformArg)
 end
 
+
+"""
+    GDALDeserializeTransformer(CPLXMLNode * psTree,
+                               GDALTransformerFunc * ppfnFunc,
+                               void ** ppTransformArg) -> CPLErr
+"""
 function deserializetransformer(psTree::Ptr{CPLXMLNode},ppfnFunc::Ptr{GDALTransformerFunc},ppTransformArg::Ptr{Ptr{Void}})
     ccall((:GDALDeserializeTransformer,libgdal),CPLErr,(Ptr{CPLXMLNode},Ptr{GDALTransformerFunc},Ptr{Ptr{Void}}),psTree,ppfnFunc,ppTransformArg)
 end
 
+
+"""
+    GDALTransformGeolocations(GDALRasterBandH hXBand,
+                              GDALRasterBandH hYBand,
+                              GDALRasterBandH hZBand,
+                              GDALTransformerFunc pfnTransformer,
+                              void * pTransformArg,
+                              GDALProgressFunc pfnProgress,
+                              void * pProgressArg,
+                              char ** papszOptions) -> CPLErr
+"""
 function transformgeolocations(hXBand::GDALRasterBandH,hYBand::GDALRasterBandH,hZBand::GDALRasterBandH,pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void},papszOptions::Vector{UTF8String})
     ccall((:GDALTransformGeolocations,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,GDALRasterBandH,GDALTransformerFunc,Ptr{Void},GDALProgressFunc,Ptr{Void},Ptr{Ptr{UInt8}}),hXBand,hYBand,hZBand,pfnTransformer,pTransformArg,pfnProgress,pProgressArg,papszOptions)
 end
 
+
+"""
+    GDAL_CG_Create(int nWidth,
+                   int nHeight,
+                   int bNoDataSet,
+                   double dfNoDataValue,
+                   double dfContourInterval,
+                   double dfContourBase,
+                   GDALContourWriter pfnWriter,
+                   void * pCBData) -> GDALContourGeneratorH
+"""
 function create(nWidth::Integer,nHeight::Integer,bNoDataSet::Integer,dfNoDataValue::Real,dfContourInterval::Real,dfContourBase::Real,pfnWriter::GDALContourWriter,pCBData::Ptr{Void})
     checknull(ccall((:GDAL_CG_Create,libgdal),GDALContourGeneratorH,(Cint,Cint,Cint,Cdouble,Cdouble,Cdouble,GDALContourWriter,Ptr{Void}),nWidth,nHeight,bNoDataSet,dfNoDataValue,dfContourInterval,dfContourBase,pfnWriter,pCBData))
 end
 
+
+"""
+    GDAL_CG_FeedLine(GDALContourGeneratorH hCG,
+                     double * padfScanline) -> CPLErr
+"""
 function feedline(hCG::GDALContourGeneratorH,padfScanline::Vector{Float64})
     ccall((:GDAL_CG_FeedLine,libgdal),CPLErr,(GDALContourGeneratorH,Ptr{Cdouble}),hCG,padfScanline)
 end
 
+
+"""
+    GDAL_CG_Destroy(GDALContourGeneratorH hCG) -> void
+"""
 function destroy(hCG::GDALContourGeneratorH)
     ccall((:GDAL_CG_Destroy,libgdal),Void,(GDALContourGeneratorH,),hCG)
 end
 
+
+"""
+    OGRContourWriter(double dfLevel,
+                     int nPoints,
+                     double * padfX,
+                     double * padfY,
+                     void * pInfo) -> CPLErr
+"""
 function contourwriter(arg1::Real,arg2::Integer,arg3::Vector{Float64},arg4::Vector{Float64},pInfo::Ptr{Void})
     ccall((:OGRContourWriter,libgdal),CPLErr,(Cdouble,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Void}),arg1,arg2,arg3,arg4,pInfo)
 end
 
+
+"""
+    GDALContourGenerate(GDALRasterBandH hBand,
+                        double dfContourInterval,
+                        double dfContourBase,
+                        int nFixedLevelCount,
+                        double * padfFixedLevels,
+                        int bUseNoData,
+                        double dfNoDataValue,
+                        void * hLayer,
+                        int iIDField,
+                        int iElevField,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg) -> CPLErr
+
+Create vector contours from raster DEM.
+
+### Parameters
+* **hBand**: The band to read raster data from. The whole band will be processed.
+* **dfContourInterval**: The elevation interval between contours generated.
+* **dfContourBase**: The "base" relative to which contour intervals are applied. This is normally zero, but could be different. To generate 10m contours at 5, 15, 25, ... the ContourBase would be 5.
+* **nFixedLevelCount**: The number of fixed levels. If this is greater than zero, then fixed levels will be used, and ContourInterval and ContourBase are ignored.
+* **padfFixedLevels**: The list of fixed contour levels at which contours should be generated. It will contain FixedLevelCount entries, and may be NULL if fixed levels are disabled (FixedLevelCount = 0).
+* **bUseNoData**: If TRUE the dfNoDataValue will be used.
+* **dfNoDataValue**: The value to use as a "nodata" value. That is, a pixel value which should be ignored in generating contours as if the value of the pixel were not known.
+* **hLayer**: The layer to which new contour vectors will be written. Each contour will have a LINESTRING geometry attached to it. This is really of type OGRLayerH, but void * is used to avoid pulling the ogr_api.h file in here.
+* **iIDField**: If not -1 this will be used as a field index to indicate where a unique id should be written for each feature (contour) written.
+* **iElevField**: If not -1 this will be used as a field index to indicate where the elevation value of the contour should be written.
+* **pfnProgress**: A GDALProgressFunc that may be used to report progress to the user, or to interrupt the algorithm. May be NULL if not required.
+* **pProgressArg**: The callback data for the pfnProgress function.
+
+### Returns
+CE_None on success or CE_Failure if an error occurs.
+"""
 function contourgenerate(hBand::GDALRasterBandH,dfContourInterval::Real,dfContourBase::Real,nFixedLevelCount::Integer,padfFixedLevels::Vector{Float64},bUseNoData::Integer,dfNoDataValue::Real,hLayer::Ptr{Void},iIDField::Integer,iElevField::Integer,pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALContourGenerate,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cdouble},Cint,Cdouble,Ptr{Void},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfContourInterval,dfContourBase,nFixedLevelCount,padfFixedLevels,bUseNoData,dfNoDataValue,hLayer,iIDField,iElevField,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeGeometries(GDALDatasetH hDS,
+                            int nBandCount,
+                            int * panBandList,
+                            int nGeomCount,
+                            OGRGeometryH * pahGeometries,
+                            GDALTransformerFunc pfnTransformer,
+                            void * pTransformArg,
+                            double * padfGeomBurnValue,
+                            char ** papszOptions,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressArg) -> CPLErr
+
+Burn geometries into raster.
+
+### Parameters
+* **hDS**: output data, must be opened in update mode.
+* **nBandCount**: the number of bands to be updated.
+* **panBandList**: the list of bands to be updated.
+* **nGeomCount**: the number of geometries being passed in pahGeometries.
+* **pahGeometries**: the array of geometries to burn in.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **padfGeomBurnValue**: the array of values to burn into the raster. There should be nBandCount values for each geometry.
+* **papszOptions**: special options controlling rasterization 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"BURN_VALUE_FROM": 
+May be set to "Z" to use the Z values of the geometries. dfBurnValue is added to this before burning. Defaults to GDALBurnValueSrc.GBV_UserBurnValue in which case just the dfBurnValue is burned. This is implemented only for points and lines for now. The M value may be supported in the future. 
+"MERGE_ALG": 
+May be REPLACE (the default) or ADD. REPLACE results in overwriting of value, while ADD adds the new value to the existing raster, suitable for heatmaps for instance.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function rasterizegeometries(hDS::GDALDatasetH,nBandCount::Integer,panBandList::Vector{Cint},nGeomCount::Integer,pahGeometries::Ptr{OGRGeometryH},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfGeomBurnValue::Vector{Float64},papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeGeometries,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{Cint},Cint,Ptr{OGRGeometryH},GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hDS,nBandCount,panBandList,nGeomCount,pahGeometries,pfnTransformer,pTransformArg,padfGeomBurnValue,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeLayers(GDALDatasetH hDS,
+                        int nBandCount,
+                        int * panBandList,
+                        int nLayerCount,
+                        OGRLayerH * pahLayers,
+                        GDALTransformerFunc pfnTransformer,
+                        void * pTransformArg,
+                        double * padfLayerBurnValues,
+                        char ** papszOptions,
+                        GDALProgressFunc pfnProgress,
+                        void * pProgressArg) -> CPLErr
+
+Burn geometries from the specified list of layers into raster.
+
+### Parameters
+* **hDS**: output data, must be opened in update mode.
+* **nBandCount**: the number of bands to be updated.
+* **panBandList**: the list of bands to be updated.
+* **nLayerCount**: the number of layers being passed in pahLayers array.
+* **pahLayers**: the array of layers to burn in.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **padfLayerBurnValues**: the array of values to burn into the raster. There should be nBandCount values for each layer.
+* **papszOptions**: special options controlling rasterization: 
+"ATTRIBUTE": 
+Identifies an attribute field on the features to be used for a burn in value. The value will be burned into all output bands. If specified, padfLayerBurnValues will not be used and can be a NULL pointer. 
+"CHUNKYSIZE": 
+The height in lines of the chunk to operate on. The larger the chunk size the less times we need to make a pass through all the shapes. If it is not set or set to zero the default chunk size will be used. Default size will be estimated based on the GDAL cache buffer size using formula: cache_size_bytes/scanline_size_bytes, so the chunk will not exceed the cache. 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE. 
+"BURN_VALUE_FROM": 
+May be set to "Z" to use the Z values of the geometries. The value from padfLayerBurnValues or the attribute field value is added to this before burning. In default case dfBurnValue is burned as it is. This is implemented properly only for points and lines for now. Polygons will be burned using the Z value from the first point. The M value may be supported in the future. 
+"MERGE_ALG": 
+May be REPLACE (the default) or ADD. REPLACE results in overwriting of value, while ADD adds the new value to the existing raster, suitable for heatmaps for instance.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function rasterizelayers(hDS::GDALDatasetH,nBandCount::Integer,panBandList::Vector{Cint},nLayerCount::Integer,pahLayers::Ptr{OGRLayerH},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},padfLayerBurnValues::Vector{Float64},papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeLayers,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{Cint},Cint,Ptr{OGRLayerH},GDALTransformerFunc,Ptr{Void},Ptr{Cdouble},Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hDS,nBandCount,panBandList,nLayerCount,pahLayers,pfnTransformer,pTransformArg,padfLayerBurnValues,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALRasterizeLayersBuf(void * pData,
+                           int nBufXSize,
+                           int nBufYSize,
+                           GDALDataType eBufType,
+                           int nPixelSpace,
+                           int nLineSpace,
+                           int nLayerCount,
+                           OGRLayerH * pahLayers,
+                           const char * pszDstProjection,
+                           double * padfDstGeoTransform,
+                           GDALTransformerFunc pfnTransformer,
+                           void * pTransformArg,
+                           double dfBurnValue,
+                           char ** papszOptions,
+                           GDALProgressFunc pfnProgress,
+                           void * pProgressArg) -> CPLErr
+
+Burn geometries from the specified list of layer into raster.
+
+### Parameters
+* **pData**: pointer to the output data array.
+* **nBufXSize**: width of the output data array in pixels.
+* **nBufYSize**: height of the output data array in pixels.
+* **eBufType**: data type of the output data array.
+* **nPixelSpace**: The byte offset from the start of one pixel value in pData to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in pData to the start of the next. If defaulted the size of the datatype eBufType * nBufXSize is used.
+* **nLayerCount**: the number of layers being passed in pahLayers array.
+* **pahLayers**: the array of layers to burn in.
+* **pszDstProjection**: WKT defining the coordinate system of the target raster.
+* **padfDstGeoTransform**: geotransformation matrix of the target raster.
+* **pfnTransformer**: transformation to apply to geometries to put into pixel/line coordinates on raster. If NULL a geotransform based one will be created internally.
+* **pTransformArg**: callback data for transformer.
+* **dfBurnValue**: the value to burn into the raster.
+* **papszOptions**: special options controlling rasterization: 
+"ATTRIBUTE": 
+Identifies an attribute field on the features to be used for a burn in value. The value will be burned into all output bands. If specified, padfLayerBurnValues will not be used and can be a NULL pointer. 
+"ALL_TOUCHED": 
+May be set to TRUE to set all pixels touched by the line or polygons, not just those whose center is within the polygon or that are selected by brezenhams line algorithm. Defaults to FALSE.
+* **pfnProgress**: the progress function to report completion.
+* **pProgressArg**: callback data for progress function.
+
+### Returns
+CE_None on success or CE_Failure on error.
+"""
 function rasterizelayersbuf(pData::Ptr{Void},nBufXSize::Integer,nBufYSize::Integer,eBufType::GDALDataType,nPixelSpace::Integer,nLineSpace::Integer,nLayerCount::Integer,pahLayers::Ptr{OGRLayerH},pszDstProjection::AbstractString,padfDstGeoTransform::Vector{Float64},pfnTransformer::GDALTransformerFunc,pTransformArg::Ptr{Void},dfBurnValue::Real,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressArg::Ptr{Void})
     ccall((:GDALRasterizeLayersBuf,libgdal),CPLErr,(Ptr{Void},Cint,Cint,GDALDataType,Cint,Cint,Cint,Ptr{OGRLayerH},Ptr{UInt8},Ptr{Cdouble},GDALTransformerFunc,Ptr{Void},Cdouble,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),pData,nBufXSize,nBufYSize,eBufType,nPixelSpace,nLineSpace,nLayerCount,pahLayers,pszDstProjection,padfDstGeoTransform,pfnTransformer,pTransformArg,dfBurnValue,papszOptions,pfnProgress,pProgressArg)
 end
 
+
+"""
+    GDALGridCreate(GDALGridAlgorithm,
+                   const void *,
+                   GUInt32,
+                   const double *,
+                   const double *,
+                   const double *,
+                   double,
+                   double,
+                   double,
+                   double,
+                   GUInt32,
+                   GUInt32,
+                   GDALDataType,
+                   void *,
+                   GDALProgressFunc,
+                   void *) -> CPLErr
+
+Create regular grid from the scattered data.
+
+### Parameters
+* **eAlgorithm**: Gridding method.
+* **poOptions**: Options to control choosen gridding method.
+* **nPoints**: Number of elements in input arrays.
+* **padfX**: Input array of X coordinates.
+* **padfY**: Input array of Y coordinates.
+* **padfZ**: Input array of Z values.
+* **dfXMin**: Lowest X border of output grid.
+* **dfXMax**: Highest X border of output grid.
+* **dfYMin**: Lowest Y border of output grid.
+* **dfYMax**: Highest Y border of output grid.
+* **nXSize**: Number of columns in output grid.
+* **nYSize**: Number of rows in output grid.
+* **eType**: Data type of output array.
+* **pData**: Pointer to array where the computed grid will be stored.
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+CE_None on success or CE_Failure if something goes wrong.
+"""
 function gridcreate(arg1::GDALGridAlgorithm,arg2::Ptr{Void},arg3::GUInt32,arg4::Vector{Float64},arg5::Vector{Float64},arg6::Vector{Float64},arg7::Real,arg8::Real,arg9::Real,arg10::Real,arg11::GUInt32,arg12::GUInt32,arg13::GDALDataType,arg14::Ptr{Void},arg15::GDALProgressFunc,arg16::Ptr{Void})
     ccall((:GDALGridCreate,libgdal),CPLErr,(GDALGridAlgorithm,Ptr{Void},GUInt32,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Cdouble,Cdouble,Cdouble,Cdouble,GUInt32,GUInt32,GDALDataType,Ptr{Void},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10,arg11,arg12,arg13,arg14,arg15,arg16)
 end
 
+
+"""
+    GDALComputeMatchingPoints(GDALDatasetH hFirstImage,
+                              GDALDatasetH hSecondImage,
+                              char ** papszOptions,
+                              int * pnGCPCount) -> GDAL_GCP *
+"""
 function computematchingpoints(hFirstImage::GDALDatasetH,hSecondImage::GDALDatasetH,papszOptions::Vector{UTF8String},pnGCPCount::Vector{Cint})
     ccall((:GDALComputeMatchingPoints,libgdal),Ptr{GDAL_GCP},(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}},Ptr{Cint}),hFirstImage,hSecondImage,papszOptions,pnGCPCount)
 end
-

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -1,868 +1,3034 @@
+
+
+"""
+    GDALGetDataTypeSize(GDALDataType) -> int
+
+Get data type size in bits.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bits or zero if it is not recognised.
+"""
 function getdatatypesize(arg1::GDALDataType)
     ccall((:GDALGetDataTypeSize,libgdal),Cint,(GDALDataType,),arg1)
 end
 
+
+"""
+    GDALDataTypeIsComplex(GDALDataType) -> int
+
+Is data type complex?
+
+### Returns
+TRUE if the passed type is complex (one of GDT_CInt16, GDT_CInt32, GDT_CFloat32 or GDT_CFloat64), that is it consists of a real and imaginary component.
+"""
 function datatypeiscomplex(arg1::GDALDataType)
     ccall((:GDALDataTypeIsComplex,libgdal),Cint,(GDALDataType,),arg1)
 end
 
+
+"""
+    GDALGetDataTypeName(GDALDataType) -> const char *
+
+Get name of data type.
+
+### Parameters
+* **eDataType**: type to get name of.
+
+### Returns
+string corresponding to existing data type or NULL pointer if invalid type given.
+"""
 function getdatatypename(arg1::GDALDataType)
     bytestring(ccall((:GDALGetDataTypeName,libgdal),Ptr{UInt8},(GDALDataType,),arg1))
 end
 
+
+"""
+    GDALGetDataTypeByName(const char *) -> GDALDataType
+
+Get data type by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the type.
+
+### Returns
+GDAL data type.
+"""
 function getdatatypebyname(arg1::AbstractString)
     ccall((:GDALGetDataTypeByName,libgdal),GDALDataType,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALDataTypeUnion(GDALDataType,
+                      GDALDataType) -> GDALDataType
+
+Return the smallest data type that can fully express both input data types.
+
+### Parameters
+* **eType1**: first data type.
+* **eType2**: second data type.
+
+### Returns
+a data type able to express eType1 and eType2.
+"""
 function datatypeunion(arg1::GDALDataType,arg2::GDALDataType)
     ccall((:GDALDataTypeUnion,libgdal),GDALDataType,(GDALDataType,GDALDataType),arg1,arg2)
 end
 
+
+"""
+    GDALGetAsyncStatusTypeName(GDALAsyncStatusType) -> const char *
+
+Get name of AsyncStatus data type.
+
+### Parameters
+* **eAsyncStatusType**: type to get name of.
+
+### Returns
+string corresponding to type.
+"""
 function getasyncstatustypename(arg1::GDALAsyncStatusType)
     bytestring(ccall((:GDALGetAsyncStatusTypeName,libgdal),Ptr{UInt8},(GDALAsyncStatusType,),arg1))
 end
 
+
+"""
+    GDALGetAsyncStatusTypeByName(const char *) -> GDALAsyncStatusType
+
+Get AsyncStatusType by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the type.
+
+### Returns
+GDAL AsyncStatus type.
+"""
 function getasyncstatustypebyname(arg1::AbstractString)
     ccall((:GDALGetAsyncStatusTypeByName,libgdal),GDALAsyncStatusType,(Ptr{UInt8},),arg1)
 end
 
+
+"""
+    GDALGetColorInterpretationName(GDALColorInterp) -> const char *
+
+Get name of color interpretation.
+
+### Parameters
+* **eInterp**: color interpretation to get name of.
+
+### Returns
+string corresponding to color interpretation or NULL pointer if invalid enumerator given.
+"""
 function getcolorinterpretationname(arg1::GDALColorInterp)
     bytestring(ccall((:GDALGetColorInterpretationName,libgdal),Ptr{UInt8},(GDALColorInterp,),arg1))
 end
 
+
+"""
+    GDALGetColorInterpretationByName(const char * pszName) -> GDALColorInterp
+
+Get color interpreation by symbolic name.
+
+### Parameters
+* **pszName**: string containing the symbolic name of the color interpretation.
+
+### Returns
+GDAL color interpretation.
+"""
 function getcolorinterpretationbyname(pszName::AbstractString)
     ccall((:GDALGetColorInterpretationByName,libgdal),GDALColorInterp,(Ptr{UInt8},),pszName)
 end
 
+
+"""
+    GDALGetPaletteInterpretationName(GDALPaletteInterp) -> const char *
+
+Get name of palette interpretation.
+
+### Parameters
+* **eInterp**: palette interpretation to get name of.
+
+### Returns
+string corresponding to palette interpretation.
+"""
 function getpaletteinterpretationname(arg1::GDALPaletteInterp)
     bytestring(ccall((:GDALGetPaletteInterpretationName,libgdal),Ptr{UInt8},(GDALPaletteInterp,),arg1))
 end
 
+
+"""
+    GDALAllRegister(void) -> void
+
+Register all known configured GDAL drivers.
+"""
 function allregister()
     ccall((:GDALAllRegister,libgdal),Void,())
 end
 
+
+"""
+    GDALCreate(GDALDriverH hDriver,
+               const char *,
+               int,
+               int,
+               int,
+               GDALDataType,
+               char **) -> GDALDatasetH
+
+Create a new dataset with this driver.
+"""
 function create(hDriver::GDALDriverH,arg1::AbstractString,arg2::Integer,arg3::Integer,arg4::Integer,arg5::GDALDataType,arg6::Vector{UTF8String})
     checknull(ccall((:GDALCreate,libgdal),GDALDatasetH,(GDALDriverH,Ptr{UInt8},Cint,Cint,Cint,GDALDataType,Ptr{Ptr{UInt8}}),hDriver,arg1,arg2,arg3,arg4,arg5,arg6))
 end
 
+
+"""
+    GDALCreateCopy(GDALDriverH,
+                   const char *,
+                   GDALDatasetH,
+                   int,
+                   char **,
+                   GDALProgressFunc,
+                   void *) -> GDALDatasetH
+
+Create a copy of a dataset.
+"""
 function createcopy(arg1::GDALDriverH,arg2::AbstractString,arg3::GDALDatasetH,arg4::Integer,arg5::Vector{UTF8String},arg6::GDALProgressFunc,arg7::Ptr{Void})
     checknull(ccall((:GDALCreateCopy,libgdal),GDALDatasetH,(GDALDriverH,Ptr{UInt8},GDALDatasetH,Cint,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7))
 end
 
+
+"""
+    GDALIdentifyDriver(const char * pszFilename,
+                       char ** papszFileList) -> GDALDriverH
+
+Identify the driver that can open a raster file.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset.
+* **papszFileList**: an array of strings, whose last element is the NULL pointer. These strings are filenames that are auxiliary to the main filename. The passed value may be NULL.
+
+### Returns
+A GDALDriverH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDriver *.
+"""
 function identifydriver(pszFilename::AbstractString,papszFileList::Vector{UTF8String})
     checknull(ccall((:GDALIdentifyDriver,libgdal),GDALDriverH,(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszFilename,papszFileList))
 end
 
+
+"""
+    GDALOpen(const char * pszFilename,
+             GDALAccess eAccess) -> GDALDatasetH
+
+Open a raster file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **eAccess**: the desired access, either GA_Update or GA_ReadOnly. Many drivers support only read only access.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function open(pszFilename::AbstractString,eAccess::GDALAccess)
     checknull(ccall((:GDALOpen,libgdal),GDALDatasetH,(Ptr{UInt8},GDALAccess),pszFilename,eAccess))
 end
 
+
+"""
+    GDALOpenShared(const char *,
+                   GDALAccess) -> GDALDatasetH
+
+Open a raster file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **eAccess**: the desired access, either GA_Update or GA_ReadOnly. Many drivers support only read only access.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function openshared(arg1::AbstractString,arg2::GDALAccess)
     checknull(ccall((:GDALOpenShared,libgdal),GDALDatasetH,(Ptr{UInt8},GDALAccess),arg1,arg2))
 end
 
+
+"""
+    GDALOpenEx(const char * pszFilename,
+               unsigned int nOpenFlags,
+               const char *const * papszAllowedDrivers,
+               const char *const * papszOpenOptions,
+               const char *const * papszSiblingFiles) -> friend GDALDatasetH
+
+Open a raster or vector file as a GDALDataset.
+
+### Parameters
+* **pszFilename**: the name of the file to access. In the case of exotic drivers this may not refer to a physical file, but instead contain information for the driver on how to access a dataset. It should be in UTF-8 encoding.
+* **nOpenFlags**: a combination of GDAL_OF_ flags that may be combined through logical or operator. 
+
+Driver kind: GDAL_OF_RASTER for raster drivers, GDAL_OF_VECTOR for vector drivers. If none of the value is specified, both kinds are implied. 
+
+Access mode: GDAL_OF_READONLY (exclusive)or GDAL_OF_UPDATE. 
+
+Shared mode: GDAL_OF_SHARED. If set, it allows the sharing of GDALDataset handles for a dataset with other callers that have set GDAL_OF_SHARED. In particular, GDALOpenEx() will first consult its list of currently open and shared GDALDataset's, and if the GetDescription() name for one exactly matches the pszFilename passed to GDALOpenEx() it will be referenced and returned, if GDALOpenEx() is called from the same thread. 
+
+Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the file will lead to an error message to be reported.
+* **papszAllowedDrivers**: NULL to consider all candidate drivers, or a NULL terminated list of strings with the driver short names that must be considered.
+* **papszOpenOptions**: NULL, or a NULL terminated list of strings with open options passed to candidate drivers. An option exists for all drivers, OVERVIEW_LEVEL=level, to select a particular overview level of a dataset. The level index starts at 0. The level number can be suffixed by "only" to specify that only this overview level must be visible, and not sub-levels. Open options are validated by default, and a warning is emitted in case the option is not recognized. In some scenarios, it might be not desirable (e.g. when not knowing which driver will open the file), so the special open option VALIDATE_OPEN_OPTIONS can be set to NO to avoid such warnings.
+* **papszSiblingFiles**: NULL, or a NULL terminated list of strings that are filenames that are auxiliary to the main filename. If NULL is passed, a probing of the file system will be done.
+
+### Returns
+A GDALDatasetH handle or NULL on failure. For C++ applications this handle can be cast to a GDALDataset *.
+"""
 function openex(pszFilename::AbstractString,nOpenFlags::UInt32,papszAllowedDrivers::Vector{UTF8String},papszOpenOptions::Vector{UTF8String},papszSiblingFiles::Vector{UTF8String})
     checknull(ccall((:GDALOpenEx,libgdal),GDALDatasetH,(Ptr{UInt8},UInt32,Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}}),pszFilename,nOpenFlags,papszAllowedDrivers,papszOpenOptions,papszSiblingFiles))
 end
 
+
+"""
+    GDALDumpOpenDatasets(FILE *) -> int
+
+List open datasets.
+"""
 function dumpopendatasets(arg1::Ptr{FILE})
     ccall((:GDALDumpOpenDatasets,libgdal),Cint,(Ptr{FILE},),arg1)
 end
 
+
+"""
+    GDALGetDriverByName(const char *) -> GDALDriverH
+
+Fetch a driver based on the short name.
+"""
 function getdriverbyname(arg1::AbstractString)
     checknull(ccall((:GDALGetDriverByName,libgdal),GDALDriverH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    GDALGetDriverCount(void) -> int
+
+Fetch the number of registered drivers.
+"""
 function getdrivercount()
     ccall((:GDALGetDriverCount,libgdal),Cint,())
 end
 
+
+"""
+    GDALGetDriver(int) -> GDALDriverH
+
+Fetch driver by index.
+"""
 function getdriver(arg1::Integer)
     checknull(ccall((:GDALGetDriver,libgdal),GDALDriverH,(Cint,),arg1))
 end
 
+
+"""
+    GDALDestroyDriver(GDALDriverH) -> void
+
+Destroy a GDALDriver.
+
+### Parameters
+* **hDriver**: the driver to destroy.
+"""
 function destroydriver(arg1::GDALDriverH)
     ccall((:GDALDestroyDriver,libgdal),Void,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALRegisterDriver(GDALDriverH) -> int
+
+Register a driver for use.
+"""
 function registerdriver(arg1::GDALDriverH)
     ccall((:GDALRegisterDriver,libgdal),Cint,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALDeregisterDriver(GDALDriverH) -> void
+
+Deregister the passed driver.
+"""
 function deregisterdriver(arg1::GDALDriverH)
     ccall((:GDALDeregisterDriver,libgdal),Void,(GDALDriverH,),arg1)
 end
 
+
+"""
+    GDALDestroyDriverManager(void) -> void
+
+Destroy the driver manager.
+"""
 function destroydrivermanager()
     ccall((:GDALDestroyDriverManager,libgdal),Void,())
 end
 
+
+"""
+    GDALDestroy(void) -> void
+"""
 function destroy()
     ccall((:GDALDestroy,libgdal),Void,())
 end
 
+
+"""
+    GDALDeleteDataset(GDALDriverH,
+                      const char *) -> CPLErr
+
+Delete named dataset.
+"""
 function deletedataset(arg1::GDALDriverH,arg2::AbstractString)
     ccall((:GDALDeleteDataset,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALRenameDataset(GDALDriverH,
+                      const char * pszNewName,
+                      const char * pszOldName) -> CPLErr
+
+Rename a dataset.
+"""
 function renamedataset(arg1::GDALDriverH,pszNewName::AbstractString,pszOldName::AbstractString)
     ccall((:GDALRenameDataset,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8},Ptr{UInt8}),arg1,pszNewName,pszOldName)
 end
 
+
+"""
+    GDALCopyDatasetFiles(GDALDriverH,
+                         const char * pszNewName,
+                         const char * pszOldName) -> CPLErr
+
+Copy the files of a dataset.
+"""
 function copydatasetfiles(arg1::GDALDriverH,pszNewName::AbstractString,pszOldName::AbstractString)
     ccall((:GDALCopyDatasetFiles,libgdal),CPLErr,(GDALDriverH,Ptr{UInt8},Ptr{UInt8}),arg1,pszNewName,pszOldName)
 end
 
+
+"""
+    GDALValidateCreationOptions(GDALDriverH,
+                                char ** papszCreationOptions) -> int
+
+Validate the list of creation options that are handled by a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver with whom the lists of creation option must be validated
+* **papszCreationOptions**: the list of creation options. An array of strings, whose last element is a NULL pointer
+
+### Returns
+TRUE if the list of creation options is compatible with the Create() and CreateCopy() method of the driver, FALSE otherwise.
+"""
 function validatecreationoptions(arg1::GDALDriverH,papszCreationOptions::Vector{UTF8String})
     ccall((:GDALValidateCreationOptions,libgdal),Cint,(GDALDriverH,Ptr{Ptr{UInt8}}),arg1,papszCreationOptions)
 end
 
+
+"""
+    GDALGetDriverShortName(GDALDriverH) -> const char *
+
+Return the short name of a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the short name of the driver. The returned string should not be freed and is owned by the driver.
+"""
 function getdrivershortname(arg1::GDALDriverH)
     bytestring(ccall((:GDALGetDriverShortName,libgdal),Ptr{UInt8},(GDALDriverH,),arg1))
 end
 
+
+"""
+    GDALGetDriverLongName(GDALDriverH) -> const char *
+
+Return the long name of a driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the long name of the driver or empty string. The returned string should not be freed and is owned by the driver.
+"""
 function getdriverlongname(arg1::GDALDriverH)
     bytestring(ccall((:GDALGetDriverLongName,libgdal),Ptr{UInt8},(GDALDriverH,),arg1))
 end
 
+
+"""
+    GDALGetDriverHelpTopic(GDALDriverH) -> const char *
+
+Return the URL to the help that describes the driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+the URL to the help that describes the driver or NULL. The returned string should not be freed and is owned by the driver.
+"""
 function getdriverhelptopic(arg1::GDALDriverH)
     bytestring(ccall((:GDALGetDriverHelpTopic,libgdal),Ptr{UInt8},(GDALDriverH,),arg1))
 end
 
+
+"""
+    GDALGetDriverCreationOptionList(GDALDriverH) -> const char *
+
+Return the list of creation options of the driver.
+
+### Parameters
+* **hDriver**: the handle of the driver
+
+### Returns
+an XML string that describes the list of creation options or empty string. The returned string should not be freed and is owned by the driver.
+"""
 function getdrivercreationoptionlist(arg1::GDALDriverH)
     bytestring(ccall((:GDALGetDriverCreationOptionList,libgdal),Ptr{UInt8},(GDALDriverH,),arg1))
 end
 
+
+"""
+    GDALInitGCPs(int,
+                 GDAL_GCP *) -> void
+"""
 function initgcps(arg1::Integer,arg2::Ptr{GDAL_GCP})
     ccall((:GDALInitGCPs,libgdal),Void,(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALDeinitGCPs(int,
+                   GDAL_GCP *) -> void
+"""
 function deinitgcps(arg1::Integer,arg2::Ptr{GDAL_GCP})
     ccall((:GDALDeinitGCPs,libgdal),Void,(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALDuplicateGCPs(int,
+                      const GDAL_GCP *) -> GDAL_GCP *
+"""
 function duplicategcps(arg1::Integer,arg2::Ptr{GDAL_GCP})
     ccall((:GDALDuplicateGCPs,libgdal),Ptr{GDAL_GCP},(Cint,Ptr{GDAL_GCP}),arg1,arg2)
 end
 
+
+"""
+    GDALGCPsToGeoTransform(int nGCPCount,
+                           const GDAL_GCP * pasGCPs,
+                           double * padfGeoTransform,
+                           int bApproxOK) -> int
+
+Generate Geotransform from GCPs.
+
+### Parameters
+* **nGCPCount**: the number of GCPs being passed in.
+* **pasGCPs**: the list of GCP structures.
+* **padfGeoTransform**: the six double array in which the affine geotransformation will be returned.
+* **bApproxOK**: If FALSE the function will fail if the geotransform is not essentially an exact fit (within 0.25 pixel) for all GCPs.
+
+### Returns
+TRUE on success or FALSE if there aren't enough points to prepare a geotransform, the pointers are ill-determined or if bApproxOK is FALSE and the fit is poor.
+"""
 function gcpstogeotransform(nGCPCount::Integer,pasGCPs::Ptr{GDAL_GCP},padfGeoTransform::Vector{Float64},bApproxOK::Integer)
     ccall((:GDALGCPsToGeoTransform,libgdal),Cint,(Cint,Ptr{GDAL_GCP},Ptr{Cdouble},Cint),nGCPCount,pasGCPs,padfGeoTransform,bApproxOK)
 end
 
+
+"""
+    GDALInvGeoTransform(double * padfGeoTransformIn,
+                        double * padfInvGeoTransformOut) -> int
+
+Invert Geotransform.
+
+### Parameters
+* **gt_in**: Input geotransform (six doubles - unaltered).
+* **gt_out**: Output geotransform (six doubles - updated).
+
+### Returns
+TRUE on success or FALSE if the equation is uninvertable.
+"""
 function invgeotransform(padfGeoTransformIn::Vector{Float64},padfInvGeoTransformOut::Vector{Float64})
     ccall((:GDALInvGeoTransform,libgdal),Cint,(Ptr{Cdouble},Ptr{Cdouble}),padfGeoTransformIn,padfInvGeoTransformOut)
 end
 
+
+"""
+    GDALApplyGeoTransform(double *,
+                          double,
+                          double,
+                          double *,
+                          double *) -> void
+
+Apply GeoTransform to x/y coordinate.
+
+### Parameters
+* **padfGeoTransform**: Six coefficient GeoTransform to apply.
+* **dfPixel**: Input pixel position.
+* **dfLine**: Input line position.
+* **pdfGeoX**: output location where geo_x (easting/longitude) location is placed.
+* **pdfGeoY**: output location where geo_y (northing/latitude) location is placed.
+"""
 function applygeotransform(arg1::Vector{Float64},arg2::Real,arg3::Real,arg4::Vector{Float64},arg5::Vector{Float64})
     ccall((:GDALApplyGeoTransform,libgdal),Void,(Ptr{Cdouble},Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALComposeGeoTransforms(const double * padfGeoTransform1,
+                             const double * padfGeoTransform2,
+                             double * padfGeoTransformOut) -> void
+
+Compose two geotransforms.
+
+### Parameters
+* **padfGT1**: the first geotransform, six values.
+* **padfGT2**: the second geotransform, six values.
+* **padfGTOut**: the output geotransform, six values, may safely be the same array as padfGT1 or padfGT2.
+"""
 function composegeotransforms(padfGeoTransform1::Vector{Float64},padfGeoTransform2::Vector{Float64},padfGeoTransformOut::Vector{Float64})
     ccall((:GDALComposeGeoTransforms,libgdal),Void,(Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),padfGeoTransform1,padfGeoTransform2,padfGeoTransformOut)
 end
 
+
+"""
+    GDALGetMetadataDomainList(GDALMajorObjectH hObject) -> char **
+
+Fetch list of metadata domains.
+"""
 function getmetadatadomainlist(hObject::GDALMajorObjectH)
     bytestring(unsafe_load(ccall((:GDALGetMetadataDomainList,libgdal),Ptr{Ptr{UInt8}},(GDALMajorObjectH,),hObject)))
 end
 
+
+"""
+    GDALGetMetadata(GDALMajorObjectH,
+                    const char *) -> char **
+
+Fetch metadata.
+"""
 function getmetadata(arg1::GDALMajorObjectH,arg2::AbstractString)
     bytestring(unsafe_load(ccall((:GDALGetMetadata,libgdal),Ptr{Ptr{UInt8}},(GDALMajorObjectH,Ptr{UInt8}),arg1,arg2)))
 end
 
+
+"""
+    GDALSetMetadata(GDALMajorObjectH,
+                    char **,
+                    const char *) -> CPLErr
+
+Set metadata.
+"""
 function setmetadata(arg1::GDALMajorObjectH,arg2::Vector{UTF8String},arg3::AbstractString)
     ccall((:GDALSetMetadata,libgdal),CPLErr,(GDALMajorObjectH,Ptr{Ptr{UInt8}},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALGetMetadataItem(GDALMajorObjectH,
+                        const char *,
+                        const char *) -> const char *
+
+Fetch single metadata item.
+"""
 function getmetadataitem(arg1::GDALMajorObjectH,arg2::AbstractString,arg3::AbstractString)
     bytestring(ccall((:GDALGetMetadataItem,libgdal),Ptr{UInt8},(GDALMajorObjectH,Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3))
 end
 
+
+"""
+    GDALSetMetadataItem(GDALMajorObjectH,
+                        const char *,
+                        const char *,
+                        const char *) -> CPLErr
+
+Set single metadata item.
+"""
 function setmetadataitem(arg1::GDALMajorObjectH,arg2::AbstractString,arg3::AbstractString,arg4::AbstractString)
     ccall((:GDALSetMetadataItem,libgdal),CPLErr,(GDALMajorObjectH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetDescription(GDALMajorObjectH) -> const char *
+
+Fetch object description.
+"""
 function getdescription(arg1::GDALMajorObjectH)
     bytestring(ccall((:GDALGetDescription,libgdal),Ptr{UInt8},(GDALMajorObjectH,),arg1))
 end
 
+
+"""
+    GDALSetDescription(GDALMajorObjectH,
+                       const char *) -> void
+
+Set object description.
+"""
 function setdescription(arg1::GDALMajorObjectH,arg2::AbstractString)
     ccall((:GDALSetDescription,libgdal),Void,(GDALMajorObjectH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALGetDatasetDriver(GDALDatasetH) -> GDALDriverH
+
+Fetch the driver to which this dataset relates.
+"""
 function getdatasetdriver(arg1::GDALDatasetH)
     checknull(ccall((:GDALGetDatasetDriver,libgdal),GDALDriverH,(GDALDatasetH,),arg1))
 end
 
+
+"""
+    GDALGetFileList(GDALDatasetH) -> char **
+
+Fetch files forming dataset.
+"""
 function getfilelist(arg1::GDALDatasetH)
     bytestring(unsafe_load(ccall((:GDALGetFileList,libgdal),Ptr{Ptr{UInt8}},(GDALDatasetH,),arg1)))
 end
 
+
+"""
+    GDALClose(GDALDatasetH hDS) -> friend void
+
+Close GDAL dataset.
+
+### Parameters
+* **hDS**: The dataset to close. May be cast from a "GDALDataset *".
+"""
 function close(arg1::GDALDatasetH)
     ccall((:GDALClose,libgdal),Void,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterXSize(GDALDatasetH) -> int
+
+Fetch raster width in pixels.
+"""
 function getrasterxsize(arg1::GDALDatasetH)
     ccall((:GDALGetRasterXSize,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterYSize(GDALDatasetH) -> int
+
+Fetch raster height in pixels.
+"""
 function getrasterysize(arg1::GDALDatasetH)
     ccall((:GDALGetRasterYSize,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterCount(GDALDatasetH) -> int
+
+Fetch the number of raster bands on this dataset.
+"""
 function getrastercount(arg1::GDALDatasetH)
     ccall((:GDALGetRasterCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetRasterBand(GDALDatasetH,
+                      int) -> GDALRasterBandH
+
+Fetch a band object for a dataset.
+"""
 function getrasterband(arg1::GDALDatasetH,arg2::Integer)
     checknull(ccall((:GDALGetRasterBand,libgdal),GDALRasterBandH,(GDALDatasetH,Cint),arg1,arg2))
 end
 
+
+"""
+    GDALAddBand(GDALDatasetH hDS,
+                GDALDataType eType,
+                char ** papszOptions) -> CPLErr
+
+Add a band to a dataset.
+"""
 function addband(hDS::GDALDatasetH,eType::GDALDataType,papszOptions::Vector{UTF8String})
     ccall((:GDALAddBand,libgdal),CPLErr,(GDALDatasetH,GDALDataType,Ptr{Ptr{UInt8}}),hDS,eType,papszOptions)
 end
 
+
+"""
+    GDALBeginAsyncReader(GDALDatasetH hDS,
+                         int nXOff,
+                         int nYOff,
+                         int nXSize,
+                         int nYSize,
+                         void * pBuf,
+                         int nBufXSize,
+                         int nBufYSize,
+                         GDALDataType eBufType,
+                         int nBandCount,
+                         int * panBandMap,
+                         int nPixelSpace,
+                         int nLineSpace,
+                         int nBandSpace,
+                         char ** papszOptions) -> GDALAsyncReaderH
+"""
 function beginasyncreader(hDS::GDALDatasetH,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer,pBuf::Ptr{Void},nBufXSize::Integer,nBufYSize::Integer,eBufType::GDALDataType,nBandCount::Integer,panBandMap::Vector{Cint},nPixelSpace::Integer,nLineSpace::Integer,nBandSpace::Integer,papszOptions::Vector{UTF8String})
     checknull(ccall((:GDALBeginAsyncReader,libgdal),GDALAsyncReaderH,(GDALDatasetH,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,Cint,Cint,Ptr{Ptr{UInt8}}),hDS,nXOff,nYOff,nXSize,nYSize,pBuf,nBufXSize,nBufYSize,eBufType,nBandCount,panBandMap,nPixelSpace,nLineSpace,nBandSpace,papszOptions))
 end
 
+
+"""
+    GDALEndAsyncReader(GDALDatasetH hDS,
+                       GDALAsyncReaderH hAsynchReaderH) -> void
+"""
 function endasyncreader(hDS::GDALDatasetH,hAsynchReaderH::GDALAsyncReaderH)
     ccall((:GDALEndAsyncReader,libgdal),Void,(GDALDatasetH,GDALAsyncReaderH),hDS,hAsynchReaderH)
 end
 
+
+"""
+    GDALDatasetRasterIO(GDALDatasetH hDS,
+                        GDALRWFlag eRWFlag,
+                        int nDSXOff,
+                        int nDSYOff,
+                        int nDSXSize,
+                        int nDSYSize,
+                        void * pBuffer,
+                        int nBXSize,
+                        int nBYSize,
+                        GDALDataType eBDataType,
+                        int nBandCount,
+                        int * panBandCount,
+                        int nPixelSpace,
+                        int nLineSpace,
+                        int nBandSpace) -> CPLErr
+
+Read/write a region of image data from multiple bands.
+"""
 function datasetrasterio(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,pBuffer::Ptr{Void},nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,nBandCount::Integer,panBandCount::Vector{Cint},nPixelSpace::Integer,nLineSpace::Integer,nBandSpace::Integer)
     ccall((:GDALDatasetRasterIO,libgdal),CPLErr,(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,Cint,Cint),hDS,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,nPixelSpace,nLineSpace,nBandSpace)
 end
 
+
+"""
+    GDALDatasetRasterIOEx(GDALDatasetH hDS,
+                          GDALRWFlag eRWFlag,
+                          int nDSXOff,
+                          int nDSYOff,
+                          int nDSXSize,
+                          int nDSYSize,
+                          void * pBuffer,
+                          int nBXSize,
+                          int nBYSize,
+                          GDALDataType eBDataType,
+                          int nBandCount,
+                          int * panBandCount,
+                          GSpacing nPixelSpace,
+                          GSpacing nLineSpace,
+                          GSpacing nBandSpace,
+                          GDALRasterIOExtraArg * psExtraArg) -> CPLErr
+
+Read/write a region of image data from multiple bands.
+"""
 function datasetrasterioex(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,pBuffer::Ptr{Void},nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,nBandCount::Integer,panBandCount::Vector{Cint},nPixelSpace::GSpacing,nLineSpace::GSpacing,nBandSpace::GSpacing,psExtraArg::GDALRasterIOExtraArg)
     ccall((:GDALDatasetRasterIOEx,libgdal),CPLErr,(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Ptr{Cint},GSpacing,GSpacing,GSpacing,Ref{GDALRasterIOExtraArg}),hDS,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,nPixelSpace,nLineSpace,nBandSpace,psExtraArg)
 end
 
+
+"""
+    GDALDatasetAdviseRead(GDALDatasetH hDS,
+                          int nDSXOff,
+                          int nDSYOff,
+                          int nDSXSize,
+                          int nDSYSize,
+                          int nBXSize,
+                          int nBYSize,
+                          GDALDataType eBDataType,
+                          int nBandCount,
+                          int * panBandCount,
+                          char ** papszOptions) -> CPLErr
+
+Advise driver of upcoming read requests.
+"""
 function datasetadviseread(hDS::GDALDatasetH,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,nBandCount::Integer,panBandCount::Vector{Cint},papszOptions::Vector{UTF8String})
     ccall((:GDALDatasetAdviseRead,libgdal),CPLErr,(GDALDatasetH,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},Ptr{Ptr{UInt8}}),hDS,nDSXOff,nDSYOff,nDSXSize,nDSYSize,nBXSize,nBYSize,eBDataType,nBandCount,panBandCount,papszOptions)
 end
 
+
+"""
+    GDALGetProjectionRef(GDALDatasetH) -> const char *
+
+Fetch the projection definition string for this dataset.
+"""
 function getprojectionref(arg1::GDALDatasetH)
     bytestring(ccall((:GDALGetProjectionRef,libgdal),Ptr{UInt8},(GDALDatasetH,),arg1))
 end
 
+
+"""
+    GDALSetProjection(GDALDatasetH,
+                      const char *) -> CPLErr
+
+Set the projection reference string for this dataset.
+"""
 function setprojection(arg1::GDALDatasetH,arg2::AbstractString)
     ccall((:GDALSetProjection,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALGetGeoTransform(GDALDatasetH,
+                        double *) -> CPLErr
+
+Fetch the affine transformation coefficients.
+"""
 function getgeotransform(arg1::GDALDatasetH,arg2::Vector{Float64})
     ccall((:GDALGetGeoTransform,libgdal),CPLErr,(GDALDatasetH,Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALSetGeoTransform(GDALDatasetH,
+                        double *) -> CPLErr
+
+Set the affine transformation coefficients.
+"""
 function setgeotransform(arg1::GDALDatasetH,arg2::Vector{Float64})
     ccall((:GDALSetGeoTransform,libgdal),CPLErr,(GDALDatasetH,Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALGetGCPCount(GDALDatasetH) -> int
+
+Get number of GCPs.
+"""
 function getgcpcount(arg1::GDALDatasetH)
     ccall((:GDALGetGCPCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALGetGCPProjection(GDALDatasetH) -> const char *
+
+Get output projection for GCPs.
+"""
 function getgcpprojection(arg1::GDALDatasetH)
     bytestring(ccall((:GDALGetGCPProjection,libgdal),Ptr{UInt8},(GDALDatasetH,),arg1))
 end
 
+
+"""
+    GDALGetGCPs(GDALDatasetH) -> const GDAL_GCP *
+
+Fetch GCPs.
+"""
 function getgcps(arg1::GDALDatasetH)
     ccall((:GDALGetGCPs,libgdal),Ptr{GDAL_GCP},(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALSetGCPs(GDALDatasetH,
+                int,
+                const GDAL_GCP *,
+                const char *) -> CPLErr
+
+Assign GCPs.
+"""
 function setgcps(arg1::GDALDatasetH,arg2::Integer,arg3::Ptr{GDAL_GCP},arg4::AbstractString)
     ccall((:GDALSetGCPs,libgdal),CPLErr,(GDALDatasetH,Cint,Ptr{GDAL_GCP},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetInternalHandle(GDALDatasetH,
+                          const char *) -> void *
+
+Fetch a format specific internally meaningful handle.
+"""
 function getinternalhandle(arg1::GDALDatasetH,arg2::AbstractString)
     ccall((:GDALGetInternalHandle,libgdal),Ptr{Void},(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALReferenceDataset(GDALDatasetH) -> int
+
+Add one to dataset reference count.
+"""
 function referencedataset(arg1::GDALDatasetH)
     ccall((:GDALReferenceDataset,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALDereferenceDataset(GDALDatasetH) -> int
+
+Subtract one from dataset reference count.
+"""
 function dereferencedataset(arg1::GDALDatasetH)
     ccall((:GDALDereferenceDataset,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALBuildOverviews(GDALDatasetH,
+                       const char *,
+                       int,
+                       int *,
+                       int,
+                       int *,
+                       GDALProgressFunc,
+                       void *) -> CPLErr
+
+Build raster overview(s)
+"""
 function buildoverviews(arg1::GDALDatasetH,arg2::AbstractString,arg3::Integer,arg4::Vector{Cint},arg5::Integer,arg6::Vector{Cint},arg7::GDALProgressFunc,arg8::Ptr{Void})
     ccall((:GDALBuildOverviews,libgdal),CPLErr,(GDALDatasetH,Ptr{UInt8},Cint,Ptr{Cint},Cint,Ptr{Cint},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)
 end
 
+
+"""
+    GDALGetOpenDatasets(GDALDatasetH ** hDS,
+                        int * pnCount) -> void
+
+Fetch all open GDAL dataset handles.
+"""
 function getopendatasets(hDS::Ptr{Ptr{GDALDatasetH}},pnCount::Vector{Cint})
     ccall((:GDALGetOpenDatasets,libgdal),Void,(Ptr{Ptr{GDALDatasetH}},Ptr{Cint}),hDS,pnCount)
 end
 
+
+"""
+    GDALGetAccess(GDALDatasetH hDS) -> int
+
+Return access flag.
+"""
 function getaccess(hDS::GDALDatasetH)
     ccall((:GDALGetAccess,libgdal),Cint,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALFlushCache(GDALDatasetH hDS) -> void
+
+Flush all write cached data to disk.
+"""
 function flushcache(hDS::GDALDatasetH)
     ccall((:GDALFlushCache,libgdal),Void,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALCreateDatasetMaskBand(GDALDatasetH hDS,
+                              int nFlags) -> CPLErr
+
+Adds a mask band to the dataset.
+"""
 function createdatasetmaskband(hDS::GDALDatasetH,nFlags::Integer)
     ccall((:GDALCreateDatasetMaskBand,libgdal),CPLErr,(GDALDatasetH,Cint),hDS,nFlags)
 end
 
+
+"""
+    GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
+                               GDALDatasetH hDstDS,
+                               char ** papszOptions,
+                               GDALProgressFunc pfnProgress,
+                               void * pProgressData) -> CPLErr
+
+Copy all dataset raster data.
+
+### Parameters
+* **hSrcDS**: the source dataset
+* **hDstDS**: the destination dataset
+* **papszOptions**: transfer hints in "StringList" Name=Value format.
+* **pfnProgress**: progress reporting function.
+* **pProgressData**: callback data for progress function.
+
+### Returns
+CE_None on success, or CE_Failure on failure.
+"""
 function datasetcopywholeraster(hSrcDS::GDALDatasetH,hDstDS::GDALDatasetH,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALDatasetCopyWholeRaster,libgdal),CPLErr,(GDALDatasetH,GDALDatasetH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcDS,hDstDS,papszOptions,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALRasterBandCopyWholeRaster(GDALRasterBandH hSrcBand,
+                                  GDALRasterBandH hDstBand,
+                                  char ** papszOptions,
+                                  GDALProgressFunc pfnProgress,
+                                  void * pProgressData) -> CPLErr
+
+Copy all raster band raster data.
+
+### Parameters
+* **hSrcBand**: the source band
+* **hDstBand**: the destination band
+* **papszOptions**: transfer hints in "StringList" Name=Value format.
+* **pfnProgress**: progress reporting function.
+* **pProgressData**: callback data for progress function.
+
+### Returns
+CE_None on success, or CE_Failure on failure.
+"""
 function rasterbandcopywholeraster(hSrcBand::GDALRasterBandH,hDstBand::GDALRasterBandH,papszOptions::Vector{UTF8String},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALRasterBandCopyWholeRaster,libgdal),CPLErr,(GDALRasterBandH,GDALRasterBandH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),hSrcBand,hDstBand,papszOptions,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALRegenerateOverviews(GDALRasterBandH hSrcBand,
+                            int nOverviewCount,
+                            GDALRasterBandH * pahOverviewBands,
+                            const char * pszResampling,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressData) -> CPLErr
+
+Generate downsampled overviews.
+
+### Parameters
+* **hSrcBand**: the source (base level) band.
+* **nOverviewCount**: the number of downsampled bands being generated.
+* **pahOvrBands**: the list of downsampled bands to be generated.
+* **pszResampling**: Resampling algorithm (eg. "AVERAGE").
+* **pfnProgress**: progress report function.
+* **pProgressData**: progress function callback data.
+
+### Returns
+CE_None on success or CE_Failure on failure.
+"""
 function regenerateoverviews(hSrcBand::GDALRasterBandH,nOverviewCount::Integer,pahOverviewBands::Ptr{GDALRasterBandH},pszResampling::AbstractString,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALRegenerateOverviews,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{GDALRasterBandH},Ptr{UInt8},GDALProgressFunc,Ptr{Void}),hSrcBand,nOverviewCount,pahOverviewBands,pszResampling,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALDatasetGetLayerCount(GDALDatasetH) -> int
+
+Get the number of layers in this dataset.
+
+### Parameters
+* **hDS**: the dataset handle.
+
+### Returns
+layer count.
+"""
 function datasetgetlayercount(arg1::GDALDatasetH)
     ccall((:GDALDatasetGetLayerCount,libgdal),Cint,(GDALDatasetH,),arg1)
 end
 
+
+"""
+    GDALDatasetGetLayer(GDALDatasetH,
+                        int) -> OGRLayerH
+
+Fetch a layer by index.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **iLayer**: a layer number between 0 and GetLayerCount()-1.
+
+### Returns
+the layer, or NULL if iLayer is out of range or an error occurs.
+"""
 function datasetgetlayer(arg1::GDALDatasetH,arg2::Integer)
     checknull(ccall((:GDALDatasetGetLayer,libgdal),OGRLayerH,(GDALDatasetH,Cint),arg1,arg2))
 end
 
+
+"""
+    GDALDatasetGetLayerByName(GDALDatasetH,
+                              const char *) -> OGRLayerH
+
+Fetch a layer by name.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszLayerName**: the layer name of the layer to fetch.
+
+### Returns
+the layer, or NULL if Layer is not found or an error occurs.
+"""
 function datasetgetlayerbyname(arg1::GDALDatasetH,arg2::AbstractString)
     checknull(ccall((:GDALDatasetGetLayerByName,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8}),arg1,arg2))
 end
 
+
+"""
+    GDALDatasetDeleteLayer(GDALDatasetH,
+                           int) -> OGRErr
+
+Delete the indicated layer from the datasource.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **iLayer**: the index of the layer to delete.
+
+### Returns
+OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
+"""
 function datasetdeletelayer(arg1::GDALDatasetH,arg2::Integer)
     ccall((:GDALDatasetDeleteLayer,libgdal),OGRErr,(GDALDatasetH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetCreateLayer(GDALDatasetH,
+                           const char *,
+                           OGRSpatialReferenceH,
+                           OGRwkbGeometryType,
+                           char **) -> OGRLayerH
+
+This function attempts to create a new layer on the dataset with the indicated name, coordinate system, geometry type.
+
+### Parameters
+* **hDS**: the dataset handle
+* **pszName**: the name for the new layer. This should ideally not match any existing layer on the datasource.
+* **poSpatialRef**: the coordinate system to use for the new layer, or NULL if no coordinate system is available.
+* **eGType**: the geometry type for the layer. Use wkbUnknown if there are no constraints on the types geometry to be written.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+NULL is returned on failure, or a new OGRLayer handle on success.
+"""
 function datasetcreatelayer(arg1::GDALDatasetH,arg2::AbstractString,arg3::OGRSpatialReferenceH,arg4::OGRwkbGeometryType,arg5::Vector{UTF8String})
     checknull(ccall((:GDALDatasetCreateLayer,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8},OGRSpatialReferenceH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4,arg5))
 end
 
+
+"""
+    GDALDatasetCopyLayer(GDALDatasetH,
+                         OGRLayerH,
+                         const char *,
+                         char **) -> OGRLayerH
+
+Duplicate an existing layer.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **hSrcLayer**: source layer.
+* **pszNewName**: the name of the layer to create.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+an handle to the layer, or NULL if an error occurs.
+"""
 function datasetcopylayer(arg1::GDALDatasetH,arg2::OGRLayerH,arg3::AbstractString,arg4::Vector{UTF8String})
     checknull(ccall((:GDALDatasetCopyLayer,libgdal),OGRLayerH,(GDALDatasetH,OGRLayerH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4))
 end
 
+
+"""
+    GDALDatasetTestCapability(GDALDatasetH,
+                              const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszCapability**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function datasettestcapability(arg1::GDALDatasetH,arg2::AbstractString)
     ccall((:GDALDatasetTestCapability,libgdal),Cint,(GDALDatasetH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetExecuteSQL(GDALDatasetH,
+                          const char *,
+                          OGRGeometryH,
+                          const char *) -> OGRLayerH
+
+Execute an SQL statement against the data store.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **pszStatement**: the SQL statement to execute.
+* **hSpatialFilter**: geometry which represents a spatial filter. Can be NULL.
+* **pszDialect**: allows control of the statement dialect. If set to NULL, the OGR SQL engine will be used, except for RDBMS drivers that will use their dedicated SQL engine, unless OGRSQL is explicitly passed as the dialect. Starting with OGR 1.10, the SQLITE dialect can also be used.
+
+### Returns
+an OGRLayer containing the results of the query. Deallocate with ReleaseResultSet().
+"""
 function datasetexecutesql(arg1::GDALDatasetH,arg2::AbstractString,arg3::OGRGeometryH,arg4::AbstractString)
     checknull(ccall((:GDALDatasetExecuteSQL,libgdal),OGRLayerH,(GDALDatasetH,Ptr{UInt8},OGRGeometryH,Ptr{UInt8}),arg1,arg2,arg3,arg4))
 end
 
+
+"""
+    GDALDatasetReleaseResultSet(GDALDatasetH,
+                                OGRLayerH) -> void
+
+Release results of ExecuteSQL().
+
+### Parameters
+* **hDS**: the dataset handle.
+* **poResultsSet**: the result of a previous ExecuteSQL() call.
+"""
 function datasetreleaseresultset(arg1::GDALDatasetH,arg2::OGRLayerH)
     ccall((:GDALDatasetReleaseResultSet,libgdal),Void,(GDALDatasetH,OGRLayerH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetGetStyleTable(GDALDatasetH) -> OGRStyleTableH
+
+Returns dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+
+### Returns
+handle to a style table which should not be modified or freed by the caller.
+"""
 function datasetgetstyletable(arg1::GDALDatasetH)
     checknull(ccall((:GDALDatasetGetStyleTable,libgdal),OGRStyleTableH,(GDALDatasetH,),arg1))
 end
 
+
+"""
+    GDALDatasetSetStyleTableDirectly(GDALDatasetH,
+                                     OGRStyleTableH) -> void
+
+Set dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+* **hStyleTable**: style table handle to set
+"""
 function datasetsetstyletabledirectly(arg1::GDALDatasetH,arg2::OGRStyleTableH)
     ccall((:GDALDatasetSetStyleTableDirectly,libgdal),Void,(GDALDatasetH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetSetStyleTable(GDALDatasetH,
+                             OGRStyleTableH) -> void
+
+Set dataset style table.
+
+### Parameters
+* **hDS**: the dataset handle
+* **hStyleTable**: style table handle to set
+"""
 function datasetsetstyletable(arg1::GDALDatasetH,arg2::OGRStyleTableH)
     ccall((:GDALDatasetSetStyleTable,libgdal),Void,(GDALDatasetH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    GDALDatasetStartTransaction(GDALDatasetH hDS,
+                                int bForce) -> OGRErr
+
+For datasources which support transactions, StartTransaction creates a transaction.
+
+### Parameters
+* **hDS**: the dataset handle.
+* **bForce**: can be set to TRUE if an emulation, possibly slow, of a transaction mechanism is acceptable.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function datasetstarttransaction(hDS::GDALDatasetH,bForce::Integer)
     ccall((:GDALDatasetStartTransaction,libgdal),OGRErr,(GDALDatasetH,Cint),hDS,bForce)
 end
 
+
+"""
+    GDALDatasetCommitTransaction(GDALDatasetH hDS) -> OGRErr
+
+For datasources which support transactions, CommitTransaction commits a transaction.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function datasetcommittransaction(hDS::GDALDatasetH)
     ccall((:GDALDatasetCommitTransaction,libgdal),OGRErr,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALDatasetRollbackTransaction(GDALDatasetH hDS) -> OGRErr
+
+For datasources which support transactions, RollbackTransaction will roll back a datasource to its state before the start of the current transaction.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function datasetrollbacktransaction(hDS::GDALDatasetH)
     ccall((:GDALDatasetRollbackTransaction,libgdal),OGRErr,(GDALDatasetH,),hDS)
 end
 
+
+"""
+    GDALGetRasterDataType(GDALRasterBandH) -> GDALDataType
+
+Fetch the pixel data type for this band.
+"""
 function getrasterdatatype(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterDataType,libgdal),GDALDataType,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBlockSize(GDALRasterBandH,
+                     int * pnXSize,
+                     int * pnYSize) -> void
+
+Fetch the "natural" block size of this band.
+"""
 function getblocksize(arg1::GDALRasterBandH,pnXSize::Vector{Cint},pnYSize::Vector{Cint})
     ccall((:GDALGetBlockSize,libgdal),Void,(GDALRasterBandH,Ptr{Cint},Ptr{Cint}),arg1,pnXSize,pnYSize)
 end
 
+
+"""
+    GDALRasterAdviseRead(GDALRasterBandH hRB,
+                         int nDSXOff,
+                         int nDSYOff,
+                         int nDSXSize,
+                         int nDSYSize,
+                         int nBXSize,
+                         int nBYSize,
+                         GDALDataType eBDataType,
+                         char ** papszOptions) -> CPLErr
+
+Advise driver of upcoming read requests.
+"""
 function rasteradviseread(hRB::GDALRasterBandH,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,papszOptions::Vector{UTF8String})
     ccall((:GDALRasterAdviseRead,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Ptr{Ptr{UInt8}}),hRB,nDSXOff,nDSYOff,nDSXSize,nDSYSize,nBXSize,nBYSize,eBDataType,papszOptions)
 end
 
+
+"""
+    GDALRasterIO(GDALRasterBandH hRBand,
+                 GDALRWFlag eRWFlag,
+                 int nDSXOff,
+                 int nDSYOff,
+                 int nDSXSize,
+                 int nDSYSize,
+                 void * pBuffer,
+                 int nBXSize,
+                 int nBYSize,
+                 GDALDataType eBDataType,
+                 int nPixelSpace,
+                 int nLineSpace) -> CPLErr
+
+Read/write a region of image data for this band.
+"""
 function rasterio(hRBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,pBuffer::Ptr{Void},nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,nPixelSpace::Integer,nLineSpace::Integer)
     ccall((:GDALRasterIO,libgdal),CPLErr,(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,Cint,Cint),hRBand,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nPixelSpace,nLineSpace)
 end
 
+
+"""
+    GDALRasterIOEx(GDALRasterBandH hRBand,
+                   GDALRWFlag eRWFlag,
+                   int nDSXOff,
+                   int nDSYOff,
+                   int nDSXSize,
+                   int nDSYSize,
+                   void * pBuffer,
+                   int nBXSize,
+                   int nBYSize,
+                   GDALDataType eBDataType,
+                   GSpacing nPixelSpace,
+                   GSpacing nLineSpace,
+                   GDALRasterIOExtraArg * psExtraArg) -> CPLErr
+
+Read/write a region of image data for this band.
+"""
 function rasterioex(hRBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nDSXOff::Integer,nDSYOff::Integer,nDSXSize::Integer,nDSYSize::Integer,pBuffer::Ptr{Void},nBXSize::Integer,nBYSize::Integer,eBDataType::GDALDataType,nPixelSpace::GSpacing,nLineSpace::GSpacing,psExtraArg::GDALRasterIOExtraArg)
     ccall((:GDALRasterIOEx,libgdal),CPLErr,(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Void},Cint,Cint,GDALDataType,GSpacing,GSpacing,Ref{GDALRasterIOExtraArg}),hRBand,eRWFlag,nDSXOff,nDSYOff,nDSXSize,nDSYSize,pBuffer,nBXSize,nBYSize,eBDataType,nPixelSpace,nLineSpace,psExtraArg)
 end
 
+
+"""
+    GDALReadBlock(GDALRasterBandH,
+                  int,
+                  int,
+                  void *) -> CPLErr
+
+Read a block of image data efficiently.
+"""
 function readblock(arg1::GDALRasterBandH,arg2::Integer,arg3::Integer,arg4::Ptr{Void})
     ccall((:GDALReadBlock,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Void}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALWriteBlock(GDALRasterBandH,
+                   int,
+                   int,
+                   void *) -> CPLErr
+
+Write a block of image data efficiently.
+"""
 function writeblock(arg1::GDALRasterBandH,arg2::Integer,arg3::Integer,arg4::Ptr{Void})
     ccall((:GDALWriteBlock,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Void}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALGetRasterBandXSize(GDALRasterBandH) -> int
+
+Fetch XSize of raster.
+"""
 function getrasterbandxsize(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterBandXSize,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetRasterBandYSize(GDALRasterBandH) -> int
+
+Fetch YSize of raster.
+"""
 function getrasterbandysize(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterBandYSize,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetRasterAccess(GDALRasterBandH) -> GDALAccess
+
+Find out if we have update permission for this band.
+"""
 function getrasteraccess(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterAccess,libgdal),GDALAccess,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBandNumber(GDALRasterBandH) -> int
+
+Fetch the band number.
+"""
 function getbandnumber(arg1::GDALRasterBandH)
     ccall((:GDALGetBandNumber,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetBandDataset(GDALRasterBandH) -> GDALDatasetH
+
+Fetch the owning dataset handle.
+"""
 function getbanddataset(arg1::GDALRasterBandH)
     checknull(ccall((:GDALGetBandDataset,libgdal),GDALDatasetH,(GDALRasterBandH,),arg1))
 end
 
+
+"""
+    GDALGetRasterColorInterpretation(GDALRasterBandH) -> GDALColorInterp
+
+How should this band be interpreted as color?
+"""
 function getrastercolorinterpretation(arg1::GDALRasterBandH)
     ccall((:GDALGetRasterColorInterpretation,libgdal),GDALColorInterp,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALSetRasterColorInterpretation(GDALRasterBandH,
+                                     GDALColorInterp) -> CPLErr
+
+Set color interpretation of a band.
+"""
 function setrastercolorinterpretation(arg1::GDALRasterBandH,arg2::GDALColorInterp)
     ccall((:GDALSetRasterColorInterpretation,libgdal),CPLErr,(GDALRasterBandH,GDALColorInterp),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterColorTable(GDALRasterBandH) -> GDALColorTableH
+
+Fetch the color table associated with band.
+"""
 function getrastercolortable(arg1::GDALRasterBandH)
     checknull(ccall((:GDALGetRasterColorTable,libgdal),GDALColorTableH,(GDALRasterBandH,),arg1))
 end
 
+
+"""
+    GDALSetRasterColorTable(GDALRasterBandH,
+                            GDALColorTableH) -> CPLErr
+
+Set the raster color table.
+"""
 function setrastercolortable(arg1::GDALRasterBandH,arg2::GDALColorTableH)
     ccall((:GDALSetRasterColorTable,libgdal),CPLErr,(GDALRasterBandH,GDALColorTableH),arg1,arg2)
 end
 
+
+"""
+    GDALHasArbitraryOverviews(GDALRasterBandH) -> int
+
+Check for arbitrary overviews.
+"""
 function hasarbitraryoverviews(arg1::GDALRasterBandH)
     ccall((:GDALHasArbitraryOverviews,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetOverviewCount(GDALRasterBandH) -> int
+
+Return the number of overview layers available.
+"""
 function getoverviewcount(arg1::GDALRasterBandH)
     ccall((:GDALGetOverviewCount,libgdal),Cint,(GDALRasterBandH,),arg1)
 end
 
+
+"""
+    GDALGetOverview(GDALRasterBandH,
+                    int) -> GDALRasterBandH
+
+Fetch overview raster band object.
+"""
 function getoverview(arg1::GDALRasterBandH,arg2::Integer)
     checknull(ccall((:GDALGetOverview,libgdal),GDALRasterBandH,(GDALRasterBandH,Cint),arg1,arg2))
 end
 
+
+"""
+    GDALGetRasterNoDataValue(GDALRasterBandH,
+                             int *) -> double
+
+Fetch the no data value for this band.
+"""
 function getrasternodatavalue(arg1::GDALRasterBandH,arg2::Vector{Cint})
     ccall((:GDALGetRasterNoDataValue,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,arg2)
 end
 
+
+"""
+    GDALSetRasterNoDataValue(GDALRasterBandH,
+                             double) -> CPLErr
+
+Set the no data value for this band.
+"""
 function setrasternodatavalue(arg1::GDALRasterBandH,arg2::Real)
     ccall((:GDALSetRasterNoDataValue,libgdal),CPLErr,(GDALRasterBandH,Cdouble),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterCategoryNames(GDALRasterBandH) -> char **
+
+Fetch the list of category names for this raster.
+"""
 function getrastercategorynames(arg1::GDALRasterBandH)
     bytestring(unsafe_load(ccall((:GDALGetRasterCategoryNames,libgdal),Ptr{Ptr{UInt8}},(GDALRasterBandH,),arg1)))
 end
 
+
+"""
+    GDALSetRasterCategoryNames(GDALRasterBandH,
+                               char **) -> CPLErr
+
+Set the category names for this band.
+"""
 function setrastercategorynames(arg1::GDALRasterBandH,arg2::Vector{UTF8String})
     ccall((:GDALSetRasterCategoryNames,libgdal),CPLErr,(GDALRasterBandH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    GDALGetRasterMinimum(GDALRasterBandH,
+                         int * pbSuccess) -> double
+
+Fetch the minimum value for this band.
+"""
 function getrasterminimum(arg1::GDALRasterBandH,pbSuccess::Vector{Cint})
     ccall((:GDALGetRasterMinimum,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALGetRasterMaximum(GDALRasterBandH,
+                         int * pbSuccess) -> double
+
+Fetch the maximum value for this band.
+"""
 function getrastermaximum(arg1::GDALRasterBandH,pbSuccess::Vector{Cint})
     ccall((:GDALGetRasterMaximum,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALGetRasterStatistics(GDALRasterBandH,
+                            int bApproxOK,
+                            int bForce,
+                            double * pdfMin,
+                            double * pdfMax,
+                            double * pdfMean,
+                            double * pdfStdDev) -> CPLErr
+
+Fetch image statistics.
+"""
 function getrasterstatistics(arg1::GDALRasterBandH,bApproxOK::Integer,bForce::Integer,pdfMin::Vector{Float64},pdfMax::Vector{Float64},pdfMean::Vector{Float64},pdfStdDev::Vector{Float64})
     ccall((:GDALGetRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cint,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,bApproxOK,bForce,pdfMin,pdfMax,pdfMean,pdfStdDev)
 end
 
+
+"""
+    GDALComputeRasterStatistics(GDALRasterBandH,
+                                int bApproxOK,
+                                double * pdfMin,
+                                double * pdfMax,
+                                double * pdfMean,
+                                double * pdfStdDev,
+                                GDALProgressFunc pfnProgress,
+                                void * pProgressData) -> CPLErr
+
+Compute image statistics.
+"""
 function computerasterstatistics(arg1::GDALRasterBandH,bApproxOK::Integer,pdfMin::Vector{Float64},pdfMax::Vector{Float64},pdfMean::Vector{Float64},pdfStdDev::Vector{Float64},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALComputeRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},GDALProgressFunc,Ptr{Void}),arg1,bApproxOK,pdfMin,pdfMax,pdfMean,pdfStdDev,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALSetRasterStatistics(GDALRasterBandH hBand,
+                            double dfMin,
+                            double dfMax,
+                            double dfMean,
+                            double dfStdDev) -> CPLErr
+
+Set statistics on band.
+"""
 function setrasterstatistics(hBand::GDALRasterBandH,dfMin::Real,dfMax::Real,dfMean::Real,dfStdDev::Real)
     ccall((:GDALSetRasterStatistics,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cdouble,Cdouble),hBand,dfMin,dfMax,dfMean,dfStdDev)
 end
 
+
+"""
+    GDALGetRasterUnitType(GDALRasterBandH) -> const char *
+
+Return raster unit type.
+"""
 function getrasterunittype(arg1::GDALRasterBandH)
     bytestring(ccall((:GDALGetRasterUnitType,libgdal),Ptr{UInt8},(GDALRasterBandH,),arg1))
 end
 
+
+"""
+    GDALSetRasterUnitType(GDALRasterBandH hBand,
+                          const char * pszNewValue) -> CPLErr
+
+Set unit type.
+"""
 function setrasterunittype(hBand::GDALRasterBandH,pszNewValue::AbstractString)
     ccall((:GDALSetRasterUnitType,libgdal),CPLErr,(GDALRasterBandH,Ptr{UInt8}),hBand,pszNewValue)
 end
 
+
+"""
+    GDALGetRasterOffset(GDALRasterBandH,
+                        int * pbSuccess) -> double
+
+Fetch the raster value offset.
+"""
 function getrasteroffset(arg1::GDALRasterBandH,pbSuccess::Vector{Cint})
     ccall((:GDALGetRasterOffset,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALSetRasterOffset(GDALRasterBandH hBand,
+                        double dfNewOffset) -> CPLErr
+
+Set scaling offset.
+"""
 function setrasteroffset(hBand::GDALRasterBandH,dfNewOffset::Real)
     ccall((:GDALSetRasterOffset,libgdal),CPLErr,(GDALRasterBandH,Cdouble),hBand,dfNewOffset)
 end
 
+
+"""
+    GDALGetRasterScale(GDALRasterBandH,
+                       int * pbSuccess) -> double
+
+Fetch the raster value scale.
+"""
 function getrasterscale(arg1::GDALRasterBandH,pbSuccess::Vector{Cint})
     ccall((:GDALGetRasterScale,libgdal),Cdouble,(GDALRasterBandH,Ptr{Cint}),arg1,pbSuccess)
 end
 
+
+"""
+    GDALSetRasterScale(GDALRasterBandH hBand,
+                       double dfNewOffset) -> CPLErr
+
+Set scaling ratio.
+"""
 function setrasterscale(hBand::GDALRasterBandH,dfNewOffset::Real)
     ccall((:GDALSetRasterScale,libgdal),CPLErr,(GDALRasterBandH,Cdouble),hBand,dfNewOffset)
 end
 
+
+"""
+    GDALComputeRasterMinMax(GDALRasterBandH hBand,
+                            int bApproxOK,
+                            double adfMinMax) -> void
+
+Compute the min/max values for a band.
+"""
 function computerasterminmax(hBand::GDALRasterBandH,bApproxOK::Integer,adfMinMax::Array_2_Cdouble)
     ccall((:GDALComputeRasterMinMax,libgdal),Void,(GDALRasterBandH,Cint,Array_2_Cdouble),hBand,bApproxOK,adfMinMax)
 end
 
+
+"""
+    GDALFlushRasterCache(GDALRasterBandH hBand) -> CPLErr
+
+Flush raster data cache.
+"""
 function flushrastercache(hBand::GDALRasterBandH)
     ccall((:GDALFlushRasterCache,libgdal),CPLErr,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALGetRasterHistogram(GDALRasterBandH hBand,
+                           double dfMin,
+                           double dfMax,
+                           int nBuckets,
+                           int * panHistogram,
+                           int bIncludeOutOfRange,
+                           int bApproxOK,
+                           GDALProgressFunc pfnProgress,
+                           void * pProgressData) -> CPLErr
+
+Compute raster histogram.
+"""
 function getrasterhistogram(hBand::GDALRasterBandH,dfMin::Real,dfMax::Real,nBuckets::Integer,panHistogram::Vector{Cint},bIncludeOutOfRange::Integer,bApproxOK::Integer,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetRasterHistogram,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cint},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfMin,dfMax,nBuckets,panHistogram,bIncludeOutOfRange,bApproxOK,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetRasterHistogramEx(GDALRasterBandH hBand,
+                             double dfMin,
+                             double dfMax,
+                             int nBuckets,
+                             GUIntBig * panHistogram,
+                             int bIncludeOutOfRange,
+                             int bApproxOK,
+                             GDALProgressFunc pfnProgress,
+                             void * pProgressData) -> CPLErr
+
+Compute raster histogram.
+"""
 function getrasterhistogramex(hBand::GDALRasterBandH,dfMin::Real,dfMax::Real,nBuckets::Integer,panHistogram::Ptr{GUIntBig},bIncludeOutOfRange::Integer,bApproxOK::Integer,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetRasterHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{GUIntBig},Cint,Cint,GDALProgressFunc,Ptr{Void}),hBand,dfMin,dfMax,nBuckets,panHistogram,bIncludeOutOfRange,bApproxOK,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultHistogram(GDALRasterBandH hBand,
+                            double * pdfMin,
+                            double * pdfMax,
+                            int * pnBuckets,
+                            int ** ppanHistogram,
+                            int bForce,
+                            GDALProgressFunc pfnProgress,
+                            void * pProgressData) -> CPLErr
+
+Fetch default raster histogram.
+"""
 function getdefaulthistogram(hBand::GDALRasterBandH,pdfMin::Vector{Float64},pdfMax::Vector{Float64},pnBuckets::Vector{Cint},ppanHistogram::Ptr{Ptr{Cint}},bForce::Integer,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetDefaultHistogram,libgdal),CPLErr,(GDALRasterBandH,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint},Ptr{Ptr{Cint}},Cint,GDALProgressFunc,Ptr{Void}),hBand,pdfMin,pdfMax,pnBuckets,ppanHistogram,bForce,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultHistogramEx(GDALRasterBandH hBand,
+                              double * pdfMin,
+                              double * pdfMax,
+                              int * pnBuckets,
+                              GUIntBig ** ppanHistogram,
+                              int bForce,
+                              GDALProgressFunc pfnProgress,
+                              void * pProgressData) -> CPLErr
+
+Fetch default raster histogram.
+"""
 function getdefaulthistogramex(hBand::GDALRasterBandH,pdfMin::Vector{Float64},pdfMax::Vector{Float64},pnBuckets::Vector{Cint},ppanHistogram::Ptr{Ptr{GUIntBig}},bForce::Integer,pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALGetDefaultHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint},Ptr{Ptr{GUIntBig}},Cint,GDALProgressFunc,Ptr{Void}),hBand,pdfMin,pdfMax,pnBuckets,ppanHistogram,bForce,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALSetDefaultHistogram(GDALRasterBandH hBand,
+                            double dfMin,
+                            double dfMax,
+                            int nBuckets,
+                            int * panHistogram) -> CPLErr
+
+Set default histogram.
+"""
 function setdefaulthistogram(hBand::GDALRasterBandH,dfMin::Real,dfMax::Real,nBuckets::Integer,panHistogram::Vector{Cint})
     ccall((:GDALSetDefaultHistogram,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{Cint}),hBand,dfMin,dfMax,nBuckets,panHistogram)
 end
 
+
+"""
+    GDALSetDefaultHistogramEx(GDALRasterBandH hBand,
+                              double dfMin,
+                              double dfMax,
+                              int nBuckets,
+                              GUIntBig * panHistogram) -> CPLErr
+
+Set default histogram.
+"""
 function setdefaulthistogramex(hBand::GDALRasterBandH,dfMin::Real,dfMax::Real,nBuckets::Integer,panHistogram::Ptr{GUIntBig})
     ccall((:GDALSetDefaultHistogramEx,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble,Cint,Ptr{GUIntBig}),hBand,dfMin,dfMax,nBuckets,panHistogram)
 end
 
+
+"""
+    GDALGetRandomRasterSample(GDALRasterBandH,
+                              int,
+                              float *) -> int
+"""
 function getrandomrastersample(arg1::GDALRasterBandH,arg2::Integer,arg3::Ptr{Cfloat})
     ccall((:GDALGetRandomRasterSample,libgdal),Cint,(GDALRasterBandH,Cint,Ptr{Cfloat}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALGetRasterSampleOverview(GDALRasterBandH,
+                                int) -> GDALRasterBandH
+
+Fetch best sampling overview.
+"""
 function getrastersampleoverview(arg1::GDALRasterBandH,arg2::Integer)
     checknull(ccall((:GDALGetRasterSampleOverview,libgdal),GDALRasterBandH,(GDALRasterBandH,Cint),arg1,arg2))
 end
 
+
+"""
+    GDALGetRasterSampleOverviewEx(GDALRasterBandH,
+                                  GUIntBig) -> GDALRasterBandH
+
+Fetch best sampling overview.
+"""
 function getrastersampleoverviewex(arg1::GDALRasterBandH,arg2::GUIntBig)
     checknull(ccall((:GDALGetRasterSampleOverviewEx,libgdal),GDALRasterBandH,(GDALRasterBandH,GUIntBig),arg1,arg2))
 end
 
+
+"""
+    GDALFillRaster(GDALRasterBandH hBand,
+                   double dfRealValue,
+                   double dfImaginaryValue) -> CPLErr
+
+Fill this band with a constant value.
+"""
 function fillraster(hBand::GDALRasterBandH,dfRealValue::Real,dfImaginaryValue::Real)
     ccall((:GDALFillRaster,libgdal),CPLErr,(GDALRasterBandH,Cdouble,Cdouble),hBand,dfRealValue,dfImaginaryValue)
 end
 
+
+"""
+    GDALComputeBandStats(GDALRasterBandH hBand,
+                         int nSampleStep,
+                         double * pdfMean,
+                         double * pdfStdDev,
+                         GDALProgressFunc pfnProgress,
+                         void * pProgressData) -> CPLErr
+"""
 function computebandstats(hBand::GDALRasterBandH,nSampleStep::Integer,pdfMean::Vector{Float64},pdfStdDev::Vector{Float64},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALComputeBandStats,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{Cdouble},Ptr{Cdouble},GDALProgressFunc,Ptr{Void}),hBand,nSampleStep,pdfMean,pdfStdDev,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALOverviewMagnitudeCorrection(GDALRasterBandH hBaseBand,
+                                    int nOverviewCount,
+                                    GDALRasterBandH * pahOverviews,
+                                    GDALProgressFunc pfnProgress,
+                                    void * pProgressData) -> CPLErr
+"""
 function overviewmagnitudecorrection(hBaseBand::GDALRasterBandH,nOverviewCount::Integer,pahOverviews::Ptr{GDALRasterBandH},pfnProgress::GDALProgressFunc,pProgressData::Ptr{Void})
     ccall((:GDALOverviewMagnitudeCorrection,libgdal),CPLErr,(GDALRasterBandH,Cint,Ptr{GDALRasterBandH},GDALProgressFunc,Ptr{Void}),hBaseBand,nOverviewCount,pahOverviews,pfnProgress,pProgressData)
 end
 
+
+"""
+    GDALGetDefaultRAT(GDALRasterBandH hBand) -> GDALRasterAttributeTableH
+
+Fetch default Raster Attribute Table.
+"""
 function getdefaultrat(hBand::GDALRasterBandH)
     checknull(ccall((:GDALGetDefaultRAT,libgdal),GDALRasterAttributeTableH,(GDALRasterBandH,),hBand))
 end
 
+
+"""
+    GDALSetDefaultRAT(GDALRasterBandH,
+                      GDALRasterAttributeTableH) -> CPLErr
+
+Set default Raster Attribute Table.
+"""
 function setdefaultrat(arg1::GDALRasterBandH,arg2::GDALRasterAttributeTableH)
     ccall((:GDALSetDefaultRAT,libgdal),CPLErr,(GDALRasterBandH,GDALRasterAttributeTableH),arg1,arg2)
 end
 
+
+"""
+    GDALAddDerivedBandPixelFunc(const char * pszName,
+                                GDALDerivedPixelFunc pfnPixelFunc) -> CPLErr
+
+This adds a pixel function to the global list of available pixel functions for derived bands.
+
+### Parameters
+* **pszFuncName**: Name used to access pixel function
+* **pfnNewFunction**: Pixel function associated with name. An existing pixel function registered with the same name will be replaced with the new one.
+
+### Returns
+CE_None, invalid (NULL) parameters are currently ignored.
+"""
 function addderivedbandpixelfunc(pszName::AbstractString,pfnPixelFunc::GDALDerivedPixelFunc)
     ccall((:GDALAddDerivedBandPixelFunc,libgdal),CPLErr,(Ptr{UInt8},GDALDerivedPixelFunc),pszName,pfnPixelFunc)
 end
 
+
+"""
+    GDALGetMaskBand(GDALRasterBandH hBand) -> GDALRasterBandH
+
+Return the mask band associated with the band.
+"""
 function getmaskband(hBand::GDALRasterBandH)
     checknull(ccall((:GDALGetMaskBand,libgdal),GDALRasterBandH,(GDALRasterBandH,),hBand))
 end
 
+
+"""
+    GDALGetMaskFlags(GDALRasterBandH hBand) -> int
+
+Return the status flags of the mask band associated with the band.
+"""
 function getmaskflags(hBand::GDALRasterBandH)
     ccall((:GDALGetMaskFlags,libgdal),Cint,(GDALRasterBandH,),hBand)
 end
 
+
+"""
+    GDALCreateMaskBand(GDALRasterBandH hBand,
+                       int nFlags) -> CPLErr
+
+Adds a mask band to the current band.
+"""
 function createmaskband(hBand::GDALRasterBandH,nFlags::Integer)
     ccall((:GDALCreateMaskBand,libgdal),CPLErr,(GDALRasterBandH,Cint),hBand,nFlags)
 end
 
+
+"""
+    GDALARGetNextUpdatedRegion(GDALAsyncReaderH hARIO,
+                               double dfTimeout,
+                               int * pnXBufOff,
+                               int * pnYBufOff,
+                               int * pnXBufSize,
+                               int * pnYBufSize) -> GDALAsyncStatusType
+"""
 function argetnextupdatedregion(hARIO::GDALAsyncReaderH,dfTimeout::Real,pnXBufOff::Vector{Cint},pnYBufOff::Vector{Cint},pnXBufSize::Vector{Cint},pnYBufSize::Vector{Cint})
     ccall((:GDALARGetNextUpdatedRegion,libgdal),GDALAsyncStatusType,(GDALAsyncReaderH,Cdouble,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),hARIO,dfTimeout,pnXBufOff,pnYBufOff,pnXBufSize,pnYBufSize)
 end
 
+
+"""
+    GDALARLockBuffer(GDALAsyncReaderH hARIO,
+                     double dfTimeout) -> int
+"""
 function arlockbuffer(hARIO::GDALAsyncReaderH,dfTimeout::Real)
     ccall((:GDALARLockBuffer,libgdal),Cint,(GDALAsyncReaderH,Cdouble),hARIO,dfTimeout)
 end
 
+
+"""
+    GDALARUnlockBuffer(GDALAsyncReaderH hARIO) -> void
+"""
 function arunlockbuffer(hARIO::GDALAsyncReaderH)
     ccall((:GDALARUnlockBuffer,libgdal),Void,(GDALAsyncReaderH,),hARIO)
 end
 
+
+"""
+    GDALGeneralCmdLineProcessor(int nArgc,
+                                char *** ppapszArgv,
+                                int nOptions) -> int
+
+General utility option processing.
+
+### Parameters
+* **nArgc**: number of values in the argument list.
+* **ppapszArgv**: pointer to the argument list array (will be updated in place).
+* **nOptions**: a or-able combination of GDAL_OF_RASTER and GDAL_OF_VECTOR to determine which drivers should be displayed by formats. If set to 0, GDAL_OF_RASTER is assumed.
+
+### Returns
+updated nArgc argument count. Return of 0 requests terminate without error, return of -1 requests exit with error code.
+"""
 function generalcmdlineprocessor(nArgc::Integer,ppapszArgv::Ptr{Ptr{Ptr{UInt8}}},nOptions::Integer)
     ccall((:GDALGeneralCmdLineProcessor,libgdal),Cint,(Cint,Ptr{Ptr{Ptr{UInt8}}},Cint),nArgc,ppapszArgv,nOptions)
 end
 
+
+"""
+    GDALSwapWords(void * pData,
+                  int nWordSize,
+                  int nWordCount,
+                  int nWordSkip) -> void
+
+Byte swap words in-place.
+
+### Parameters
+* **pData**: pointer to start of data buffer.
+* **nWordSize**: size of words being swapped in bytes. Normally 2, 4 or 8.
+* **nWordCount**: the number of words to be swapped in this call.
+* **nWordSkip**: the byte offset from the start of one word to the start of the next. For packed buffers this is the same as nWordSize.
+"""
 function swapwords(pData::Ptr{Void},nWordSize::Integer,nWordCount::Integer,nWordSkip::Integer)
     ccall((:GDALSwapWords,libgdal),Void,(Ptr{Void},Cint,Cint,Cint),pData,nWordSize,nWordCount,nWordSkip)
 end
 
+
+"""
+    GDALCopyWords(void * pSrcData,
+                  GDALDataType eSrcType,
+                  int nSrcPixelOffset,
+                  void * pDstData,
+                  GDALDataType eDstType,
+                  int nDstPixelOffset,
+                  int nWordCount) -> void
+
+Copy pixel words from buffer to buffer.
+
+### Parameters
+* **pSrcData**: Pointer to source data to be converted.
+* **eSrcType**: the source data type (see GDALDataType enum)
+* **nSrcPixelStride**: Source pixel stride (i.e. distance between 2 words), in bytes
+* **pDstData**: Pointer to buffer where destination data should go
+* **eDstType**: the destination data type (see GDALDataType enum)
+* **nDstPixelStride**: Destination pixel stride (i.e. distance between 2 words), in bytes
+* **nWordCount**: number of words to be copied
+"""
 function copywords(pSrcData::Ptr{Void},eSrcType::GDALDataType,nSrcPixelOffset::Integer,pDstData::Ptr{Void},eDstType::GDALDataType,nDstPixelOffset::Integer,nWordCount::Integer)
     ccall((:GDALCopyWords,libgdal),Void,(Ptr{Void},GDALDataType,Cint,Ptr{Void},GDALDataType,Cint,Cint),pSrcData,eSrcType,nSrcPixelOffset,pDstData,eDstType,nDstPixelOffset,nWordCount)
 end
 
+
+"""
+    GDALCopyBits(const GByte * pabySrcData,
+                 int nSrcOffset,
+                 int nSrcStep,
+                 GByte * pabyDstData,
+                 int nDstOffset,
+                 int nDstStep,
+                 int nBitCount,
+                 int nStepCount) -> void
+
+Bitwise word copying.
+
+### Parameters
+* **pabySrcData**: the source data buffer.
+* **nSrcOffset**: the offset (in bits) in pabySrcData to the start of the first word to copy.
+* **nSrcStep**: the offset in bits from the start one source word to the start of the next.
+* **pabyDstData**: the destination data buffer.
+* **nDstOffset**: the offset (in bits) in pabyDstData to the start of the first word to copy over.
+* **nDstStep**: the offset in bits from the start one word to the start of the next.
+* **nBitCount**: the number of bits in a word to be copied.
+* **nStepCount**: the number of words to copy.
+"""
 function copybits(pabySrcData::Ptr{GByte},nSrcOffset::Integer,nSrcStep::Integer,pabyDstData::Ptr{GByte},nDstOffset::Integer,nDstStep::Integer,nBitCount::Integer,nStepCount::Integer)
     ccall((:GDALCopyBits,libgdal),Void,(Ptr{GByte},Cint,Cint,Ptr{GByte},Cint,Cint,Cint,Cint),pabySrcData,nSrcOffset,nSrcStep,pabyDstData,nDstOffset,nDstStep,nBitCount,nStepCount)
 end
 
+
+"""
+    GDALLoadWorldFile(const char *,
+                      double *) -> int
+
+Read ESRI world file.
+
+### Parameters
+* **pszFilename**: the world file name.
+* **padfGeoTransform**: the six double array into which the geotransformation should be placed.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function loadworldfile(arg1::AbstractString,arg2::Vector{Float64})
     ccall((:GDALLoadWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble}),arg1,arg2)
 end
 
+
+"""
+    GDALReadWorldFile(const char *,
+                      const char *,
+                      double *) -> int
+
+Read ESRI world file.
+
+### Parameters
+* **pszBaseFilename**: the target raster file.
+* **pszExtension**: the extension to use (ie. ".wld") or NULL to derive it from the pszBaseFilename
+* **padfGeoTransform**: the six double array into which the geotransformation should be placed.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function readworldfile(arg1::AbstractString,arg2::AbstractString,arg3::Vector{Float64})
     ccall((:GDALReadWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALWriteWorldFile(const char *,
+                       const char *,
+                       double *) -> int
+
+Write ESRI world file.
+
+### Parameters
+* **pszBaseFilename**: the target raster file.
+* **pszExtension**: the extension to use (ie. ".wld"). Must not be NULL
+* **padfGeoTransform**: the six double array from which the geotransformation should be read.
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function writeworldfile(arg1::AbstractString,arg2::AbstractString,arg3::Vector{Float64})
     ccall((:GDALWriteWorldFile,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALLoadTabFile(const char *,
+                    double *,
+                    char **,
+                    int *,
+                    GDAL_GCP **) -> int
+"""
 function loadtabfile(arg1::AbstractString,arg2::Vector{Float64},arg3::Vector{UTF8String},arg4::Vector{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALLoadTabFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALReadTabFile(const char *,
+                    double *,
+                    char **,
+                    int *,
+                    GDAL_GCP **) -> int
+"""
 function readtabfile(arg1::AbstractString,arg2::Vector{Float64},arg3::Vector{UTF8String},arg4::Vector{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALReadTabFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALLoadOziMapFile(const char *,
+                       double *,
+                       char **,
+                       int *,
+                       GDAL_GCP **) -> int
+"""
 function loadozimapfile(arg1::AbstractString,arg2::Vector{Float64},arg3::Vector{UTF8String},arg4::Vector{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALLoadOziMapFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALReadOziMapFile(const char *,
+                       double *,
+                       char **,
+                       int *,
+                       GDAL_GCP **) -> int
+"""
 function readozimapfile(arg1::AbstractString,arg2::Vector{Float64},arg3::Vector{UTF8String},arg4::Vector{Cint},arg5::Ptr{Ptr{GDAL_GCP}})
     ccall((:GDALReadOziMapFile,libgdal),Cint,(Ptr{UInt8},Ptr{Cdouble},Ptr{Ptr{UInt8}},Ptr{Cint},Ptr{Ptr{GDAL_GCP}}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    GDALDecToDMS(double,
+                 const char *,
+                 int) -> const char *
+"""
 function dectodms(arg1::Real,arg2::AbstractString,arg3::Integer)
     bytestring(ccall((:GDALDecToDMS,libgdal),Ptr{UInt8},(Cdouble,Ptr{UInt8},Cint),arg1,arg2,arg3))
 end
 
+
+"""
+    GDALPackedDMSToDec(double) -> double
+
+Convert a packed DMS value (DDDMMMSSS.SS) into decimal degrees.
+"""
 function packeddmstodec(arg1::Real)
     ccall((:GDALPackedDMSToDec,libgdal),Cdouble,(Cdouble,),arg1)
 end
 
+
+"""
+    GDALDecToPackedDMS(double) -> double
+
+Convert decimal degrees into packed DMS value (DDDMMMSSS.SS).
+"""
 function dectopackeddms(arg1::Real)
     ccall((:GDALDecToPackedDMS,libgdal),Cdouble,(Cdouble,),arg1)
 end
 
+
+"""
+    GDALExtractRPCInfo(char **,
+                       GDALRPCInfo *) -> int
+"""
 function extractrpcinfo(arg1::Vector{UTF8String},arg2::Ptr{GDALRPCInfo})
     ccall((:GDALExtractRPCInfo,libgdal),Cint,(Ptr{Ptr{UInt8}},Ptr{GDALRPCInfo}),arg1,arg2)
 end
 
+
+"""
+    GDALCreateColorTable(GDALPaletteInterp) -> GDALColorTableH
+
+Construct a new color table.
+"""
 function createcolortable(arg1::GDALPaletteInterp)
     checknull(ccall((:GDALCreateColorTable,libgdal),GDALColorTableH,(GDALPaletteInterp,),arg1))
 end
 
+
+"""
+    GDALDestroyColorTable(GDALColorTableH) -> void
+
+Destroys a color table.
+"""
 function destroycolortable(arg1::GDALColorTableH)
     ccall((:GDALDestroyColorTable,libgdal),Void,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALCloneColorTable(GDALColorTableH) -> GDALColorTableH
+
+Make a copy of a color table.
+"""
 function clonecolortable(arg1::GDALColorTableH)
     checknull(ccall((:GDALCloneColorTable,libgdal),GDALColorTableH,(GDALColorTableH,),arg1))
 end
 
+
+"""
+    GDALGetPaletteInterpretation(GDALColorTableH) -> GDALPaletteInterp
+
+Fetch palette interpretation.
+"""
 function getpaletteinterpretation(arg1::GDALColorTableH)
     ccall((:GDALGetPaletteInterpretation,libgdal),GDALPaletteInterp,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALGetColorEntryCount(GDALColorTableH) -> int
+
+Get number of color entries in table.
+"""
 function getcolorentrycount(arg1::GDALColorTableH)
     ccall((:GDALGetColorEntryCount,libgdal),Cint,(GDALColorTableH,),arg1)
 end
 
+
+"""
+    GDALGetColorEntry(GDALColorTableH,
+                      int) -> const GDALColorEntry *
+
+Fetch a color entry from table.
+"""
 function getcolorentry(arg1::GDALColorTableH,arg2::Integer)
     ccall((:GDALGetColorEntry,libgdal),Ptr{GDALColorEntry},(GDALColorTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALGetColorEntryAsRGB(GDALColorTableH,
+                           int,
+                           GDALColorEntry *) -> int
+
+Fetch a table entry in RGB format.
+"""
 function getcolorentryasrgb(arg1::GDALColorTableH,arg2::Integer,arg3::Ptr{GDALColorEntry})
     ccall((:GDALGetColorEntryAsRGB,libgdal),Cint,(GDALColorTableH,Cint,Ptr{GDALColorEntry}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALSetColorEntry(GDALColorTableH,
+                      int,
+                      const GDALColorEntry *) -> void
+
+Set entry in color table.
+"""
 function setcolorentry(arg1::GDALColorTableH,arg2::Integer,arg3::Ptr{GDALColorEntry})
     ccall((:GDALSetColorEntry,libgdal),Void,(GDALColorTableH,Cint,Ptr{GDALColorEntry}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALCreateColorRamp(GDALColorTableH hTable,
+                        int nStartIndex,
+                        const GDALColorEntry * psStartColor,
+                        int nEndIndex,
+                        const GDALColorEntry * psEndColor) -> void
+
+Create color ramp.
+"""
 function createcolorramp(hTable::GDALColorTableH,nStartIndex::Integer,psStartColor::Ptr{GDALColorEntry},nEndIndex::Integer,psEndColor::Ptr{GDALColorEntry})
     ccall((:GDALCreateColorRamp,libgdal),Void,(GDALColorTableH,Cint,Ptr{GDALColorEntry},Cint,Ptr{GDALColorEntry}),hTable,nStartIndex,psStartColor,nEndIndex,psEndColor)
 end
 
+
+"""
+    GDALCreateRasterAttributeTable(void) -> GDALRasterAttributeTableH
+
+Construct empty table.
+"""
 function createrasterattributetable()
     checknull(ccall((:GDALCreateRasterAttributeTable,libgdal),GDALRasterAttributeTableH,()))
 end
 
+
+"""
+    GDALDestroyRasterAttributeTable(GDALRasterAttributeTableH) -> void
+
+Destroys a RAT.
+"""
 function destroyrasterattributetable(arg1::GDALRasterAttributeTableH)
     ccall((:GDALDestroyRasterAttributeTable,libgdal),Void,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetColumnCount(GDALRasterAttributeTableH) -> int
+
+Fetch table column count.
+"""
 function ratgetcolumncount(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATGetColumnCount,libgdal),Cint,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetNameOfCol(GDALRasterAttributeTableH,
+                        int) -> const char *
+
+Fetch name of indicated column.
+"""
 function ratgetnameofcol(arg1::GDALRasterAttributeTableH,arg2::Integer)
     bytestring(ccall((:GDALRATGetNameOfCol,libgdal),Ptr{UInt8},(GDALRasterAttributeTableH,Cint),arg1,arg2))
 end
 
+
+"""
+    GDALRATGetUsageOfCol(GDALRasterAttributeTableH,
+                         int) -> GDALRATFieldUsage
+
+Fetch column usage value.
+"""
 function ratgetusageofcol(arg1::GDALRasterAttributeTableH,arg2::Integer)
     ccall((:GDALRATGetUsageOfCol,libgdal),GDALRATFieldUsage,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetTypeOfCol(GDALRasterAttributeTableH,
+                        int) -> GDALRATFieldType
+
+Fetch column type.
+"""
 function ratgettypeofcol(arg1::GDALRasterAttributeTableH,arg2::Integer)
     ccall((:GDALRATGetTypeOfCol,libgdal),GDALRATFieldType,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetColOfUsage(GDALRasterAttributeTableH,
+                         GDALRATFieldUsage) -> int
+
+Fetch column index for given usage.
+"""
 function ratgetcolofusage(arg1::GDALRasterAttributeTableH,arg2::GDALRATFieldUsage)
     ccall((:GDALRATGetColOfUsage,libgdal),Cint,(GDALRasterAttributeTableH,GDALRATFieldUsage),arg1,arg2)
 end
 
+
+"""
+    GDALRATGetRowCount(GDALRasterAttributeTableH) -> int
+
+Fetch row count.
+"""
 function ratgetrowcount(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATGetRowCount,libgdal),Cint,(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetValueAsString(GDALRasterAttributeTableH,
+                            int,
+                            int) -> const char *
+
+Fetch field value as a string.
+"""
 function ratgetvalueasstring(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer)
     bytestring(ccall((:GDALRATGetValueAsString,libgdal),Ptr{UInt8},(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3))
 end
 
+
+"""
+    GDALRATGetValueAsInt(GDALRasterAttributeTableH,
+                         int,
+                         int) -> int
+
+Fetch field value as a integer.
+"""
 function ratgetvalueasint(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer)
     ccall((:GDALRATGetValueAsInt,libgdal),Cint,(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATGetValueAsDouble(GDALRasterAttributeTableH,
+                            int,
+                            int) -> double
+
+Fetch field value as a double.
+"""
 function ratgetvalueasdouble(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer)
     ccall((:GDALRATGetValueAsDouble,libgdal),Cdouble,(GDALRasterAttributeTableH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATSetValueAsString(GDALRasterAttributeTableH,
+                            int,
+                            int,
+                            const char *) -> void
+
+Set field value from string.
+"""
 function ratsetvalueasstring(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer,arg4::AbstractString)
     ccall((:GDALRATSetValueAsString,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetValueAsInt(GDALRasterAttributeTableH,
+                         int,
+                         int,
+                         int) -> void
+
+Set field value from integer.
+"""
 function ratsetvalueasint(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer,arg4::Integer)
     ccall((:GDALRATSetValueAsInt,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Cint),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetValueAsDouble(GDALRasterAttributeTableH,
+                            int,
+                            int,
+                            double) -> void
+
+Set field value from double.
+"""
 function ratsetvalueasdouble(arg1::GDALRasterAttributeTableH,arg2::Integer,arg3::Integer,arg4::Real)
     ccall((:GDALRATSetValueAsDouble,libgdal),Void,(GDALRasterAttributeTableH,Cint,Cint,Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATChangesAreWrittenToFile(GDALRasterAttributeTableH hRAT) -> int
+
+Determine whether changes made to this RAT are reflected directly in the dataset.
+"""
 function ratchangesarewrittentofile(hRAT::GDALRasterAttributeTableH)
     ccall((:GDALRATChangesAreWrittenToFile,libgdal),Cint,(GDALRasterAttributeTableH,),hRAT)
 end
 
+
+"""
+    GDALRATValuesIOAsDouble(GDALRasterAttributeTableH hRAT,
+                            GDALRWFlag eRWFlag,
+                            int iField,
+                            int iStartRow,
+                            int iLength,
+                            double * pdfData) -> CPLErr
+
+Read or Write a block of doubles to/from the Attribute Table.
+"""
 function ratvaluesioasdouble(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Integer,iStartRow::Integer,iLength::Integer,pdfData::Vector{Float64})
     ccall((:GDALRATValuesIOAsDouble,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Cdouble}),hRAT,eRWFlag,iField,iStartRow,iLength,pdfData)
 end
 
+
+"""
+    GDALRATValuesIOAsInteger(GDALRasterAttributeTableH hRAT,
+                             GDALRWFlag eRWFlag,
+                             int iField,
+                             int iStartRow,
+                             int iLength,
+                             int * pnData) -> CPLErr
+
+Read or Write a block of ints to/from the Attribute Table.
+"""
 function ratvaluesioasinteger(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Integer,iStartRow::Integer,iLength::Integer,pnData::Vector{Cint})
     ccall((:GDALRATValuesIOAsInteger,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Cint}),hRAT,eRWFlag,iField,iStartRow,iLength,pnData)
 end
 
+
+"""
+    GDALRATValuesIOAsString(GDALRasterAttributeTableH hRAT,
+                            GDALRWFlag eRWFlag,
+                            int iField,
+                            int iStartRow,
+                            int iLength,
+                            char ** papszStrList) -> CPLErr
+
+Read or Write a block of strings to/from the Attribute Table.
+"""
 function ratvaluesioasstring(hRAT::GDALRasterAttributeTableH,eRWFlag::GDALRWFlag,iField::Integer,iStartRow::Integer,iLength::Integer,papszStrList::Vector{UTF8String})
     ccall((:GDALRATValuesIOAsString,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALRWFlag,Cint,Cint,Cint,Ptr{Ptr{UInt8}}),hRAT,eRWFlag,iField,iStartRow,iLength,papszStrList)
 end
 
+
+"""
+    GDALRATSetRowCount(GDALRasterAttributeTableH,
+                       int) -> void
+
+Set row count.
+"""
 function ratsetrowcount(arg1::GDALRasterAttributeTableH,arg2::Integer)
     ccall((:GDALRATSetRowCount,libgdal),Void,(GDALRasterAttributeTableH,Cint),arg1,arg2)
 end
 
+
+"""
+    GDALRATCreateColumn(GDALRasterAttributeTableH,
+                        const char *,
+                        GDALRATFieldType,
+                        GDALRATFieldUsage) -> CPLErr
+
+Create new column.
+"""
 function ratcreatecolumn(arg1::GDALRasterAttributeTableH,arg2::AbstractString,arg3::GDALRATFieldType,arg4::GDALRATFieldUsage)
     ccall((:GDALRATCreateColumn,libgdal),CPLErr,(GDALRasterAttributeTableH,Ptr{UInt8},GDALRATFieldType,GDALRATFieldUsage),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    GDALRATSetLinearBinning(GDALRasterAttributeTableH,
+                            double,
+                            double) -> CPLErr
+
+Set linear binning information.
+"""
 function ratsetlinearbinning(arg1::GDALRasterAttributeTableH,arg2::Real,arg3::Real)
     ccall((:GDALRATSetLinearBinning,libgdal),CPLErr,(GDALRasterAttributeTableH,Cdouble,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATGetLinearBinning(GDALRasterAttributeTableH,
+                            double *,
+                            double *) -> int
+
+Get linear binning information.
+"""
 function ratgetlinearbinning(arg1::GDALRasterAttributeTableH,arg2::Vector{Float64},arg3::Vector{Float64})
     ccall((:GDALRATGetLinearBinning,libgdal),Cint,(GDALRasterAttributeTableH,Ptr{Cdouble},Ptr{Cdouble}),arg1,arg2,arg3)
 end
 
+
+"""
+    GDALRATInitializeFromColorTable(GDALRasterAttributeTableH,
+                                    GDALColorTableH) -> CPLErr
+
+Initialize from color table.
+"""
 function ratinitializefromcolortable(arg1::GDALRasterAttributeTableH,arg2::GDALColorTableH)
     ccall((:GDALRATInitializeFromColorTable,libgdal),CPLErr,(GDALRasterAttributeTableH,GDALColorTableH),arg1,arg2)
 end
 
+
+"""
+    GDALRATTranslateToColorTable(GDALRasterAttributeTableH,
+                                 int nEntryCount) -> GDALColorTableH
+
+Translate to a color table.
+"""
 function rattranslatetocolortable(arg1::GDALRasterAttributeTableH,nEntryCount::Integer)
     checknull(ccall((:GDALRATTranslateToColorTable,libgdal),GDALColorTableH,(GDALRasterAttributeTableH,Cint),arg1,nEntryCount))
 end
 
+
+"""
+    GDALRATDumpReadable(GDALRasterAttributeTableH,
+                        FILE *) -> void
+
+Dump RAT in readable form.
+"""
 function ratdumpreadable(arg1::GDALRasterAttributeTableH,arg2::Ptr{FILE})
     ccall((:GDALRATDumpReadable,libgdal),Void,(GDALRasterAttributeTableH,Ptr{FILE}),arg1,arg2)
 end
 
+
+"""
+    GDALRATClone(GDALRasterAttributeTableH) -> GDALRasterAttributeTableH
+
+Copy Raster Attribute Table.
+"""
 function ratclone(arg1::GDALRasterAttributeTableH)
     checknull(ccall((:GDALRATClone,libgdal),GDALRasterAttributeTableH,(GDALRasterAttributeTableH,),arg1))
 end
 
+
+"""
+    GDALRATSerializeJSON(GDALRasterAttributeTableH) -> void *
+
+Serialize Raster Attribute Table in Json format.
+"""
 function ratserializejson(arg1::GDALRasterAttributeTableH)
     ccall((:GDALRATSerializeJSON,libgdal),Ptr{Void},(GDALRasterAttributeTableH,),arg1)
 end
 
+
+"""
+    GDALRATGetRowOfValue(GDALRasterAttributeTableH,
+                         double) -> int
+
+Get row for pixel value.
+"""
 function ratgetrowofvalue(arg1::GDALRasterAttributeTableH,arg2::Real)
     ccall((:GDALRATGetRowOfValue,libgdal),Cint,(GDALRasterAttributeTableH,Cdouble),arg1,arg2)
 end
 
+
+"""
+    GDALSetCacheMax(int nBytes) -> void
+
+Set maximum cache memory.
+
+### Parameters
+* **nNewSizeInBytes**: the maximum number of bytes for caching.
+"""
 function setcachemax(nBytes::Integer)
     ccall((:GDALSetCacheMax,libgdal),Void,(Cint,),nBytes)
 end
 
+
+"""
+    GDALGetCacheMax(void) -> int
+
+Get maximum cache memory.
+
+### Returns
+maximum in bytes.
+"""
 function getcachemax()
     ccall((:GDALGetCacheMax,libgdal),Cint,())
 end
 
+
+"""
+    GDALGetCacheUsed(void) -> int
+
+Get cache memory used.
+
+### Returns
+the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
+"""
 function getcacheused()
     ccall((:GDALGetCacheUsed,libgdal),Cint,())
 end
 
+
+"""
+    GDALSetCacheMax64(GIntBig nBytes) -> void
+
+Set maximum cache memory.
+
+### Parameters
+* **nNewSizeInBytes**: the maximum number of bytes for caching.
+"""
 function setcachemax64(nBytes::GIntBig)
     ccall((:GDALSetCacheMax64,libgdal),Void,(GIntBig,),nBytes)
 end
 
+
+"""
+    GDALGetCacheMax64(void) -> GIntBig
+
+Get maximum cache memory.
+
+### Returns
+maximum in bytes.
+"""
 function getcachemax64()
     ccall((:GDALGetCacheMax64,libgdal),GIntBig,())
 end
 
+
+"""
+    GDALGetCacheUsed64(void) -> GIntBig
+
+Get cache memory used.
+
+### Returns
+the number of bytes of memory currently in use by the GDALRasterBlock memory caching.
+"""
 function getcacheused64()
     ccall((:GDALGetCacheUsed64,libgdal),GIntBig,())
 end
 
+
+"""
+    GDALFlushCacheBlock(void) -> int
+
+Try to flush one cached raster block.
+
+### Returns
+TRUE if one block was flushed, FALSE if there are no cached blocks or if they are currently locked.
+"""
 function flushcacheblock()
     ccall((:GDALFlushCacheBlock,libgdal),Cint,())
 end
 
+
+"""
+    GDALDatasetGetVirtualMem(GDALDatasetH hDS,
+                             GDALRWFlag eRWFlag,
+                             int nXOff,
+                             int nYOff,
+                             int nXSize,
+                             int nYSize,
+                             int nBufXSize,
+                             int nBufYSize,
+                             GDALDataType eBufType,
+                             int nBandCount,
+                             int * panBandMap,
+                             int nPixelSpace,
+                             GIntBig nLineSpace,
+                             GIntBig nBandSpace,
+                             size_t nCacheSize,
+                             size_t nPageSizeHint,
+                             int bSingleThreadUsage,
+                             char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL dataset object.
+
+### Parameters
+* **hDS**: Dataset object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nBufXSize**: the width of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **nBufYSize**: the height of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nBandCount**: the number of bands being read or written.
+* **panBandMap**: the list of nBandCount band numbers being read/written. Note band numbers are 1 based. This may be NULL to select the first nBandCount bands.
+* **nPixelSpace**: The byte offset from the start of one pixel value in the buffer to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in the buffer to the start of the next. If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+* **nBandSpace**: the byte offset from the start of one bands data to the start of the next. If defaulted (0) the value will be nLineSpace * nBufYSize implying band sequential organization of the data buffer.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **nPageSizeHint**: hint for the page size. Must be a multiple of the system page size, returned by CPLGetPageSize(). Minimum value is generally 4096. Might be set to 0 to let the function determine a default page size.
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function datasetgetvirtualmem(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer,nBufXSize::Integer,nBufYSize::Integer,eBufType::GDALDataType,nBandCount::Integer,panBandMap::Vector{Cint},nPixelSpace::Integer,nLineSpace::GIntBig,nBandSpace::GIntBig,nCacheSize::Csize_t,nPageSizeHint::Csize_t,bSingleThreadUsage::Integer,papszOptions::Vector{UTF8String})
     ccall((:GDALDatasetGetVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},Cint,GIntBig,GIntBig,Csize_t,Csize_t,Cint,Ptr{Ptr{UInt8}}),hDS,eRWFlag,nXOff,nYOff,nXSize,nYSize,nBufXSize,nBufYSize,eBufType,nBandCount,panBandMap,nPixelSpace,nLineSpace,nBandSpace,nCacheSize,nPageSizeHint,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALRasterBandGetVirtualMem(GDALRasterBandH hBand,
+                                GDALRWFlag eRWFlag,
+                                int nXOff,
+                                int nYOff,
+                                int nXSize,
+                                int nYSize,
+                                int nBufXSize,
+                                int nBufYSize,
+                                GDALDataType eBufType,
+                                int nPixelSpace,
+                                GIntBig nLineSpace,
+                                size_t nCacheSize,
+                                size_t nPageSizeHint,
+                                int bSingleThreadUsage,
+                                char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL raster band object.
+
+### Parameters
+* **hBand**: Rasterband object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nBufXSize**: the width of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **nBufYSize**: the height of the buffer image into which the desired region is to be read, or from which it is to be written.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nPixelSpace**: The byte offset from the start of one pixel value in the buffer to the start of the next pixel value within a scanline. If defaulted (0) the size of the datatype eBufType is used.
+* **nLineSpace**: The byte offset from the start of one scanline in the buffer to the start of the next. If defaulted (0) the size of the datatype eBufType * nBufXSize is used.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **nPageSizeHint**: hint for the page size. Must be a multiple of the system page size, returned by CPLGetPageSize(). Minimum value is generally 4096. Might be set to 0 to let the function determine a default page size.
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function rasterbandgetvirtualmem(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer,nBufXSize::Integer,nBufYSize::Integer,eBufType::GDALDataType,nPixelSpace::Integer,nLineSpace::GIntBig,nCacheSize::Csize_t,nPageSizeHint::Csize_t,bSingleThreadUsage::Integer,papszOptions::Vector{UTF8String})
     ccall((:GDALRasterBandGetVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,GIntBig,Csize_t,Csize_t,Cint,Ptr{Ptr{UInt8}}),hBand,eRWFlag,nXOff,nYOff,nXSize,nYSize,nBufXSize,nBufYSize,eBufType,nPixelSpace,nLineSpace,nCacheSize,nPageSizeHint,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALGetVirtualMemAuto(GDALRasterBandH hBand,
+                          GDALRWFlag eRWFlag,
+                          int * pnPixelSpace,
+                          GIntBig * pnLineSpace,
+                          char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL raster band object.
+"""
 function getvirtualmemauto(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,pnPixelSpace::Vector{Cint},pnLineSpace::Ptr{GIntBig},papszOptions::Vector{UTF8String})
     ccall((:GDALGetVirtualMemAuto,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Ptr{Cint},Ptr{GIntBig},Ptr{Ptr{UInt8}}),hBand,eRWFlag,pnPixelSpace,pnLineSpace,papszOptions)
 end
 
+
+"""
+    GDALDatasetGetTiledVirtualMem(GDALDatasetH hDS,
+                                  GDALRWFlag eRWFlag,
+                                  int nXOff,
+                                  int nYOff,
+                                  int nXSize,
+                                  int nYSize,
+                                  int nTileXSize,
+                                  int nTileYSize,
+                                  GDALDataType eBufType,
+                                  int nBandCount,
+                                  int * panBandMap,
+                                  GDALTileOrganization eTileOrganization,
+                                  size_t nCacheSize,
+                                  int bSingleThreadUsage,
+                                  char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL dataset object, with tiling organization.
+
+### Parameters
+* **hDS**: Dataset object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nTileXSize**: the width of the tiles.
+* **nTileYSize**: the height of the tiles.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nBandCount**: the number of bands being read or written.
+* **panBandMap**: the list of nBandCount band numbers being read/written. Note band numbers are 1 based. This may be NULL to select the first nBandCount bands.
+* **eTileOrganization**: tile organization.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function datasetgettiledvirtualmem(hDS::GDALDatasetH,eRWFlag::GDALRWFlag,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer,nTileXSize::Integer,nTileYSize::Integer,eBufType::GDALDataType,nBandCount::Integer,panBandMap::Vector{Cint},eTileOrganization::GDALTileOrganization,nCacheSize::Csize_t,bSingleThreadUsage::Integer,papszOptions::Vector{UTF8String})
     ccall((:GDALDatasetGetTiledVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALDatasetH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Cint,Ptr{Cint},GDALTileOrganization,Csize_t,Cint,Ptr{Ptr{UInt8}}),hDS,eRWFlag,nXOff,nYOff,nXSize,nYSize,nTileXSize,nTileYSize,eBufType,nBandCount,panBandMap,eTileOrganization,nCacheSize,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALRasterBandGetTiledVirtualMem(GDALRasterBandH hBand,
+                                     GDALRWFlag eRWFlag,
+                                     int nXOff,
+                                     int nYOff,
+                                     int nXSize,
+                                     int nYSize,
+                                     int nTileXSize,
+                                     int nTileYSize,
+                                     GDALDataType eBufType,
+                                     size_t nCacheSize,
+                                     int bSingleThreadUsage,
+                                     char ** papszOptions) -> CPLVirtualMem *
+
+Create a CPLVirtualMem object from a GDAL rasterband object, with tiling organization.
+
+### Parameters
+* **hBand**: Rasterband object
+* **eRWFlag**: Either GF_Read to read a region of data, or GF_Write to write a region of data.
+* **nXOff**: The pixel offset to the top left corner of the region of the band to be accessed. This would be zero to start from the left side.
+* **nYOff**: The line offset to the top left corner of the region of the band to be accessed. This would be zero to start from the top.
+* **nXSize**: The width of the region of the band to be accessed in pixels.
+* **nYSize**: The height of the region of the band to be accessed in lines.
+* **nTileXSize**: the width of the tiles.
+* **nTileYSize**: the height of the tiles.
+* **eBufType**: the type of the pixel values in the data buffer. The pixel values will automatically be translated to/from the GDALRasterBand data type as needed.
+* **nCacheSize**: size in bytes of the maximum memory that will be really allocated (must ideally fit into RAM)
+* **bSingleThreadUsage**: set to TRUE if there will be no concurrent threads that will access the virtual memory mapping. This can optimize performance a bit. If set to FALSE, CPLVirtualMemDeclareThread() must be called.
+* **papszOptions**: NULL terminated list of options. Unused for now.
+
+### Returns
+a virtual memory object that must be freed by CPLVirtualMemFree(), or NULL in case of failure.
+"""
 function rasterbandgettiledvirtualmem(hBand::GDALRasterBandH,eRWFlag::GDALRWFlag,nXOff::Integer,nYOff::Integer,nXSize::Integer,nYSize::Integer,nTileXSize::Integer,nTileYSize::Integer,eBufType::GDALDataType,nCacheSize::Csize_t,bSingleThreadUsage::Integer,papszOptions::Vector{UTF8String})
     ccall((:GDALRasterBandGetTiledVirtualMem,libgdal),Ptr{CPLVirtualMem},(GDALRasterBandH,GDALRWFlag,Cint,Cint,Cint,Cint,Cint,Cint,GDALDataType,Csize_t,Cint,Ptr{Ptr{UInt8}}),hBand,eRWFlag,nXOff,nYOff,nXSize,nYSize,nTileXSize,nTileYSize,eBufType,nCacheSize,bSingleThreadUsage,papszOptions)
 end
 
+
+"""
+    GDALGetJPEG2000Structure(const char * pszFilename,
+                             char ** papszOptions) -> CPLXMLNode *
+
+Dump the structure of a JPEG2000 file as a XML tree.
+
+### Parameters
+* **pszFilename**: filename.
+* **papszOptions**: NULL terminated list of options, or NULL. Allowed options are BINARY_CONTENT=YES, TEXT_CONTENT=YES, CODESTREAM=YES, ALL=YES.
+
+### Returns
+XML tree (to be freed with CPLDestroyXMLNode()) or NULL in case of error
+"""
 function getjpeg2000structure(pszFilename::AbstractString,papszOptions::Vector{UTF8String})
     ccall((:GDALGetJPEG2000Structure,libgdal),Ptr{CPLXMLNode},(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszFilename,papszOptions)
 end
-

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -1,1364 +1,5660 @@
+
+
+"""
+    OGR_G_CreateFromWkb(unsigned char *,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *,
+                        int) -> OGRErr
+
+Create a geometry object of the appropriate type from it's well known binary representation.
+
+### Parameters
+* **pabyData**: pointer to the input BLOB data.
+* **hSRS**: handle to the spatial reference to be assigned to the created geometry object. This may be NULL.
+* **phGeometry**: the newly created geometry object will be assigned to the indicated handle on return. This will be NULL in case of failure. If not NULL, *phGeometry should be freed with OGR_G_DestroyGeometry() after use.
+* **nBytes**: the number of bytes of data available in pabyData, or -1 if it is not known, but assumed to be sufficient.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function createfromwkb(arg1::Ptr{Cuchar},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH},arg4::Integer)
     ccall((:OGR_G_CreateFromWkb,libgdal),OGRErr,(Ptr{Cuchar},OGRSpatialReferenceH,Ptr{OGRGeometryH},Cint),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_CreateFromWkt(char **,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *) -> OGRErr
+
+Create a geometry object of the appropriate type from it's well known text representation.
+
+### Parameters
+* **ppszData**: input zero terminated string containing well known text representation of the geometry to be created. The pointer is updated to point just beyond that last character consumed.
+* **hSRS**: handle to the spatial reference to be assigned to the created geometry object. This may be NULL.
+* **phGeometry**: the newly created geometry object will be assigned to the indicated handle on return. This will be NULL if the method fails. If not NULL, *phGeometry should be freed with OGR_G_DestroyGeometry() after use.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function createfromwkt(arg1::Vector{UTF8String},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH})
     ccall((:OGR_G_CreateFromWkt,libgdal),OGRErr,(Ptr{Ptr{UInt8}},OGRSpatialReferenceH,Ptr{OGRGeometryH}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_CreateFromFgf(unsigned char *,
+                        OGRSpatialReferenceH,
+                        OGRGeometryH *,
+                        int,
+                        int *) -> OGRErr
+"""
 function createfromfgf(arg1::Ptr{Cuchar},arg2::OGRSpatialReferenceH,arg3::Ptr{OGRGeometryH},arg4::Integer,arg5::Vector{Cint})
     ccall((:OGR_G_CreateFromFgf,libgdal),OGRErr,(Ptr{Cuchar},OGRSpatialReferenceH,Ptr{OGRGeometryH},Cint,Ptr{Cint}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OGR_G_DestroyGeometry(OGRGeometryH) -> void
+
+Destroy geometry object.
+
+### Parameters
+* **hGeom**: handle to the geometry to delete.
+"""
 function destroygeometry(arg1::OGRGeometryH)
     ccall((:OGR_G_DestroyGeometry,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CreateGeometry(OGRwkbGeometryType) -> OGRGeometryH
+
+Create an empty geometry of desired type.
+
+### Parameters
+* **eGeometryType**: the type code of the geometry to be created.
+
+### Returns
+handle to the newly create geometry or NULL on failure. Should be freed with OGR_G_DestroyGeometry() after use.
+"""
 function creategeometry(arg1::OGRwkbGeometryType)
     checknull(ccall((:OGR_G_CreateGeometry,libgdal),OGRGeometryH,(OGRwkbGeometryType,),arg1))
 end
 
+
+"""
+    OGR_G_ApproximateArcAngles(double dfCenterX,
+                               double dfCenterY,
+                               double dfZ,
+                               double dfPrimaryRadius,
+                               double dfSecondaryAxis,
+                               double dfRotation,
+                               double dfStartAngle,
+                               double dfEndAngle,
+                               double dfMaxAngleStepSizeDegrees) -> OGRGeometryH
+
+Stroke arc to linestring.
+
+### Parameters
+* **dfCenterX**: center X
+* **dfCenterY**: center Y
+* **dfZ**: center Z
+* **dfPrimaryRadius**: X radius of ellipse.
+* **dfSecondaryRadius**: Y radius of ellipse.
+* **dfRotation**: rotation of the ellipse clockwise.
+* **dfStartAngle**: angle to first point on arc (clockwise of X-positive)
+* **dfEndAngle**: angle to last point on arc (clockwise of X-positive)
+* **dfMaxAngleStepSizeDegrees**: the largest step in degrees along the arc, zero to use the default setting.
+
+### Returns
+OGRLineString geometry representing an approximation of the arc.
+"""
 function approximatearcangles(dfCenterX::Real,dfCenterY::Real,dfZ::Real,dfPrimaryRadius::Real,dfSecondaryAxis::Real,dfRotation::Real,dfStartAngle::Real,dfEndAngle::Real,dfMaxAngleStepSizeDegrees::Real)
     checknull(ccall((:OGR_G_ApproximateArcAngles,libgdal),OGRGeometryH,(Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),dfCenterX,dfCenterY,dfZ,dfPrimaryRadius,dfSecondaryAxis,dfRotation,dfStartAngle,dfEndAngle,dfMaxAngleStepSizeDegrees))
 end
 
+
+"""
+    OGR_G_ForceToPolygon(OGRGeometryH) -> OGRGeometryH
+
+Convert to polygon.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function forcetopolygon(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ForceToPolygon,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ForceToLineString(OGRGeometryH) -> OGRGeometryH
+
+Convert to line string.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function forcetolinestring(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ForceToLineString,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ForceToMultiPolygon(OGRGeometryH) -> OGRGeometryH
+
+Convert to multipolygon.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function forcetomultipolygon(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ForceToMultiPolygon,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ForceToMultiPoint(OGRGeometryH) -> OGRGeometryH
+
+Convert to multipoint.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function forcetomultipoint(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ForceToMultiPoint,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ForceToMultiLineString(OGRGeometryH) -> OGRGeometryH
+
+Convert to multilinestring.
+
+### Parameters
+* **hGeom**: handle to the geometry to convert (ownership surrendered).
+
+### Returns
+the converted geometry (ownership to caller).
+"""
 function forcetomultilinestring(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ForceToMultiLineString,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ForceTo(OGRGeometryH hGeom,
+                  OGRwkbGeometryType eTargetType,
+                  char ** papszOptions) -> OGRGeometryH
+
+Convert to another geometry type.
+
+### Parameters
+* **hGeom**: the input geometry - ownership is passed to the method.
+* **eTargetType**: target output geometry type.
+* **papszOptions**: options as a null-terminated list of strings or NULL.
+
+### Returns
+new geometry.
+"""
 function forceto(hGeom::OGRGeometryH,eTargetType::OGRwkbGeometryType,papszOptions::Vector{UTF8String})
     checknull(ccall((:OGR_G_ForceTo,libgdal),OGRGeometryH,(OGRGeometryH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),hGeom,eTargetType,papszOptions))
 end
 
+
+"""
+    OGR_G_GetDimension(OGRGeometryH) -> int
+
+Get the dimension of this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension from.
+
+### Returns
+0 for points, 1 for lines and 2 for surfaces.
+"""
 function getdimension(arg1::OGRGeometryH)
     ccall((:OGR_G_GetDimension,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetCoordinateDimension(OGRGeometryH) -> int
+
+Get the dimension of the coordinates in this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension of the coordinates from.
+
+### Returns
+in practice this will return 2 or 3. It can also return 0 in the case of an empty point.
+"""
 function getcoordinatedimension(arg1::OGRGeometryH)
     ccall((:OGR_G_GetCoordinateDimension,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_SetCoordinateDimension(OGRGeometryH,
+                                 int) -> void
+
+Set the coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set the dimension of the coordinates.
+* **nNewDimension**: New coordinate dimension value, either 2 or 3.
+"""
 function setcoordinatedimension(arg1::OGRGeometryH,arg2::Integer)
     ccall((:OGR_G_SetCoordinateDimension,libgdal),Void,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Clone(OGRGeometryH) -> OGRGeometryH
+
+Make a copy of this object.
+
+### Parameters
+* **hGeom**: handle on the geometry to clone from.
+
+### Returns
+an handle on the copy of the geometry with the spatial reference system as the original.
+"""
 function clone(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_Clone,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_GetEnvelope(OGRGeometryH,
+                      OGREnvelope *) -> void
+
+Computes and returns the bounding envelope for this geometry in the passed psEnvelope structure.
+
+### Parameters
+* **hGeom**: handle of the geometry to get envelope from.
+* **psEnvelope**: the structure in which to place the results.
+"""
 function getenvelope(arg1::OGRGeometryH,arg2::Ptr{OGREnvelope})
     ccall((:OGR_G_GetEnvelope,libgdal),Void,(OGRGeometryH,Ptr{OGREnvelope}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetEnvelope3D(OGRGeometryH,
+                        OGREnvelope3D *) -> void
+
+Computes and returns the bounding envelope (3D) for this geometry in the passed psEnvelope structure.
+
+### Parameters
+* **hGeom**: handle of the geometry to get envelope from.
+* **psEnvelope**: the structure in which to place the results.
+"""
 function getenvelope3d(arg1::OGRGeometryH,arg2::Ptr{OGREnvelope3D})
     ccall((:OGR_G_GetEnvelope3D,libgdal),Void,(OGRGeometryH,Ptr{OGREnvelope3D}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ImportFromWkb(OGRGeometryH,
+                        unsigned char *,
+                        int) -> OGRErr
+
+Assign geometry from well known binary data.
+
+### Parameters
+* **hGeom**: handle on the geometry to assign the well know binary data to.
+* **pabyData**: the binary input data.
+* **nSize**: the size of pabyData in bytes, or zero if not known.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function importfromwkb(arg1::OGRGeometryH,arg2::Ptr{Cuchar},arg3::Integer)
     ccall((:OGR_G_ImportFromWkb,libgdal),OGRErr,(OGRGeometryH,Ptr{Cuchar},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_ExportToWkb(OGRGeometryH,
+                      OGRwkbByteOrder,
+                      unsigned char *) -> OGRErr
+
+Convert a geometry well known binary format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a well know binary data from.
+* **eOrder**: One of wkbXDR or wkbNDR indicating MSB or LSB byte order respectively.
+* **pabyDstBuffer**: a buffer into which the binary representation is written. This buffer must be at least OGR_G_WkbSize() byte in size.
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function exporttowkb(arg1::OGRGeometryH,arg2::OGRwkbByteOrder,arg3::Ptr{Cuchar})
     ccall((:OGR_G_ExportToWkb,libgdal),OGRErr,(OGRGeometryH,OGRwkbByteOrder,Ptr{Cuchar}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_ExportToIsoWkb(OGRGeometryH,
+                         OGRwkbByteOrder,
+                         unsigned char *) -> OGRErr
+
+Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known binary format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a well know binary data from.
+* **eOrder**: One of wkbXDR or wkbNDR indicating MSB or LSB byte order respectively.
+* **pabyDstBuffer**: a buffer into which the binary representation is written. This buffer must be at least OGR_G_WkbSize() byte in size.
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function exporttoisowkb(arg1::OGRGeometryH,arg2::OGRwkbByteOrder,arg3::Ptr{Cuchar})
     ccall((:OGR_G_ExportToIsoWkb,libgdal),OGRErr,(OGRGeometryH,OGRwkbByteOrder,Ptr{Cuchar}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_WkbSize(OGRGeometryH hGeom) -> int
+
+Returns size of related binary representation.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the binary size from.
+
+### Returns
+size of binary representation in bytes.
+"""
 function wkbsize(hGeom::OGRGeometryH)
     ccall((:OGR_G_WkbSize,libgdal),Cint,(OGRGeometryH,),hGeom)
 end
 
+
+"""
+    OGR_G_ImportFromWkt(OGRGeometryH,
+                        char **) -> OGRErr
+
+Assign geometry from well known text data.
+
+### Parameters
+* **hGeom**: handle on the geometry to assign well know text data to.
+* **ppszSrcText**: pointer to a pointer to the source text. The pointer is updated to pointer after the consumed text.
+
+### Returns
+OGRERR_NONE if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA, OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA may be returned.
+"""
 function importfromwkt(arg1::OGRGeometryH,arg2::Vector{UTF8String})
     ccall((:OGR_G_ImportFromWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ExportToWkt(OGRGeometryH,
+                      char **) -> OGRErr
+
+Convert a geometry into well known text format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a text format from.
+* **ppszSrcText**: a text buffer is allocated by the program, and assigned to the passed pointer. After use, *ppszDstText should be freed with OGRFree().
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function exporttowkt(arg1::OGRGeometryH,arg2::Vector{UTF8String})
     ccall((:OGR_G_ExportToWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_ExportToIsoWkt(OGRGeometryH,
+                         char **) -> OGRErr
+
+Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert to a text format from.
+* **ppszSrcText**: a text buffer is allocated by the program, and assigned to the passed pointer. After use, *ppszDstText should be freed with OGRFree().
+
+### Returns
+Currently OGRERR_NONE is always returned.
+"""
 function exporttoisowkt(arg1::OGRGeometryH,arg2::Vector{UTF8String})
     ccall((:OGR_G_ExportToIsoWkt,libgdal),OGRErr,(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetGeometryType(OGRGeometryH) -> OGRwkbGeometryType
+
+Fetch geometry type.
+
+### Parameters
+* **hGeom**: handle on the geometry to get type from.
+
+### Returns
+the geometry type code.
+"""
 function getgeometrytype(arg1::OGRGeometryH)
     ccall((:OGR_G_GetGeometryType,libgdal),OGRwkbGeometryType,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetGeometryName(OGRGeometryH) -> const char *
+
+Fetch WKT name for geometry type.
+
+### Parameters
+* **hGeom**: handle on the geometry to get name from.
+
+### Returns
+name used for this geometry type in well known text format.
+"""
 function getgeometryname(arg1::OGRGeometryH)
     bytestring(ccall((:OGR_G_GetGeometryName,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_DumpReadable(OGRGeometryH,
+                       FILE *,
+                       const char *) -> void
+
+Dump geometry in well known text format to indicated output file.
+
+### Parameters
+* **hGeom**: handle on the geometry to dump.
+* **fp**: the text file to write the geometry to.
+* **pszPrefix**: the prefix to put on each line of output.
+"""
 function dumpreadable(arg1::OGRGeometryH,arg2::Ptr{FILE},arg3::AbstractString)
     ccall((:OGR_G_DumpReadable,libgdal),Void,(OGRGeometryH,Ptr{FILE},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_FlattenTo2D(OGRGeometryH) -> void
+
+Convert geometry to strictly 2D.
+
+### Parameters
+* **hGeom**: handle on the geometry to convert.
+"""
 function flattento2d(arg1::OGRGeometryH)
     ccall((:OGR_G_FlattenTo2D,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CloseRings(OGRGeometryH) -> void
+
+Force rings to be closed.
+
+### Parameters
+* **hGeom**: handle to the geometry.
+"""
 function closerings(arg1::OGRGeometryH)
     ccall((:OGR_G_CloseRings,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_CreateFromGML(const char * pszGML) -> OGRGeometryH
+
+Create geometry from GML.
+
+### Parameters
+* **pszGML**: The GML fragment for the geometry.
+
+### Returns
+a geometry on succes, or NULL on error.
+"""
 function createfromgml(arg1::AbstractString)
     checknull(ccall((:OGR_G_CreateFromGML,libgdal),OGRGeometryH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    OGR_G_ExportToGML(OGRGeometryH hGeometry) -> char *
+
+Convert a geometry into GML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+
+### Returns
+A GML fragment or NULL in case of error.
+"""
 function exporttogml(arg1::OGRGeometryH)
     bytestring(ccall((:OGR_G_ExportToGML,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ExportToGMLEx(OGRGeometryH hGeometry,
+                        char ** papszOptions) -> char *
+
+Convert a geometry into GML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **papszOptions**: NULL-terminated list of options.
+
+### Returns
+A GML fragment or NULL in case of error.
+"""
 function exporttogmlex(arg1::OGRGeometryH,papszOptions::Vector{UTF8String})
     bytestring(ccall((:OGR_G_ExportToGMLEx,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,papszOptions))
 end
 
+
+"""
+    OGR_G_CreateFromGMLTree(const CPLXMLNode * psTree) -> OGRGeometryH
+"""
 function createfromgmltree(arg1::Ptr{CPLXMLNode})
     checknull(ccall((:OGR_G_CreateFromGMLTree,libgdal),OGRGeometryH,(Ptr{CPLXMLNode},),arg1))
 end
 
+
+"""
+    OGR_G_ExportToGMLTree(OGRGeometryH hGeometry) -> CPLXMLNode *
+"""
 function exporttogmltree(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportToGMLTree,libgdal),Ptr{CPLXMLNode},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportEnvelopeToGMLTree(OGRGeometryH hGeometry) -> CPLXMLNode *
+"""
 function exportenvelopetogmltree(arg1::OGRGeometryH)
     ccall((:OGR_G_ExportEnvelopeToGMLTree,libgdal),Ptr{CPLXMLNode},(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_ExportToKML(OGRGeometryH hGeometry,
+                      const char * pszAltitudeMode) -> char *
+
+Convert a geometry into KML format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **pszAltitudeMode**: value to write in altitudeMode element, or NULL.
+
+### Returns
+A KML fragment or NULL in case of error.
+"""
 function exporttokml(arg1::OGRGeometryH,pszAltitudeMode::AbstractString)
     bytestring(ccall((:OGR_G_ExportToKML,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{UInt8}),arg1,pszAltitudeMode))
 end
 
+
+"""
+    OGR_G_ExportToJson(OGRGeometryH) -> char *
+
+Convert a geometry into GeoJSON format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+
+### Returns
+A GeoJSON fragment or NULL in case of error.
+"""
 function exporttojson(arg1::OGRGeometryH)
     bytestring(ccall((:OGR_G_ExportToJson,libgdal),Ptr{UInt8},(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ExportToJsonEx(OGRGeometryH,
+                         char ** papszOptions) -> char *
+
+Convert a geometry into GeoJSON format.
+
+### Parameters
+* **hGeometry**: handle to the geometry.
+* **papszOptions**: a null terminated list of options. For now, only COORDINATE_PRECISION=int_number where int_number is the maximum number of figures after decimal separator to write in coordinates.
+
+### Returns
+A GeoJSON fragment or NULL in case of error.
+"""
 function exporttojsonex(arg1::OGRGeometryH,papszOptions::Vector{UTF8String})
     bytestring(ccall((:OGR_G_ExportToJsonEx,libgdal),Ptr{UInt8},(OGRGeometryH,Ptr{Ptr{UInt8}}),arg1,papszOptions))
 end
 
+
+"""
+    OGR_G_CreateGeometryFromJson(const char *) -> OGRGeometryH
+"""
 function creategeometryfromjson(arg1::AbstractString)
     checknull(ccall((:OGR_G_CreateGeometryFromJson,libgdal),OGRGeometryH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    OGR_G_AssignSpatialReference(OGRGeometryH,
+                                 OGRSpatialReferenceH) -> void
+
+Assign spatial reference to this object.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the new spatial reference system.
+* **hSRS**: handle on the new spatial reference system to apply.
+"""
 function assignspatialreference(arg1::OGRGeometryH,arg2::OGRSpatialReferenceH)
     ccall((:OGR_G_AssignSpatialReference,libgdal),Void,(OGRGeometryH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetSpatialReference(OGRGeometryH) -> OGRSpatialReferenceH
+
+Returns spatial reference system for geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get spatial reference from.
+
+### Returns
+a reference to the spatial reference geometry.
+"""
 function getspatialreference(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_GetSpatialReference,libgdal),OGRSpatialReferenceH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_Transform(OGRGeometryH,
+                    OGRCoordinateTransformationH) -> OGRErr
+
+Apply arbitrary coordinate transformation to geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the transform to.
+* **hTransform**: handle on the transformation to apply.
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function transform(arg1::OGRGeometryH,arg2::OGRCoordinateTransformationH)
     ccall((:OGR_G_Transform,libgdal),OGRErr,(OGRGeometryH,OGRCoordinateTransformationH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_TransformTo(OGRGeometryH,
+                      OGRSpatialReferenceH) -> OGRErr
+
+Transform geometry to new spatial reference system.
+
+### Parameters
+* **hGeom**: handle on the geometry to apply the transform to.
+* **hSRS**: handle on the spatial reference system to apply.
+
+### Returns
+OGRERR_NONE on success, or an error code.
+"""
 function transformto(arg1::OGRGeometryH,arg2::OGRSpatialReferenceH)
     ccall((:OGR_G_TransformTo,libgdal),OGRErr,(OGRGeometryH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Simplify(OGRGeometryH hThis,
+                   double tolerance) -> OGRGeometryH
+
+Compute a simplified geometry.
+
+### Parameters
+* **hThis**: the geometry.
+* **dTolerance**: the distance tolerance for the simplification.
+
+### Returns
+the simplified geometry or NULL if an error occurs.
+"""
 function simplify(hThis::OGRGeometryH,tolerance::Real)
     checknull(ccall((:OGR_G_Simplify,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),hThis,tolerance))
 end
 
+
+"""
+    OGR_G_SimplifyPreserveTopology(OGRGeometryH hThis,
+                                   double tolerance) -> OGRGeometryH
+
+Simplify the geometry while preserving topology.
+
+### Parameters
+* **hThis**: the geometry.
+* **dTolerance**: the distance tolerance for the simplification.
+
+### Returns
+the simplified geometry or NULL if an error occurs.
+"""
 function simplifypreservetopology(hThis::OGRGeometryH,tolerance::Real)
     checknull(ccall((:OGR_G_SimplifyPreserveTopology,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),hThis,tolerance))
 end
 
+
+"""
+    OGR_G_Segmentize(OGRGeometryH hGeom,
+                     double dfMaxLength) -> void
+
+Modify the geometry such it has no segment longer then the given distance.
+
+### Parameters
+* **hGeom**: handle on the geometry to segmentize
+* **dfMaxLength**: the maximum distance between 2 points after segmentization
+"""
 function segmentize(hGeom::OGRGeometryH,dfMaxLength::Real)
     ccall((:OGR_G_Segmentize,libgdal),Void,(OGRGeometryH,Cdouble),hGeom,dfMaxLength)
 end
 
+
+"""
+    OGR_G_Intersects(OGRGeometryH,
+                     OGRGeometryH) -> int
+
+Do these features intersect?
+
+### Parameters
+* **hGeom**: handle on the first geometry.
+* **hOtherGeom**: handle on the other geometry to test against.
+
+### Returns
+TRUE if the geometries intersect, otherwise FALSE.
+"""
 function intersects(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Intersects,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Equals(OGRGeometryH,
+                 OGRGeometryH) -> int
+
+Returns TRUE if two geometries are equivalent.
+
+### Parameters
+* **hGeom**: handle on the first geometry.
+* **hOther**: handle on the other geometry to test against.
+
+### Returns
+TRUE if equivalent or FALSE otherwise.
+"""
 function equals(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Equals,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Disjoint(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for disjointness.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are disjoint, otherwise FALSE.
+"""
 function disjoint(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Disjoint,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Touches(OGRGeometryH,
+                  OGRGeometryH) -> int
+
+Test for touching.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are touching, otherwise FALSE.
+"""
 function touches(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Touches,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Crosses(OGRGeometryH,
+                  OGRGeometryH) -> int
+
+Test for crossing.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are crossing, otherwise FALSE.
+"""
 function crosses(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Crosses,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Within(OGRGeometryH,
+                 OGRGeometryH) -> int
+
+Test for containment.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if hThis is within hOther, otherwise FALSE.
+"""
 function within(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Within,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Contains(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for containment.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if hThis contains hOther geometry, otherwise FALSE.
+"""
 function contains(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Contains,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Overlaps(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Test for overlap.
+
+### Parameters
+* **hThis**: the geometry to compare.
+* **hOther**: the other geometry to compare.
+
+### Returns
+TRUE if they are overlapping, otherwise FALSE.
+"""
 function overlaps(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Overlaps,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Boundary(OGRGeometryH) -> OGRGeometryH
+
+Compute boundary.
+
+### Parameters
+* **hTarget**: The Geometry to calculate the boundary of.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function boundary(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_Boundary,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_ConvexHull(OGRGeometryH) -> OGRGeometryH
+
+Compute convex hull.
+
+### Parameters
+* **hTarget**: The Geometry to calculate the convex hull of.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function convexhull(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_ConvexHull,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_Buffer(OGRGeometryH,
+                 double,
+                 int) -> OGRGeometryH
+
+Compute buffer of geometry.
+
+### Parameters
+* **hTarget**: the geometry.
+* **dfDist**: the buffer distance to be applied. Should be expressed into the same unit as the coordinates of the geometry.
+* **nQuadSegs**: the number of segments used to approximate a 90 degree (quadrant) of curvature.
+
+### Returns
+the newly created geometry, or NULL if an error occurs.
+"""
 function buffer(arg1::OGRGeometryH,arg2::Real,arg3::Integer)
     checknull(ccall((:OGR_G_Buffer,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble,Cint),arg1,arg2,arg3))
 end
 
+
+"""
+    OGR_G_Intersection(OGRGeometryH,
+                       OGRGeometryH) -> OGRGeometryH
+
+Compute intersection.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the intersection or NULL if there is no intersection or an error occurs.
+"""
 function intersection(arg1::OGRGeometryH,arg2::OGRGeometryH)
     checknull(ccall((:OGR_G_Intersection,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2))
 end
 
+
+"""
+    OGR_G_Union(OGRGeometryH,
+                OGRGeometryH) -> OGRGeometryH
+
+Compute union.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the union or NULL if an error occurs.
+"""
 function union(arg1::OGRGeometryH,arg2::OGRGeometryH)
     checknull(ccall((:OGR_G_Union,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2))
 end
 
+
+"""
+    OGR_G_UnionCascaded(OGRGeometryH) -> OGRGeometryH
+
+Compute union using cascading.
+
+### Parameters
+* **hThis**: the geometry.
+
+### Returns
+a new geometry representing the union or NULL if an error occurs.
+"""
 function unioncascaded(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_UnionCascaded,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_PointOnSurface(OGRGeometryH) -> OGRGeometryH
+
+Returns a point guaranteed to lie on the surface.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+a point guaranteed to lie on the surface or NULL if an error occured.
+"""
 function pointonsurface(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_PointOnSurface,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_Difference(OGRGeometryH,
+                     OGRGeometryH) -> OGRGeometryH
+
+Compute difference.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the difference or NULL if the difference is empty or an error occurs.
+"""
 function difference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     checknull(ccall((:OGR_G_Difference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2))
 end
 
+
+"""
+    OGR_G_SymDifference(OGRGeometryH,
+                        OGRGeometryH) -> OGRGeometryH
+
+Compute symmetric difference.
+
+### Parameters
+* **hThis**: the geometry.
+* **hOther**: the other geometry.
+
+### Returns
+a new geometry representing the symmetric difference or NULL if the difference is empty or an error occurs.
+"""
 function symdifference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     checknull(ccall((:OGR_G_SymDifference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2))
 end
 
+
+"""
+    OGR_G_Distance(OGRGeometryH,
+                   OGRGeometryH) -> double
+
+Compute distance between two geometries.
+
+### Parameters
+* **hFirst**: the first geometry to compare against.
+* **hOther**: the other geometry to compare against.
+
+### Returns
+the distance between the geometries or -1 if an error occurs.
+"""
 function distance(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Distance,libgdal),Cdouble,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Length(OGRGeometryH hGeom) -> double
+
+Compute length of a geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+the lenght or 0.0 for unsupported geometry types.
+"""
 function length(arg1::OGRGeometryH)
     ccall((:OGR_G_Length,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Area(OGRGeometryH hGeom) -> double
+
+Compute geometry area.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+
+### Returns
+the area or 0.0 for unsupported geometry types.
+"""
 function area(arg1::OGRGeometryH)
     ccall((:OGR_G_Area,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Centroid(OGRGeometryH,
+                   OGRGeometryH) -> int
+
+Compute the geometry centroid.
+
+### Returns
+OGRERR_NONE on success or OGRERR_FAILURE on error.
+"""
 function centroid(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Centroid,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Value(OGRGeometryH hGeom,
+                double dfDistance) -> OGRGeometryH
+
+Fetch point at given distance along curve.
+
+### Parameters
+* **hGeom**: curve geometry.
+* **dfDistance**: distance along the curve at which to sample position. This distance should be between zero and get_Length() for this curve.
+
+### Returns
+a point or NULL.
+"""
 function value(arg1::OGRGeometryH,dfDistance::Real)
     checknull(ccall((:OGR_G_Value,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble),arg1,dfDistance))
 end
 
+
+"""
+    OGR_G_Empty(OGRGeometryH) -> void
+
+Clear geometry information.
+
+### Parameters
+* **hGeom**: handle on the geometry to empty.
+"""
 function empty(arg1::OGRGeometryH)
     ccall((:OGR_G_Empty,libgdal),Void,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsEmpty(OGRGeometryH) -> int
+
+Test if the geometry is empty.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function isempty(arg1::OGRGeometryH)
     ccall((:OGR_G_IsEmpty,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsValid(OGRGeometryH) -> int
+
+Test if the geometry is valid.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function isvalid(arg1::OGRGeometryH)
     ccall((:OGR_G_IsValid,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsSimple(OGRGeometryH) -> int
+
+Returns TRUE if the geometry is simple.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if object is simple, otherwise FALSE.
+"""
 function issimple(arg1::OGRGeometryH)
     ccall((:OGR_G_IsSimple,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_IsRing(OGRGeometryH) -> int
+
+Test if the geometry is a ring.
+
+### Parameters
+* **hGeom**: The Geometry to test.
+
+### Returns
+TRUE if the geometry has no points, otherwise FALSE.
+"""
 function isring(arg1::OGRGeometryH)
     ccall((:OGR_G_IsRing,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_Polygonize(OGRGeometryH) -> OGRGeometryH
+
+Polygonizes a set of sparse edges.
+
+### Parameters
+* **hTarget**: The Geometry to be polygonized.
+
+### Returns
+a handle to a newly allocated geometry now owned by the caller, or NULL on failure.
+"""
 function polygonize(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_Polygonize,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_Intersect(OGRGeometryH,
+                    OGRGeometryH) -> int
+"""
 function intersect(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Intersect,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_Equal(OGRGeometryH,
+                OGRGeometryH) -> int
+"""
 function equal(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_Equal,libgdal),Cint,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_SymmetricDifference(OGRGeometryH,
+                              OGRGeometryH) -> OGRGeometryH
+
+Compute symmetric difference (deprecated)
+"""
 function symmetricdifference(arg1::OGRGeometryH,arg2::OGRGeometryH)
     checknull(ccall((:OGR_G_SymmetricDifference,libgdal),OGRGeometryH,(OGRGeometryH,OGRGeometryH),arg1,arg2))
 end
 
+
+"""
+    OGR_G_GetArea(OGRGeometryH hGeom) -> double
+
+Compute geometry area (deprecated)
+"""
 function getarea(arg1::OGRGeometryH)
     ccall((:OGR_G_GetArea,libgdal),Cdouble,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetBoundary(OGRGeometryH) -> OGRGeometryH
+
+Compute boundary (deprecated)
+"""
 function getboundary(arg1::OGRGeometryH)
     checknull(ccall((:OGR_G_GetBoundary,libgdal),OGRGeometryH,(OGRGeometryH,),arg1))
 end
 
+
+"""
+    OGR_G_GetPointCount(OGRGeometryH hGeom) -> int
+
+Fetch number of points from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the number of points.
+
+### Returns
+the number of points.
+"""
 function getpointcount(arg1::OGRGeometryH)
     ccall((:OGR_G_GetPointCount,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetPoints(OGRGeometryH hGeom,
+                    void * pabyX,
+                    int nXStride,
+                    void * pabyY,
+                    int nYStride,
+                    void * pabyZ,
+                    int nZStride) -> int
+
+Returns all points of line string.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **pabyX**: a buffer of at least (sizeof(double) * nXStride * nPointCount) bytes, may be NULL.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: a buffer of at least (sizeof(double) * nYStride * nPointCount) bytes, may be NULL.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: a buffer of at last size (sizeof(double) * nZStride * nPointCount) bytes, may be NULL.
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+
+### Returns
+the number of points
+"""
 function getpoints(hGeom::OGRGeometryH,pabyX::Ptr{Void},nXStride::Integer,pabyY::Ptr{Void},nYStride::Integer,pabyZ::Ptr{Void},nZStride::Integer)
     ccall((:OGR_G_GetPoints,libgdal),Cint,(OGRGeometryH,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
 end
 
+
+"""
+    OGR_G_GetX(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the x coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the x coordinate.
+* **i**: point to get the x coordinate.
+
+### Returns
+the X coordinate of this point.
+"""
 function getx(arg1::OGRGeometryH,arg2::Integer)
     ccall((:OGR_G_GetX,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetY(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the x coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the y coordinate.
+* **i**: point to get the Y coordinate.
+
+### Returns
+the Y coordinate of this point.
+"""
 function gety(arg1::OGRGeometryH,arg2::Integer)
     ccall((:OGR_G_GetY,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetZ(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the z coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the Z coordinate.
+* **i**: point to get the Z coordinate.
+
+### Returns
+the Z coordinate of this point.
+"""
 function getz(arg1::OGRGeometryH,arg2::Integer)
     ccall((:OGR_G_GetZ,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_G_GetPoint(OGRGeometryH hGeom,
+                   int i,
+                   double * pdfX,
+                   double * pdfY,
+                   double * pdfZ) -> void
+
+Fetch a point in line string or a point geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **i**: the vertex to fetch, from 0 to getNumPoints()-1, zero for a point.
+* **pdfX**: value of x coordinate.
+* **pdfY**: value of y coordinate.
+* **pdfZ**: value of z coordinate.
+"""
 function getpoint(arg1::OGRGeometryH,iPoint::Integer,arg2::Vector{Float64},arg3::Vector{Float64},arg4::Vector{Float64})
     ccall((:OGR_G_GetPoint,libgdal),Void,(OGRGeometryH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_SetPointCount(OGRGeometryH hGeom,
+                        int nNewPointCount) -> void
+
+Set number of points in a geometry.
+
+### Parameters
+* **nNewPointCount**: the new number of points for geometry.
+"""
 function setpointcount(hGeom::OGRGeometryH,nNewPointCount::Integer)
     ccall((:OGR_G_SetPointCount,libgdal),Void,(OGRGeometryH,Cint),hGeom,nNewPointCount)
 end
 
+
+"""
+    OGR_G_SetPoint(OGRGeometryH hGeom,
+                   int i,
+                   double dfX,
+                   double dfY,
+                   double dfZ) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfZ**: input Z coordinate to assign (defaults to zero).
+"""
 function setpoint(arg1::OGRGeometryH,iPoint::Integer,arg2::Real,arg3::Real,arg4::Real)
     ccall((:OGR_G_SetPoint,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_SetPoint_2D(OGRGeometryH hGeom,
+                      int i,
+                      double dfX,
+                      double dfY) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+"""
 function setpoint_2d(arg1::OGRGeometryH,iPoint::Integer,arg2::Real,arg3::Real)
     ccall((:OGR_G_SetPoint_2D,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble),arg1,iPoint,arg2,arg3)
 end
 
+
+"""
+    OGR_G_AddPoint(OGRGeometryH hGeom,
+                   double dfX,
+                   double dfY,
+                   double dfZ) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfZ**: z coordinate of point to add.
+"""
 function addpoint(arg1::OGRGeometryH,arg2::Real,arg3::Real,arg4::Real)
     ccall((:OGR_G_AddPoint,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_G_AddPoint_2D(OGRGeometryH hGeom,
+                      double dfX,
+                      double dfY) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+"""
 function addpoint_2d(arg1::OGRGeometryH,arg2::Real,arg3::Real)
     ccall((:OGR_G_AddPoint_2D,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_SetPoints(OGRGeometryH hGeom,
+                    int nPointsIn,
+                    void * pabyX,
+                    int nXStride,
+                    void * pabyY,
+                    int nYStride,
+                    void * pabyZ,
+                    int nZStride) -> void
+
+Assign all points in a point or a line string geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to set the coordinates.
+* **nPointsIn**: number of points being passed in padfX and padfY.
+* **padfX**: list of X coordinates of points being assigned.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **padfY**: list of Y coordinates of points being assigned.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **padfZ**: list of Z coordinates of points being assigned (defaults to NULL for 2D objects).
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+"""
 function setpoints(hGeom::OGRGeometryH,nPointsIn::Integer,pabyX::Ptr{Void},nXStride::Integer,pabyY::Ptr{Void},nYStride::Integer,pabyZ::Ptr{Void},nZStride::Integer)
     ccall((:OGR_G_SetPoints,libgdal),Void,(OGRGeometryH,Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
 end
 
+
+"""
+    OGR_G_GetGeometryCount(OGRGeometryH hGeom) -> int
+
+Fetch the number of elements in a geometry or number of geometries in container.
+
+### Parameters
+* **hGeom**: single geometry or geometry container from which to get the number of elements.
+
+### Returns
+the number of elements.
+"""
 function getgeometrycount(arg1::OGRGeometryH)
     ccall((:OGR_G_GetGeometryCount,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
+
+"""
+    OGR_G_GetGeometryRef(OGRGeometryH hGeom,
+                         int iSubGeom) -> OGRGeometryH
+
+Fetch geometry from a geometry container.
+
+### Parameters
+* **hGeom**: handle to the geometry container from which to get a geometry from.
+* **iSubGeom**: the index of the geometry to fetch, between 0 and getNumGeometries() - 1.
+
+### Returns
+handle to the requested geometry.
+"""
 function getgeometryref(arg1::OGRGeometryH,arg2::Integer)
     checknull(ccall((:OGR_G_GetGeometryRef,libgdal),OGRGeometryH,(OGRGeometryH,Cint),arg1,arg2))
 end
 
+
+"""
+    OGR_G_AddGeometry(OGRGeometryH hGeom,
+                      OGRGeometryH hNewSubGeom) -> OGRErr
+
+Add a geometry to a geometry container.
+
+### Parameters
+* **hGeom**: existing geometry container.
+* **hNewSubGeom**: geometry to add to the container.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of existing geometry.
+"""
 function addgeometry(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_AddGeometry,libgdal),OGRErr,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_AddGeometryDirectly(OGRGeometryH hGeom,
+                              OGRGeometryH hNewSubGeom) -> OGRErr
+
+Add a geometry directly to an existing geometry container.
+
+### Parameters
+* **hGeom**: existing geometry.
+* **hNewSubGeom**: geometry to add to the existing geometry.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the type of geometry container.
+"""
 function addgeometrydirectly(arg1::OGRGeometryH,arg2::OGRGeometryH)
     ccall((:OGR_G_AddGeometryDirectly,libgdal),OGRErr,(OGRGeometryH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_G_RemoveGeometry(OGRGeometryH hGeom,
+                         int iGeom,
+                         int bDelete) -> OGRErr
+
+Remove a geometry from an exiting geometry container.
+
+### Parameters
+* **hGeom**: the existing geometry to delete from.
+* **iGeom**: the index of the geometry to delete. A value of -1 is a special flag meaning that all geometries should be removed.
+* **bDelete**: if TRUE the geometry will be destroyed, otherwise it will not. The default is TRUE as the existing geometry is considered to own the geometries in it.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_FAILURE if the index is out of range.
+"""
 function removegeometry(arg1::OGRGeometryH,arg2::Integer,arg3::Integer)
     ccall((:OGR_G_RemoveGeometry,libgdal),OGRErr,(OGRGeometryH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_G_HasCurveGeometry(OGRGeometryH hGeom,
+                           int bLookForNonLinear) -> int
+
+Returns if this geometry is or has curve geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **bLookForNonLinear**: set it to TRUE to check if the geometry is or contains a CIRCULARSTRING.
+
+### Returns
+TRUE if this geometry is or has curve geometry.
+"""
 function hascurvegeometry(arg1::OGRGeometryH,bLookForNonLinear::Integer)
     ccall((:OGR_G_HasCurveGeometry,libgdal),Cint,(OGRGeometryH,Cint),arg1,bLookForNonLinear)
 end
 
+
+"""
+    OGR_G_GetLinearGeometry(OGRGeometryH hGeom,
+                            double dfMaxAngleStepSizeDegrees,
+                            char ** papszOptions) -> OGRGeometryH
+
+Return, possibly approximate, linear version of this geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **dfMaxAngleStepSizeDegrees**: the largest step in degrees along the arc, zero to use the default setting.
+* **papszOptions**: options as a null-terminated list of strings or NULL. See OGRGeometryFactory::curveToLineString() for valid options.
+
+### Returns
+a new geometry.
+"""
 function getlineargeometry(hGeom::OGRGeometryH,dfMaxAngleStepSizeDegrees::Real,papszOptions::Vector{UTF8String})
     checknull(ccall((:OGR_G_GetLinearGeometry,libgdal),OGRGeometryH,(OGRGeometryH,Cdouble,Ptr{Ptr{UInt8}}),hGeom,dfMaxAngleStepSizeDegrees,papszOptions))
 end
 
+
+"""
+    OGR_G_GetCurveGeometry(OGRGeometryH hGeom,
+                           char ** papszOptions) -> OGRGeometryH
+
+Return curve version of this geometry.
+
+### Parameters
+* **hGeom**: the geometry to operate on.
+* **papszOptions**: options as a null-terminated list of strings. Unused for now. Must be set to NULL.
+
+### Returns
+a new geometry.
+"""
 function getcurvegeometry(hGeom::OGRGeometryH,papszOptions::Vector{UTF8String})
     checknull(ccall((:OGR_G_GetCurveGeometry,libgdal),OGRGeometryH,(OGRGeometryH,Ptr{Ptr{UInt8}}),hGeom,papszOptions))
 end
 
+
+"""
+    OGRBuildPolygonFromEdges(OGRGeometryH hLinesAsCollection,
+                             int bBestEffort,
+                             int bAutoClose,
+                             double dfTolerance,
+                             OGRErr * peErr) -> OGRGeometryH
+
+Build a ring from a bunch of arcs.
+
+### Parameters
+* **hLines**: handle to an OGRGeometryCollection (or OGRMultiLineString) containing the line string geometries to be built into rings.
+* **bBestEffort**: not yet implemented???.
+* **bAutoClose**: indicates if the ring should be close when first and last points of the ring are the same.
+* **dfTolerance**: tolerance into which two arcs are considered close enough to be joined.
+* **peErr**: OGRERR_NONE on success, or OGRERR_FAILURE on failure.
+
+### Returns
+an handle to the new geometry, a polygon.
+"""
 function buildpolygonfromedges(hLinesAsCollection::OGRGeometryH,bBestEffort::Integer,bAutoClose::Integer,dfTolerance::Real,peErr::Ptr{OGRErr})
     checknull(ccall((:OGRBuildPolygonFromEdges,libgdal),OGRGeometryH,(OGRGeometryH,Cint,Cint,Cdouble,Ptr{OGRErr}),hLinesAsCollection,bBestEffort,bAutoClose,dfTolerance,peErr))
 end
 
+
+"""
+    OGRSetGenerate_DB2_V72_BYTE_ORDER(int bGenerate_DB2_V72_BYTE_ORDER) -> OGRErr
+
+Special entry point to enable the hack for generating DB2 V7.2 style WKB.
+"""
 function setgenerate_db2_v72_byte_order(bGenerate_DB2_V72_BYTE_ORDER::Integer)
     ccall((:OGRSetGenerate_DB2_V72_BYTE_ORDER,libgdal),OGRErr,(Cint,),bGenerate_DB2_V72_BYTE_ORDER)
 end
 
+
+"""
+    OGRGetGenerate_DB2_V72_BYTE_ORDER(void) -> int
+"""
 function getgenerate_db2_v72_byte_order()
     ccall((:OGRGetGenerate_DB2_V72_BYTE_ORDER,libgdal),Cint,())
 end
 
+
+"""
+    OGRSetNonLinearGeometriesEnabledFlag(int bFlag) -> void
+
+Set flag to enable/disable returning non-linear geometries in the C API.
+
+### Parameters
+* **bFlag**: TRUE if non-linear geometries might be returned (default value). FALSE to ask for non-linear geometries to be approximated as linear geometries.
+
+### Returns
+a point or NULL.
+"""
 function setnonlineargeometriesenabledflag(bFlag::Integer)
     ccall((:OGRSetNonLinearGeometriesEnabledFlag,libgdal),Void,(Cint,),bFlag)
 end
 
+
+"""
+    OGRGetNonLinearGeometriesEnabledFlag(void) -> int
+
+Get flag to enable/disable returning non-linear geometries in the C API.
+"""
 function getnonlineargeometriesenabledflag()
     ccall((:OGRGetNonLinearGeometriesEnabledFlag,libgdal),Cint,())
 end
 
+
+"""
+    OGR_Fld_Create(const char *,
+                   OGRFieldType) -> OGRFieldDefnH
+
+Create a new field definition.
+
+### Parameters
+* **pszName**: the name of the new field definition.
+* **eType**: the type of the new field definition.
+
+### Returns
+handle to the new field definition.
+"""
 function create(arg1::AbstractString,arg2::OGRFieldType)
     checknull(ccall((:OGR_Fld_Create,libgdal),OGRFieldDefnH,(Ptr{UInt8},OGRFieldType),arg1,arg2))
 end
 
+
+"""
+    OGR_Fld_Destroy(OGRFieldDefnH) -> void
+
+Destroy a field definition.
+
+### Parameters
+* **hDefn**: handle to the field definition to destroy.
+"""
 function destroy(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_Destroy,libgdal),Void,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetName(OGRFieldDefnH,
+                    const char *) -> void
+
+Reset the name of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to apply the new name to.
+* **pszName**: the new name to apply.
+"""
 function setname(arg1::OGRFieldDefnH,arg2::AbstractString)
     ccall((:OGR_Fld_SetName,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetNameRef(OGRFieldDefnH) -> const char *
+
+Fetch name of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+
+### Returns
+the name of the field definition.
+"""
 function getnameref(arg1::OGRFieldDefnH)
     bytestring(ccall((:OGR_Fld_GetNameRef,libgdal),Ptr{UInt8},(OGRFieldDefnH,),arg1))
 end
 
+
+"""
+    OGR_Fld_GetType(OGRFieldDefnH) -> OGRFieldType
+
+Fetch type of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get type from.
+
+### Returns
+field type.
+"""
 function gettype(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetType,libgdal),OGRFieldType,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetType(OGRFieldDefnH,
+                    OGRFieldType) -> void
+
+Set the type of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set type to.
+* **eType**: the new field type.
+"""
 function settype(arg1::OGRFieldDefnH,arg2::OGRFieldType)
     ccall((:OGR_Fld_SetType,libgdal),Void,(OGRFieldDefnH,OGRFieldType),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetSubType(OGRFieldDefnH) -> OGRFieldSubType
+
+Fetch subtype of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get subtype from.
+
+### Returns
+field subtype.
+"""
 function getsubtype(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetSubType,libgdal),OGRFieldSubType,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetSubType(OGRFieldDefnH,
+                       OGRFieldSubType) -> void
+
+Set the subtype of this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set type to.
+* **eSubType**: the new field subtype.
+"""
 function setsubtype(arg1::OGRFieldDefnH,arg2::OGRFieldSubType)
     ccall((:OGR_Fld_SetSubType,libgdal),Void,(OGRFieldDefnH,OGRFieldSubType),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetJustify(OGRFieldDefnH) -> OGRJustification
+
+Get the justification for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get justification from.
+
+### Returns
+the justification.
+"""
 function getjustify(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetJustify,libgdal),OGRJustification,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetJustify(OGRFieldDefnH,
+                       OGRJustification) -> void
+
+Set the justification for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to set justification to.
+* **eJustify**: the new justification.
+"""
 function setjustify(arg1::OGRFieldDefnH,arg2::OGRJustification)
     ccall((:OGR_Fld_SetJustify,libgdal),Void,(OGRFieldDefnH,OGRJustification),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetWidth(OGRFieldDefnH) -> int
+
+Get the formatting width for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get width from.
+
+### Returns
+the width, zero means no specified width.
+"""
 function getwidth(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetWidth,libgdal),Cint,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetWidth(OGRFieldDefnH,
+                     int) -> void
+
+Set the formatting width for this field in characters.
+
+### Parameters
+* **hDefn**: handle to the field definition to set width to.
+* **nNewWidth**: the new width.
+"""
 function setwidth(arg1::OGRFieldDefnH,arg2::Integer)
     ccall((:OGR_Fld_SetWidth,libgdal),Void,(OGRFieldDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_GetPrecision(OGRFieldDefnH) -> int
+
+Get the formatting precision for this field.
+
+### Parameters
+* **hDefn**: handle to the field definition to get precision from.
+
+### Returns
+the precision.
+"""
 function getprecision(arg1::OGRFieldDefnH)
     ccall((:OGR_Fld_GetPrecision,libgdal),Cint,(OGRFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_Fld_SetPrecision(OGRFieldDefnH,
+                         int) -> void
+
+Set the formatting precision for this field in characters.
+
+### Parameters
+* **hDefn**: handle to the field definition to set precision to.
+* **nPrecision**: the new precision.
+"""
 function setprecision(arg1::OGRFieldDefnH,arg2::Integer)
     ccall((:OGR_Fld_SetPrecision,libgdal),Void,(OGRFieldDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_Fld_Set(OGRFieldDefnH,
+                const char *,
+                OGRFieldType,
+                int,
+                int,
+                OGRJustification) -> void
+
+Set defining parameters for a field in one call.
+
+### Parameters
+* **hDefn**: handle to the field definition to set to.
+* **pszNameIn**: the new name to assign.
+* **eTypeIn**: the new type (one of the OFT values like OFTInteger).
+* **nWidthIn**: the preferred formatting width. Defaults to zero indicating undefined.
+* **nPrecisionIn**: number of decimals places for formatting, defaults to zero indicating undefined.
+* **eJustifyIn**: the formatting justification (OJLeft or OJRight), defaults to OJUndefined.
+"""
 function set(arg1::OGRFieldDefnH,arg2::AbstractString,arg3::OGRFieldType,arg4::Integer,arg5::Integer,arg6::OGRJustification)
     ccall((:OGR_Fld_Set,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8},OGRFieldType,Cint,Cint,OGRJustification),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_Fld_IsIgnored(OGRFieldDefnH hDefn) -> int
+
+Return whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+ignore state
+"""
 function isignored(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsIgnored,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_Fld_SetIgnored(OGRFieldDefnH hDefn,
+                       int) -> void
+
+Set whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **ignore**: ignore state
+"""
 function setignored(hDefn::OGRFieldDefnH,arg1::Integer)
     ccall((:OGR_Fld_SetIgnored,libgdal),Void,(OGRFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_IsNullable(OGRFieldDefnH hDefn) -> int
+
+Return whether this field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the field is authorized to be null.
+"""
 function isnullable(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsNullable,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_Fld_SetNullable(OGRFieldDefnH hDefn,
+                        int) -> void
+
+Set whether this field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **bNullableIn**: FALSE if the field must have a not-null constraint.
+"""
 function setnullable(hDefn::OGRFieldDefnH,arg1::Integer)
     ccall((:OGR_Fld_SetNullable,libgdal),Void,(OGRFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_GetDefault(OGRFieldDefnH hDefn) -> const char *
+
+Get default field value.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+
+### Returns
+default field value or NULL.
+"""
 function getdefault(hDefn::OGRFieldDefnH)
     bytestring(ccall((:OGR_Fld_GetDefault,libgdal),Ptr{UInt8},(OGRFieldDefnH,),hDefn))
 end
 
+
+"""
+    OGR_Fld_SetDefault(OGRFieldDefnH hDefn,
+                       const char *) -> void
+
+Set default field value.
+
+### Parameters
+* **hDefn**: handle to the field definition.
+* **pszDefault**: new default field value or NULL pointer.
+"""
 function setdefault(hDefn::OGRFieldDefnH,arg1::AbstractString)
     ccall((:OGR_Fld_SetDefault,libgdal),Void,(OGRFieldDefnH,Ptr{UInt8}),hDefn,arg1)
 end
 
+
+"""
+    OGR_Fld_IsDefaultDriverSpecific(OGRFieldDefnH hDefn) -> int
+
+Returns whether the default value is driver specific.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the default value is driver specific.
+"""
 function isdefaultdriverspecific(hDefn::OGRFieldDefnH)
     ccall((:OGR_Fld_IsDefaultDriverSpecific,libgdal),Cint,(OGRFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GetFieldTypeName(OGRFieldType) -> const char *
+
+Fetch human readable name for a field type.
+
+### Parameters
+* **eType**: the field type to get name for.
+
+### Returns
+the name.
+"""
 function getfieldtypename(arg1::OGRFieldType)
     bytestring(ccall((:OGR_GetFieldTypeName,libgdal),Ptr{UInt8},(OGRFieldType,),arg1))
 end
 
+
+"""
+    OGR_GetFieldSubTypeName(OGRFieldSubType) -> const char *
+
+Fetch human readable name for a field subtype.
+
+### Parameters
+* **eSubType**: the field subtype to get name for.
+
+### Returns
+the name.
+"""
 function getfieldsubtypename(arg1::OGRFieldSubType)
     bytestring(ccall((:OGR_GetFieldSubTypeName,libgdal),Ptr{UInt8},(OGRFieldSubType,),arg1))
 end
 
+
+"""
+    OGR_AreTypeSubTypeCompatible(OGRFieldType eType,
+                                 OGRFieldSubType eSubType) -> int
+
+Return if type and subtype are compatible.
+
+### Parameters
+* **eType**: the field type.
+* **eSubType**: the field subtype.
+
+### Returns
+TRUE if type and subtype are compatible
+"""
 function aretypesubtypecompatible(eType::OGRFieldType,eSubType::OGRFieldSubType)
     ccall((:OGR_AreTypeSubTypeCompatible,libgdal),Cint,(OGRFieldType,OGRFieldSubType),eType,eSubType)
 end
 
+
+"""
+    OGR_GFld_Create(const char *,
+                    OGRwkbGeometryType) -> OGRGeomFieldDefnH
+
+Create a new field geometry definition.
+
+### Parameters
+* **pszName**: the name of the new field definition.
+* **eType**: the type of the new field definition.
+
+### Returns
+handle to the new field definition.
+"""
 function create(arg1::AbstractString,arg2::OGRwkbGeometryType)
     checknull(ccall((:OGR_GFld_Create,libgdal),OGRGeomFieldDefnH,(Ptr{UInt8},OGRwkbGeometryType),arg1,arg2))
 end
 
+
+"""
+    OGR_GFld_Destroy(OGRGeomFieldDefnH) -> void
+
+Destroy a geometry field definition.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to destroy.
+"""
 function destroy(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_Destroy,libgdal),Void,(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_SetName(OGRGeomFieldDefnH,
+                     const char *) -> void
+
+Reset the name of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to apply the new name to.
+* **pszName**: the new name to apply.
+"""
 function setname(arg1::OGRGeomFieldDefnH,arg2::AbstractString)
     ccall((:OGR_GFld_SetName,libgdal),Void,(OGRGeomFieldDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_GFld_GetNameRef(OGRGeomFieldDefnH) -> const char *
+
+Fetch name of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition.
+
+### Returns
+the name of the geometry field definition.
+"""
 function getnameref(arg1::OGRGeomFieldDefnH)
     bytestring(ccall((:OGR_GFld_GetNameRef,libgdal),Ptr{UInt8},(OGRGeomFieldDefnH,),arg1))
 end
 
+
+"""
+    OGR_GFld_GetType(OGRGeomFieldDefnH) -> OGRwkbGeometryType
+
+Fetch geometry type of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to get type from.
+
+### Returns
+field geometry type.
+"""
 function gettype(arg1::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_GetType,libgdal),OGRwkbGeometryType,(OGRGeomFieldDefnH,),arg1)
 end
 
+
+"""
+    OGR_GFld_SetType(OGRGeomFieldDefnH,
+                     OGRwkbGeometryType) -> void
+
+Set the geometry type of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition to set type to.
+* **eType**: the new field geometry type.
+"""
 function settype(arg1::OGRGeomFieldDefnH,arg2::OGRwkbGeometryType)
     ccall((:OGR_GFld_SetType,libgdal),Void,(OGRGeomFieldDefnH,OGRwkbGeometryType),arg1,arg2)
 end
 
+
+"""
+    OGR_GFld_GetSpatialRef(OGRGeomFieldDefnH) -> OGRSpatialReferenceH
+
+Fetch spatial reference system of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+
+### Returns
+field spatial reference system.
+"""
 function getspatialref(arg1::OGRGeomFieldDefnH)
     checknull(ccall((:OGR_GFld_GetSpatialRef,libgdal),OGRSpatialReferenceH,(OGRGeomFieldDefnH,),arg1))
 end
 
+
+"""
+    OGR_GFld_SetSpatialRef(OGRGeomFieldDefnH,
+                           OGRSpatialReferenceH hSRS) -> void
+
+Set the spatial reference of this field.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+* **hSRS**: the new SRS to apply.
+"""
 function setspatialref(arg1::OGRGeomFieldDefnH,hSRS::OGRSpatialReferenceH)
     ccall((:OGR_GFld_SetSpatialRef,libgdal),Void,(OGRGeomFieldDefnH,OGRSpatialReferenceH),arg1,hSRS)
 end
 
+
+"""
+    OGR_GFld_IsNullable(OGRGeomFieldDefnH hDefn) -> int
+
+Return whether this geometry field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+
+### Returns
+TRUE if the field is authorized to be null.
+"""
 function isnullable(hDefn::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_IsNullable,libgdal),Cint,(OGRGeomFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GFld_SetNullable(OGRGeomFieldDefnH hDefn,
+                         int) -> void
+
+Set whether this geometry field can receive null values.
+
+### Parameters
+* **hDefn**: handle to the field definition
+* **bNullableIn**: FALSE if the field must have a not-null constraint.
+"""
 function setnullable(hDefn::OGRGeomFieldDefnH,arg1::Integer)
     ccall((:OGR_GFld_SetNullable,libgdal),Void,(OGRGeomFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_GFld_IsIgnored(OGRGeomFieldDefnH hDefn) -> int
+
+Return whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+
+### Returns
+ignore state
+"""
 function isignored(hDefn::OGRGeomFieldDefnH)
     ccall((:OGR_GFld_IsIgnored,libgdal),Cint,(OGRGeomFieldDefnH,),hDefn)
 end
 
+
+"""
+    OGR_GFld_SetIgnored(OGRGeomFieldDefnH hDefn,
+                        int) -> void
+
+Set whether this field should be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the geometry field definition
+* **ignore**: ignore state
+"""
 function setignored(hDefn::OGRGeomFieldDefnH,arg1::Integer)
     ccall((:OGR_GFld_SetIgnored,libgdal),Void,(OGRGeomFieldDefnH,Cint),hDefn,arg1)
 end
 
+
+"""
+    OGR_FD_Create(const char *) -> OGRFeatureDefnH
+
+Create a new feature definition object to hold the field definitions.
+
+### Parameters
+* **pszName**: the name to be assigned to this layer/class. It does not need to be unique.
+
+### Returns
+handle to the newly created feature definition.
+"""
 function create(arg1::AbstractString)
     checknull(ccall((:OGR_FD_Create,libgdal),OGRFeatureDefnH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    OGR_FD_Destroy(OGRFeatureDefnH) -> void
+
+Destroy a feature definition object and release all memory associated with it.
+
+### Parameters
+* **hDefn**: handle to the feature definition to be destroyed.
+"""
 function destroy(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Destroy,libgdal),Void,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_Release(OGRFeatureDefnH) -> void
+
+Drop a reference, and destroy if unreferenced.
+
+### Parameters
+* **hDefn**: handle to the feature definition to be released.
+"""
 function release(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Release,libgdal),Void,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetName(OGRFeatureDefnH) -> const char *
+
+Get name of the OGRFeatureDefn passed as an argument.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the name from.
+
+### Returns
+the name. This name is internal and should not be modified, or freed.
+"""
 function getname(arg1::OGRFeatureDefnH)
     bytestring(ccall((:OGR_FD_GetName,libgdal),Ptr{UInt8},(OGRFeatureDefnH,),arg1))
 end
 
+
+"""
+    OGR_FD_GetFieldCount(OGRFeatureDefnH) -> int
+
+Fetch number of fields on the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the fields count from.
+
+### Returns
+count of fields.
+"""
 function getfieldcount(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetFieldCount,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetFieldDefn(OGRFeatureDefnH,
+                        int) -> OGRFieldDefnH
+
+Fetch field definition of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the field definition from.
+* **iField**: the field to fetch, between 0 and GetFieldCount()-1.
+
+### Returns
+an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
+"""
 function getfielddefn(arg1::OGRFeatureDefnH,arg2::Integer)
     checknull(ccall((:OGR_FD_GetFieldDefn,libgdal),OGRFieldDefnH,(OGRFeatureDefnH,Cint),arg1,arg2))
 end
 
+
+"""
+    OGR_FD_GetFieldIndex(OGRFeatureDefnH,
+                         const char *) -> int
+
+Find field by name.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get field index from.
+* **pszFieldName**: the field name to search for.
+
+### Returns
+the field index, or -1 if no match found.
+"""
 function getfieldindex(arg1::OGRFeatureDefnH,arg2::AbstractString)
     ccall((:OGR_FD_GetFieldIndex,libgdal),Cint,(OGRFeatureDefnH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_AddFieldDefn(OGRFeatureDefnH,
+                        OGRFieldDefnH) -> void
+
+Add a new field definition to the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to add the field definition to.
+* **hNewField**: handle to the new field definition.
+"""
 function addfielddefn(arg1::OGRFeatureDefnH,arg2::OGRFieldDefnH)
     ccall((:OGR_FD_AddFieldDefn,libgdal),Void,(OGRFeatureDefnH,OGRFieldDefnH),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_DeleteFieldDefn(OGRFeatureDefnH hDefn,
+                           int iField) -> OGRErr
+
+Delete an existing field definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition.
+* **iField**: the index of the field defintion.
+
+### Returns
+OGRERR_NONE in case of success.
+"""
 function deletefielddefn(hDefn::OGRFeatureDefnH,iField::Integer)
     ccall((:OGR_FD_DeleteFieldDefn,libgdal),OGRErr,(OGRFeatureDefnH,Cint),hDefn,iField)
 end
 
+
+"""
+    OGR_FD_ReorderFieldDefns(OGRFeatureDefnH hDefn,
+                             int * panMap) -> OGRErr
+"""
 function reorderfielddefns(hDefn::OGRFeatureDefnH,panMap::Vector{Cint})
     ccall((:OGR_FD_ReorderFieldDefns,libgdal),OGRErr,(OGRFeatureDefnH,Ptr{Cint}),hDefn,panMap)
 end
 
+
+"""
+    OGR_FD_GetGeomType(OGRFeatureDefnH) -> OGRwkbGeometryType
+
+Fetch the geometry base type of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the geometry type from.
+
+### Returns
+the base type for all geometry related to this definition.
+"""
 function getgeomtype(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetGeomType,libgdal),OGRwkbGeometryType,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetGeomType(OGRFeatureDefnH,
+                       OGRwkbGeometryType) -> void
+
+Assign the base geometry type for the passed layer (the same as the feature definition).
+
+### Parameters
+* **hDefn**: handle to the layer or feature definition to set the geometry type to.
+* **eType**: the new type to assign.
+"""
 function setgeomtype(arg1::OGRFeatureDefnH,arg2::OGRwkbGeometryType)
     ccall((:OGR_FD_SetGeomType,libgdal),Void,(OGRFeatureDefnH,OGRwkbGeometryType),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_IsGeometryIgnored(OGRFeatureDefnH) -> int
+
+Determine whether the geometry can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+ignore state
+"""
 function isgeometryignored(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_IsGeometryIgnored,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetGeometryIgnored(OGRFeatureDefnH,
+                              int) -> void
+
+Set whether the geometry can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **bIgnore**: ignore state
+"""
 function setgeometryignored(arg1::OGRFeatureDefnH,arg2::Integer)
     ccall((:OGR_FD_SetGeometryIgnored,libgdal),Void,(OGRFeatureDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_IsStyleIgnored(OGRFeatureDefnH) -> int
+
+Determine whether the style can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on which OGRFeature are based on.
+
+### Returns
+ignore state
+"""
 function isstyleignored(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_IsStyleIgnored,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_SetStyleIgnored(OGRFeatureDefnH,
+                           int) -> void
+
+Set whether the style can be omitted when fetching features.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **bIgnore**: ignore state
+"""
 function setstyleignored(arg1::OGRFeatureDefnH,arg2::Integer)
     ccall((:OGR_FD_SetStyleIgnored,libgdal),Void,(OGRFeatureDefnH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_FD_Reference(OGRFeatureDefnH) -> int
+
+Increments the reference count by one.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the updated reference count.
+"""
 function reference(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Reference,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_Dereference(OGRFeatureDefnH) -> int
+
+Decrements the reference count by one.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the updated reference count.
+"""
 function dereference(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_Dereference,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetReferenceCount(OGRFeatureDefnH) -> int
+
+Fetch current reference count.
+
+### Parameters
+* **hDefn**: handle to the feature definition on witch OGRFeature are based on.
+
+### Returns
+the current reference count.
+"""
 function getreferencecount(arg1::OGRFeatureDefnH)
     ccall((:OGR_FD_GetReferenceCount,libgdal),Cint,(OGRFeatureDefnH,),arg1)
 end
 
+
+"""
+    OGR_FD_GetGeomFieldCount(OGRFeatureDefnH hFDefn) -> int
+
+Fetch number of geometry fields on the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the fields count from.
+
+### Returns
+count of geometry fields.
+"""
 function getgeomfieldcount(hFDefn::OGRFeatureDefnH)
     ccall((:OGR_FD_GetGeomFieldCount,libgdal),Cint,(OGRFeatureDefnH,),hFDefn)
 end
 
+
+"""
+    OGR_FD_GetGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                            int i) -> OGRGeomFieldDefnH
+
+Fetch geometry field definition of the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get the field definition from.
+* **iGeomField**: the geometry field to fetch, between 0 and GetGeomFieldCount()-1.
+
+### Returns
+an handle to an internal field definition object or NULL if invalid index. This object should not be modified or freed by the application.
+"""
 function getgeomfielddefn(hFDefn::OGRFeatureDefnH,i::Integer)
     checknull(ccall((:OGR_FD_GetGeomFieldDefn,libgdal),OGRGeomFieldDefnH,(OGRFeatureDefnH,Cint),hFDefn,i))
 end
 
+
+"""
+    OGR_FD_GetGeomFieldIndex(OGRFeatureDefnH hFDefn,
+                             const char * pszName) -> int
+
+Find geometry field by name.
+
+### Parameters
+* **hDefn**: handle to the feature definition to get field index from.
+* **pszGeomFieldName**: the geometry field name to search for.
+
+### Returns
+the geometry field index, or -1 if no match found.
+"""
 function getgeomfieldindex(hFDefn::OGRFeatureDefnH,pszName::AbstractString)
     ccall((:OGR_FD_GetGeomFieldIndex,libgdal),Cint,(OGRFeatureDefnH,Ptr{UInt8}),hFDefn,pszName)
 end
 
+
+"""
+    OGR_FD_AddGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                            OGRGeomFieldDefnH hGFldDefn) -> void
+
+Add a new field definition to the passed feature definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition to add the geometry field definition to.
+* **hNewGeomField**: handle to the new field definition.
+"""
 function addgeomfielddefn(hFDefn::OGRFeatureDefnH,hGFldDefn::OGRGeomFieldDefnH)
     ccall((:OGR_FD_AddGeomFieldDefn,libgdal),Void,(OGRFeatureDefnH,OGRGeomFieldDefnH),hFDefn,hGFldDefn)
 end
 
+
+"""
+    OGR_FD_DeleteGeomFieldDefn(OGRFeatureDefnH hFDefn,
+                               int iGeomField) -> OGRErr
+
+Delete an existing geometry field definition.
+
+### Parameters
+* **hDefn**: handle to the feature definition.
+* **iGeomField**: the index of the geometry field defintion.
+
+### Returns
+OGRERR_NONE in case of success.
+"""
 function deletegeomfielddefn(hFDefn::OGRFeatureDefnH,iGeomField::Integer)
     ccall((:OGR_FD_DeleteGeomFieldDefn,libgdal),OGRErr,(OGRFeatureDefnH,Cint),hFDefn,iGeomField)
 end
 
+
+"""
+    OGR_FD_IsSame(OGRFeatureDefnH hFDefn,
+                  OGRFeatureDefnH hOtherFDefn) -> int
+
+Test if the feature definition is identical to the other one.
+
+### Parameters
+* **hFDefn**: handle to the feature definition on witch OGRFeature are based on.
+* **hOtherFDefn**: handle to the other feature definition to compare to.
+
+### Returns
+TRUE if the feature definition is identical to the other one.
+"""
 function issame(hFDefn::OGRFeatureDefnH,hOtherFDefn::OGRFeatureDefnH)
     ccall((:OGR_FD_IsSame,libgdal),Cint,(OGRFeatureDefnH,OGRFeatureDefnH),hFDefn,hOtherFDefn)
 end
 
+
+"""
+    OGR_F_Create(OGRFeatureDefnH) -> OGRFeatureH
+
+Feature factory.
+
+### Parameters
+* **hDefn**: handle to the feature class (layer) definition to which the feature will adhere.
+
+### Returns
+an handle to the new feature object with null fields and no geometry.
+"""
 function create(arg1::OGRFeatureDefnH)
     checknull(ccall((:OGR_F_Create,libgdal),OGRFeatureH,(OGRFeatureDefnH,),arg1))
 end
 
+
+"""
+    OGR_F_Destroy(OGRFeatureH) -> void
+
+Destroy feature.
+
+### Parameters
+* **hFeat**: handle to the feature to destroy.
+"""
 function destroy(arg1::OGRFeatureH)
     ccall((:OGR_F_Destroy,libgdal),Void,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_GetDefnRef(OGRFeatureH) -> OGRFeatureDefnH
+
+Fetch feature definition.
+
+### Parameters
+* **hFeat**: handle to the feature to get the feature definition from.
+
+### Returns
+an handle to the feature definition object on which feature depends.
+"""
 function getdefnref(arg1::OGRFeatureH)
     checknull(ccall((:OGR_F_GetDefnRef,libgdal),OGRFeatureDefnH,(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_SetGeometryDirectly(OGRFeatureH,
+                              OGRGeometryH) -> OGRErr
+
+Set feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature on which to apply the geometry.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function setgeometrydirectly(arg1::OGRFeatureH,arg2::OGRGeometryH)
     ccall((:OGR_F_SetGeometryDirectly,libgdal),OGRErr,(OGRFeatureH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetGeometry(OGRFeatureH,
+                      OGRGeometryH) -> OGRErr
+
+Set feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature on which new geometry is applied to.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function setgeometry(arg1::OGRFeatureH,arg2::OGRGeometryH)
     ccall((:OGR_F_SetGeometry,libgdal),OGRErr,(OGRFeatureH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetGeometryRef(OGRFeatureH) -> OGRGeometryH
+
+Fetch an handle to feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature to get geometry from.
+
+### Returns
+an handle to internal feature geometry. This object should not be modified.
+"""
 function getgeometryref(arg1::OGRFeatureH)
     checknull(ccall((:OGR_F_GetGeometryRef,libgdal),OGRGeometryH,(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_StealGeometry(OGRFeatureH) -> OGRGeometryH
+
+Take away ownership of geometry.
+
+### Returns
+the pointer to the geometry.
+"""
 function stealgeometry(arg1::OGRFeatureH)
     checknull(ccall((:OGR_F_StealGeometry,libgdal),OGRGeometryH,(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_Clone(OGRFeatureH) -> OGRFeatureH
+
+Duplicate feature.
+
+### Parameters
+* **hFeat**: handle to the feature to clone.
+
+### Returns
+an handle to the new feature, exactly matching this feature.
+"""
 function clone(arg1::OGRFeatureH)
     checknull(ccall((:OGR_F_Clone,libgdal),OGRFeatureH,(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_Equal(OGRFeatureH,
+                OGRFeatureH) -> int
+
+Test if two features are the same.
+
+### Parameters
+* **hFeat**: handle to one of the feature.
+* **hOtherFeat**: handle to the other feature to test this one against.
+
+### Returns
+TRUE if they are equal, otherwise FALSE.
+"""
 function equal(arg1::OGRFeatureH,arg2::OGRFeatureH)
     ccall((:OGR_F_Equal,libgdal),Cint,(OGRFeatureH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldCount(OGRFeatureH) -> int
+
+Fetch number of fields on this feature This will always be the same as the field count for the OGRFeatureDefn.
+
+### Parameters
+* **hFeat**: handle to the feature to get the fields count from.
+
+### Returns
+count of fields.
+"""
 function getfieldcount(arg1::OGRFeatureH)
     ccall((:OGR_F_GetFieldCount,libgdal),Cint,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_GetFieldDefnRef(OGRFeatureH,
+                          int) -> OGRFieldDefnH
+
+Fetch definition for this field.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **i**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
+"""
 function getfielddefnref(arg1::OGRFeatureH,arg2::Integer)
     checknull(ccall((:OGR_F_GetFieldDefnRef,libgdal),OGRFieldDefnH,(OGRFeatureH,Cint),arg1,arg2))
 end
 
+
+"""
+    OGR_F_GetFieldIndex(OGRFeatureH,
+                        const char *) -> int
+
+Fetch the field index given field name.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **pszName**: the name of the field to search for.
+
+### Returns
+the field index, or -1 if no matching field is found.
+"""
 function getfieldindex(arg1::OGRFeatureH,arg2::AbstractString)
     ccall((:OGR_F_GetFieldIndex,libgdal),Cint,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_IsFieldSet(OGRFeatureH,
+                     int) -> int
+
+Test if a field has ever been assigned a value or not.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is.
+* **iField**: the field to test.
+
+### Returns
+TRUE if the field has been set, otherwise false.
+"""
 function isfieldset(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_IsFieldSet,libgdal),Cint,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_UnsetField(OGRFeatureH,
+                     int) -> void
+
+Clear a field, marking it as unset.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is.
+* **iField**: the field to unset.
+"""
 function unsetfield(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_UnsetField,libgdal),Void,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetRawFieldRef(OGRFeatureH,
+                         int) -> OGRField *
+
+Fetch an handle to the internal field value given the index.
+
+### Parameters
+* **hFeat**: handle to the feature on which field is found.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the returned handle is to an internal data structure, and should not be freed, or modified.
+"""
 function getrawfieldref(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_GetRawFieldRef,libgdal),Ptr{OGRField},(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger(OGRFeatureH,
+                            int) -> int
+
+Fetch field value as integer.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function getfieldasinteger(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_GetFieldAsInteger,libgdal),Cint,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger64(OGRFeatureH,
+                              int) -> GIntBig
+
+Fetch field value as integer 64 bit.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function getfieldasinteger64(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_GetFieldAsInteger64,libgdal),GIntBig,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsDouble(OGRFeatureH,
+                           int) -> double
+
+Fetch field value as a double.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value.
+"""
 function getfieldasdouble(arg1::OGRFeatureH,arg2::Integer)
     ccall((:OGR_F_GetFieldAsDouble,libgdal),Cdouble,(OGRFeatureH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetFieldAsString(OGRFeatureH,
+                           int) -> const char *
+
+Fetch field value as a string.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value. This string is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function getfieldasstring(arg1::OGRFeatureH,arg2::Integer)
     bytestring(ccall((:OGR_F_GetFieldAsString,libgdal),Ptr{UInt8},(OGRFeatureH,Cint),arg1,arg2))
 end
 
+
+"""
+    OGR_F_GetFieldAsIntegerList(OGRFeatureH,
+                                int,
+                                int *) -> const int *
+
+Fetch field value as a list of integers.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of integers) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function getfieldasintegerlist(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{Cint})
     ccall((:OGR_F_GetFieldAsIntegerList,libgdal),Ptr{Cint},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsInteger64List(OGRFeatureH,
+                                  int,
+                                  int *) -> const GIntBig *
+
+Fetch field value as a list of 64 bit integers.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of integers) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function getfieldasinteger64list(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{Cint})
     ccall((:OGR_F_GetFieldAsInteger64List,libgdal),Ptr{GIntBig},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsDoubleList(OGRFeatureH,
+                               int,
+                               int *) -> const double *
+
+Fetch field value as a list of doubles.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnCount**: an integer to put the list count (number of doubles) into.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief. If *pnCount is zero on return the returned pointer may be NULL or non-NULL.
+"""
 function getfieldasdoublelist(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{Cint})
     ccall((:OGR_F_GetFieldAsDoubleList,libgdal),Ptr{Cdouble},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsStringList(OGRFeatureH,
+                               int) -> char **
+
+Fetch field value as a list of strings.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function getfieldasstringlist(arg1::OGRFeatureH,arg2::Integer)
     bytestring(unsafe_load(ccall((:OGR_F_GetFieldAsStringList,libgdal),Ptr{Ptr{UInt8}},(OGRFeatureH,Cint),arg1,arg2)))
 end
 
+
+"""
+    OGR_F_GetFieldAsBinary(OGRFeatureH,
+                           int,
+                           int *) -> GByte *
+
+Fetch field value as binary.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnBytes**: location to place count of bytes returned.
+
+### Returns
+the field value. This list is internal, and should not be modified, or freed. Its lifetime may be very brief.
+"""
 function getfieldasbinary(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{Cint})
     ccall((:OGR_F_GetFieldAsBinary,libgdal),Ptr{GByte},(OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_GetFieldAsDateTime(OGRFeatureH,
+                             int,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *,
+                             int *) -> int
+
+Fetch field value as date and time.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnYear**: (including century)
+* **pnMonth**: (1-12)
+* **pnDay**: (1-31)
+* **pnHour**: (0-23)
+* **pnMinute**: (0-59)
+* **pnSecond**: (0-59)
+* **pnTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function getfieldasdatetime(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{Cint},arg4::Vector{Cint},arg5::Vector{Cint},arg6::Vector{Cint},arg7::Vector{Cint},arg8::Vector{Cint},arg9::Vector{Cint})
     ccall((:OGR_F_GetFieldAsDateTime,libgdal),Cint,(OGRFeatureH,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_GetFieldAsDateTimeEx(OGRFeatureH hFeat,
+                               int iField,
+                               int * pnYear,
+                               int * pnMonth,
+                               int * pnDay,
+                               int * pnHour,
+                               int * pnMinute,
+                               float * pfSecond,
+                               int * pnTZFlag) -> int
+
+Fetch field value as date and time.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pnYear**: (including century)
+* **pnMonth**: (1-12)
+* **pnDay**: (1-31)
+* **pnHour**: (0-23)
+* **pnMinute**: (0-59)
+* **pfSecond**: (0-59 with millisecond accuracy)
+* **pnTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+
+### Returns
+TRUE on success or FALSE on failure.
+"""
 function getfieldasdatetimeex(hFeat::OGRFeatureH,iField::Integer,pnYear::Vector{Cint},pnMonth::Vector{Cint},pnDay::Vector{Cint},pnHour::Vector{Cint},pnMinute::Vector{Cint},pfSecond::Ptr{Cfloat},pnTZFlag::Vector{Cint})
     ccall((:OGR_F_GetFieldAsDateTimeEx,libgdal),Cint,(OGRFeatureH,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat},Ptr{Cint}),hFeat,iField,pnYear,pnMonth,pnDay,pnHour,pnMinute,pfSecond,pnTZFlag)
 end
 
+
+"""
+    OGR_F_SetFieldInteger(OGRFeatureH,
+                          int,
+                          int) -> void
+
+Set field to integer value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **nValue**: the value to assign.
+"""
 function setfieldinteger(arg1::OGRFeatureH,arg2::Integer,arg3::Integer)
     ccall((:OGR_F_SetFieldInteger,libgdal),Void,(OGRFeatureH,Cint,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldInteger64(OGRFeatureH,
+                            int,
+                            GIntBig) -> void
+
+Set field to 64 bit integer value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **nValue**: the value to assign.
+"""
 function setfieldinteger64(arg1::OGRFeatureH,arg2::Integer,arg3::GIntBig)
     ccall((:OGR_F_SetFieldInteger64,libgdal),Void,(OGRFeatureH,Cint,GIntBig),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldDouble(OGRFeatureH,
+                         int,
+                         double) -> void
+
+Set field to double value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **dfValue**: the value to assign.
+"""
 function setfielddouble(arg1::OGRFeatureH,arg2::Integer,arg3::Real)
     ccall((:OGR_F_SetFieldDouble,libgdal),Void,(OGRFeatureH,Cint,Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldString(OGRFeatureH,
+                         int,
+                         const char *) -> void
+
+Set field to string value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **pszValue**: the value to assign.
+"""
 function setfieldstring(arg1::OGRFeatureH,arg2::Integer,arg3::AbstractString)
     ccall((:OGR_F_SetFieldString,libgdal),Void,(OGRFeatureH,Cint,Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldIntegerList(OGRFeatureH,
+                              int,
+                              int,
+                              int *) -> void
+
+Set field to list of integers value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **panValues**: the values to assign.
+"""
 function setfieldintegerlist(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Vector{Cint})
     ccall((:OGR_F_SetFieldIntegerList,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{Cint}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldInteger64List(OGRFeatureH,
+                                int,
+                                int,
+                                const GIntBig *) -> void
+
+Set field to list of 64 bit integers value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **panValues**: the values to assign.
+"""
 function setfieldinteger64list(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Ptr{GIntBig})
     ccall((:OGR_F_SetFieldInteger64List,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{GIntBig}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldDoubleList(OGRFeatureH,
+                             int,
+                             int,
+                             double *) -> void
+
+Set field to list of doubles value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nCount**: the number of values in the list being assigned.
+* **padfValues**: the values to assign.
+"""
 function setfielddoublelist(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Vector{Float64})
     ccall((:OGR_F_SetFieldDoubleList,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{Cdouble}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldStringList(OGRFeatureH,
+                             int,
+                             char **) -> void
+
+Set field to list of strings value.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **papszValues**: the values to assign.
+"""
 function setfieldstringlist(arg1::OGRFeatureH,arg2::Integer,arg3::Vector{UTF8String})
     ccall((:OGR_F_SetFieldStringList,libgdal),Void,(OGRFeatureH,Cint,Ptr{Ptr{UInt8}}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldRaw(OGRFeatureH,
+                      int,
+                      OGRField *) -> void
+
+Set field.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to fetch, from 0 to GetFieldCount()-1.
+* **psValue**: handle on the value to assign.
+"""
 function setfieldraw(arg1::OGRFeatureH,arg2::Integer,arg3::Ptr{OGRField})
     ccall((:OGR_F_SetFieldRaw,libgdal),Void,(OGRFeatureH,Cint,Ptr{OGRField}),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFieldBinary(OGRFeatureH,
+                         int,
+                         int,
+                         GByte *) -> void
+
+Set field to binary data.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nBytes**: the number of bytes in pabyData array.
+* **pabyData**: the data to apply.
+"""
 function setfieldbinary(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Ptr{GByte})
     ccall((:OGR_F_SetFieldBinary,libgdal),Void,(OGRFeatureH,Cint,Cint,Ptr{GByte}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_SetFieldDateTime(OGRFeatureH,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int,
+                           int) -> void
+
+Set field to datetime.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nYear**: (including century)
+* **nMonth**: (1-12)
+* **nDay**: (1-31)
+* **nHour**: (0-23)
+* **nMinute**: (0-59)
+* **nSecond**: (0-59)
+* **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+"""
 function setfielddatetime(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Integer,arg5::Integer,arg6::Integer,arg7::Integer,arg8::Integer,arg9::Integer)
     ccall((:OGR_F_SetFieldDateTime,libgdal),Void,(OGRFeatureH,Cint,Cint,Cint,Cint,Cint,Cint,Cint,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_SetFieldDateTimeEx(OGRFeatureH,
+                             int,
+                             int,
+                             int,
+                             int,
+                             int,
+                             int,
+                             float,
+                             int) -> void
+
+Set field to datetime.
+
+### Parameters
+* **hFeat**: handle to the feature that owned the field.
+* **iField**: the field to set, from 0 to GetFieldCount()-1.
+* **nYear**: (including century)
+* **nMonth**: (1-12)
+* **nDay**: (1-31)
+* **nHour**: (0-23)
+* **nMinute**: (0-59)
+* **fSecond**: (0-59, with millisecond accuracy)
+* **nTZFlag**: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+"""
 function setfielddatetimeex(arg1::OGRFeatureH,arg2::Integer,arg3::Integer,arg4::Integer,arg5::Integer,arg6::Integer,arg7::Integer,arg8::Cfloat,arg9::Integer)
     ccall((:OGR_F_SetFieldDateTimeEx,libgdal),Void,(OGRFeatureH,Cint,Cint,Cint,Cint,Cint,Cint,Cfloat,Cint),arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)
 end
 
+
+"""
+    OGR_F_GetGeomFieldCount(OGRFeatureH hFeat) -> int
+
+Fetch number of geometry fields on this feature This will always be the same as the geometry field count for the OGRFeatureDefn.
+
+### Parameters
+* **hFeat**: handle to the feature to get the geometry fields count from.
+
+### Returns
+count of geometry fields.
+"""
 function getgeomfieldcount(hFeat::OGRFeatureH)
     ccall((:OGR_F_GetGeomFieldCount,libgdal),Cint,(OGRFeatureH,),hFeat)
 end
 
+
+"""
+    OGR_F_GetGeomFieldDefnRef(OGRFeatureH hFeat,
+                              int iField) -> OGRGeomFieldDefnH
+
+Fetch definition for this geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which the field is found.
+* **i**: the field to fetch, from 0 to GetGeomFieldCount()-1.
+
+### Returns
+an handle to the field definition (from the OGRFeatureDefn). This is an internal reference, and should not be deleted or modified.
+"""
 function getgeomfielddefnref(hFeat::OGRFeatureH,iField::Integer)
     checknull(ccall((:OGR_F_GetGeomFieldDefnRef,libgdal),OGRGeomFieldDefnH,(OGRFeatureH,Cint),hFeat,iField))
 end
 
+
+"""
+    OGR_F_GetGeomFieldIndex(OGRFeatureH hFeat,
+                            const char * pszName) -> int
+
+Fetch the geometry field index given geometry field name.
+
+### Parameters
+* **hFeat**: handle to the feature on which the geometry field is found.
+* **pszName**: the name of the geometry field to search for.
+
+### Returns
+the geometry field index, or -1 if no matching geometry field is found.
+"""
 function getgeomfieldindex(hFeat::OGRFeatureH,pszName::AbstractString)
     ccall((:OGR_F_GetGeomFieldIndex,libgdal),Cint,(OGRFeatureH,Ptr{UInt8}),hFeat,pszName)
 end
 
+
+"""
+    OGR_F_GetGeomFieldRef(OGRFeatureH hFeat,
+                          int iField) -> OGRGeometryH
+
+Fetch an handle to feature geometry.
+
+### Parameters
+* **hFeat**: handle to the feature to get geometry from.
+* **iField**: geometry field to get.
+
+### Returns
+an handle to internal feature geometry. This object should not be modified.
+"""
 function getgeomfieldref(hFeat::OGRFeatureH,iField::Integer)
     checknull(ccall((:OGR_F_GetGeomFieldRef,libgdal),OGRGeometryH,(OGRFeatureH,Cint),hFeat,iField))
 end
 
+
+"""
+    OGR_F_SetGeomFieldDirectly(OGRFeatureH hFeat,
+                               int iField,
+                               OGRGeometryH hGeom) -> OGRErr
+
+Set feature geometry of a specified geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which to apply the geometry.
+* **iField**: geometry field to set.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGRERR_FAILURE if the index is invalid, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function setgeomfielddirectly(hFeat::OGRFeatureH,iField::Integer,hGeom::OGRGeometryH)
     ccall((:OGR_F_SetGeomFieldDirectly,libgdal),OGRErr,(OGRFeatureH,Cint,OGRGeometryH),hFeat,iField,hGeom)
 end
 
+
+"""
+    OGR_F_SetGeomField(OGRFeatureH hFeat,
+                       int iField,
+                       OGRGeometryH hGeom) -> OGRErr
+
+Set feature geometry of a specified geometry field.
+
+### Parameters
+* **hFeat**: handle to the feature on which new geometry is applied to.
+* **iField**: geometry field to set.
+* **hGeom**: handle to the new geometry to apply to feature.
+
+### Returns
+OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the OGRFeatureDefn (checking not yet implemented).
+"""
 function setgeomfield(hFeat::OGRFeatureH,iField::Integer,hGeom::OGRGeometryH)
     ccall((:OGR_F_SetGeomField,libgdal),OGRErr,(OGRFeatureH,Cint,OGRGeometryH),hFeat,iField,hGeom)
 end
 
+
+"""
+    OGR_F_GetFID(OGRFeatureH) -> GIntBig
+
+Get feature identifier.
+
+### Parameters
+* **hFeat**: handle to the feature from which to get the feature identifier.
+
+### Returns
+feature id or OGRNullFID if none has been assigned.
+"""
 function getfid(arg1::OGRFeatureH)
     ccall((:OGR_F_GetFID,libgdal),GIntBig,(OGRFeatureH,),arg1)
 end
 
+
+"""
+    OGR_F_SetFID(OGRFeatureH,
+                 GIntBig) -> OGRErr
+
+Set the feature identifier.
+
+### Parameters
+* **hFeat**: handle to the feature to set the feature id to.
+* **nFID**: the new feature identifier value to assign.
+
+### Returns
+On success OGRERR_NONE, or on failure some other value.
+"""
 function setfid(arg1::OGRFeatureH,arg2::GIntBig)
     ccall((:OGR_F_SetFID,libgdal),OGRErr,(OGRFeatureH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_F_DumpReadable(OGRFeatureH,
+                       FILE *) -> void
+
+Dump this feature in a human readable form.
+
+### Parameters
+* **hFeat**: handle to the feature to dump.
+* **fpOut**: the stream to write to, such as strout.
+"""
 function dumpreadable(arg1::OGRFeatureH,arg2::Ptr{FILE})
     ccall((:OGR_F_DumpReadable,libgdal),Void,(OGRFeatureH,Ptr{FILE}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetFrom(OGRFeatureH,
+                  OGRFeatureH,
+                  int) -> OGRErr
+
+Set one feature from another.
+
+### Parameters
+* **hFeat**: handle to the feature to set to.
+* **hOtherFeat**: handle to the feature from which geometry, and field values will be copied.
+* **bForgiving**: TRUE if the operation should continue despite lacking output fields matching some of the source fields.
+
+### Returns
+OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
+"""
 function setfrom(arg1::OGRFeatureH,arg2::OGRFeatureH,arg3::Integer)
     ccall((:OGR_F_SetFrom,libgdal),OGRErr,(OGRFeatureH,OGRFeatureH,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_F_SetFromWithMap(OGRFeatureH,
+                         OGRFeatureH,
+                         int,
+                         int *) -> OGRErr
+
+Set one feature from another.
+
+### Parameters
+* **hFeat**: handle to the feature to set to.
+* **hOtherFeat**: handle to the feature from which geometry, and field values will be copied.
+* **panMap**: Array of the indices of the destination feature's fields stored at the corresponding index of the source feature's fields. A value of -1 should be used to ignore the source's field. The array should not be NULL and be as long as the number of fields in the source feature.
+* **bForgiving**: TRUE if the operation should continue despite lacking output fields matching some of the source fields.
+
+### Returns
+OGRERR_NONE if the operation succeeds, even if some values are not transferred, otherwise an error code.
+"""
 function setfromwithmap(arg1::OGRFeatureH,arg2::OGRFeatureH,arg3::Integer,arg4::Vector{Cint})
     ccall((:OGR_F_SetFromWithMap,libgdal),OGRErr,(OGRFeatureH,OGRFeatureH,Cint,Ptr{Cint}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OGR_F_GetStyleString(OGRFeatureH) -> const char *
+
+Fetch style string for this feature.
+
+### Parameters
+* **hFeat**: handle to the feature to get the style from.
+
+### Returns
+a reference to a representation in string format, or NULL if there isn't one.
+"""
 function getstylestring(arg1::OGRFeatureH)
     bytestring(ccall((:OGR_F_GetStyleString,libgdal),Ptr{UInt8},(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_SetStyleString(OGRFeatureH,
+                         const char *) -> void
+
+Set feature style string.
+
+### Parameters
+* **hFeat**: handle to the feature to set style to.
+* **pszStyle**: the style string to apply to this feature, cannot be NULL.
+"""
 function setstylestring(arg1::OGRFeatureH,arg2::AbstractString)
     ccall((:OGR_F_SetStyleString,libgdal),Void,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetStyleStringDirectly(OGRFeatureH,
+                                 char *) -> void
+
+Set feature style string.
+
+### Parameters
+* **hFeat**: handle to the feature to set style to.
+* **pszStyle**: the style string to apply to this feature, cannot be NULL.
+"""
 function setstylestringdirectly(arg1::OGRFeatureH,arg2::AbstractString)
     ccall((:OGR_F_SetStyleStringDirectly,libgdal),Void,(OGRFeatureH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_F_GetStyleTable(OGRFeatureH) -> OGRStyleTableH
+"""
 function getstyletable(arg1::OGRFeatureH)
     checknull(ccall((:OGR_F_GetStyleTable,libgdal),OGRStyleTableH,(OGRFeatureH,),arg1))
 end
 
+
+"""
+    OGR_F_SetStyleTableDirectly(OGRFeatureH,
+                                OGRStyleTableH) -> void
+"""
 function setstyletabledirectly(arg1::OGRFeatureH,arg2::OGRStyleTableH)
     ccall((:OGR_F_SetStyleTableDirectly,libgdal),Void,(OGRFeatureH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_SetStyleTable(OGRFeatureH,
+                        OGRStyleTableH) -> void
+"""
 function setstyletable(arg1::OGRFeatureH,arg2::OGRStyleTableH)
     ccall((:OGR_F_SetStyleTable,libgdal),Void,(OGRFeatureH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_F_FillUnsetWithDefault(OGRFeatureH hFeat,
+                               int bNotNullableOnly,
+                               char ** papszOptions) -> void
+
+Fill unset fields with default values that might be defined.
+
+### Parameters
+* **hFeat**: handle to the feature.
+* **bNotNullableOnly**: if we should fill only unset fields with a not-null constraint.
+* **papszOptions**: unused currently. Must be set to NULL.
+"""
 function fillunsetwithdefault(hFeat::OGRFeatureH,bNotNullableOnly::Integer,papszOptions::Vector{UTF8String})
     ccall((:OGR_F_FillUnsetWithDefault,libgdal),Void,(OGRFeatureH,Cint,Ptr{Ptr{UInt8}}),hFeat,bNotNullableOnly,papszOptions)
 end
 
+
+"""
+    OGR_F_Validate(OGRFeatureH,
+                   int nValidateFlags,
+                   int bEmitError) -> int
+
+Validate that a feature meets constraints of its schema.
+
+### Parameters
+* **hFeat**: handle to the feature to validate.
+* **nValidateFlags**: OGR_F_VAL_ALL or combination of OGR_F_VAL_NULL, OGR_F_VAL_GEOM_TYPE, OGR_F_VAL_WIDTH and OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT with '|' operator
+* **bEmitError**: TRUE if a CPLError() must be emitted when a check fails
+
+### Returns
+TRUE if all enabled validation tests pass.
+"""
 function validate(arg1::OGRFeatureH,nValidateFlags::Integer,bEmitError::Integer)
     ccall((:OGR_F_Validate,libgdal),Cint,(OGRFeatureH,Cint,Cint),arg1,nValidateFlags,bEmitError)
 end
 
+
+"""
+    OGR_L_GetName(OGRLayerH) -> const char *
+
+Return the layer name.
+
+### Parameters
+* **hLayer**: handle to the layer.
+
+### Returns
+the layer name (must not been freed)
+"""
 function getname(arg1::OGRLayerH)
     bytestring(ccall((:OGR_L_GetName,libgdal),Ptr{UInt8},(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_GetGeomType(OGRLayerH) -> OGRwkbGeometryType
+
+Return the layer geometry type.
+
+### Parameters
+* **hLayer**: handle to the layer.
+
+### Returns
+the geometry type
+"""
 function getgeomtype(arg1::OGRLayerH)
     ccall((:OGR_L_GetGeomType,libgdal),OGRwkbGeometryType,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetSpatialFilter(OGRLayerH) -> OGRGeometryH
+
+This function returns the current spatial filter for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the spatial filter from.
+
+### Returns
+an handle to the spatial filter geometry.
+"""
 function getspatialfilter(arg1::OGRLayerH)
     checknull(ccall((:OGR_L_GetSpatialFilter,libgdal),OGRGeometryH,(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_SetSpatialFilter(OGRLayerH,
+                           OGRGeometryH) -> void
+
+Set a new spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
+"""
 function setspatialfilter(arg1::OGRLayerH,arg2::OGRGeometryH)
     ccall((:OGR_L_SetSpatialFilter,libgdal),Void,(OGRLayerH,OGRGeometryH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterRect(OGRLayerH,
+                               double,
+                               double,
+                               double,
+                               double) -> void
+
+Set a new rectangular spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **dfMinX**: the minimum X coordinate for the rectangular region.
+* **dfMinY**: the minimum Y coordinate for the rectangular region.
+* **dfMaxX**: the maximum X coordinate for the rectangular region.
+* **dfMaxY**: the maximum Y coordinate for the rectangular region.
+"""
 function setspatialfilterrect(arg1::OGRLayerH,arg2::Real,arg3::Real,arg4::Real,arg5::Real)
     ccall((:OGR_L_SetSpatialFilterRect,libgdal),Void,(OGRLayerH,Cdouble,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterEx(OGRLayerH,
+                             int iGeomField,
+                             OGRGeometryH hGeom) -> void
+
+Set a new spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **iGeomField**: index of the geometry field on which the spatial filter operates.
+* **hGeom**: handle to the geometry to use as a filtering region. NULL may be passed indicating that the current spatial filter should be cleared, but no new one instituted.
+"""
 function setspatialfilterex(arg1::OGRLayerH,iGeomField::Integer,hGeom::OGRGeometryH)
     ccall((:OGR_L_SetSpatialFilterEx,libgdal),Void,(OGRLayerH,Cint,OGRGeometryH),arg1,iGeomField,hGeom)
 end
 
+
+"""
+    OGR_L_SetSpatialFilterRectEx(OGRLayerH,
+                                 int iGeomField,
+                                 double dfMinX,
+                                 double dfMinY,
+                                 double dfMaxX,
+                                 double dfMaxY) -> void
+
+Set a new rectangular spatial filter.
+
+### Parameters
+* **hLayer**: handle to the layer on which to set the spatial filter.
+* **iGeomField**: index of the geometry field on which the spatial filter operates.
+* **dfMinX**: the minimum X coordinate for the rectangular region.
+* **dfMinY**: the minimum Y coordinate for the rectangular region.
+* **dfMaxX**: the maximum X coordinate for the rectangular region.
+* **dfMaxY**: the maximum Y coordinate for the rectangular region.
+"""
 function setspatialfilterrectex(arg1::OGRLayerH,iGeomField::Integer,dfMinX::Real,dfMinY::Real,dfMaxX::Real,dfMaxY::Real)
     ccall((:OGR_L_SetSpatialFilterRectEx,libgdal),Void,(OGRLayerH,Cint,Cdouble,Cdouble,Cdouble,Cdouble),arg1,iGeomField,dfMinX,dfMinY,dfMaxX,dfMaxY)
 end
 
+
+"""
+    OGR_L_SetAttributeFilter(OGRLayerH,
+                             const char *) -> OGRErr
+
+Set a new attribute query.
+
+### Parameters
+* **hLayer**: handle to the layer on which attribute query will be executed.
+* **pszQuery**: query in restricted SQL WHERE format, or NULL to clear the current query.
+
+### Returns
+OGRERR_NONE if successfully installed, or an error code if the query expression is in error, or some other failure occurs.
+"""
 function setattributefilter(arg1::OGRLayerH,arg2::AbstractString)
     ccall((:OGR_L_SetAttributeFilter,libgdal),OGRErr,(OGRLayerH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_ResetReading(OGRLayerH) -> void
+
+Reset feature reading to start on the first feature.
+
+### Parameters
+* **hLayer**: handle to the layer on which features are read.
+"""
 function resetreading(arg1::OGRLayerH)
     ccall((:OGR_L_ResetReading,libgdal),Void,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetNextFeature(OGRLayerH) -> OGRFeatureH
+
+Fetch the next available feature from this layer.
+
+### Parameters
+* **hLayer**: handle to the layer from which feature are read.
+
+### Returns
+an handle to a feature, or NULL if no more features are available.
+"""
 function getnextfeature(arg1::OGRLayerH)
     checknull(ccall((:OGR_L_GetNextFeature,libgdal),OGRFeatureH,(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_SetNextByIndex(OGRLayerH,
+                         GIntBig) -> OGRErr
+
+Move read cursor to the nIndex'th feature in the current resultset.
+
+### Parameters
+* **hLayer**: handle to the layer
+* **nIndex**: the index indicating how many steps into the result set to seek.
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function setnextbyindex(arg1::OGRLayerH,arg2::GIntBig)
     ccall((:OGR_L_SetNextByIndex,libgdal),OGRErr,(OGRLayerH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetFeature(OGRLayerH,
+                     GIntBig) -> OGRFeatureH
+
+Fetch a feature by its identifier.
+
+### Parameters
+* **hLayer**: handle to the layer that owned the feature.
+* **nFeatureId**: the feature id of the feature to read.
+
+### Returns
+an handle to a feature now owned by the caller, or NULL on failure.
+"""
 function getfeature(arg1::OGRLayerH,arg2::GIntBig)
     checknull(ccall((:OGR_L_GetFeature,libgdal),OGRFeatureH,(OGRLayerH,GIntBig),arg1,arg2))
 end
 
+
+"""
+    OGR_L_SetFeature(OGRLayerH,
+                     OGRFeatureH) -> OGRErr
+
+Rewrite an existing feature.
+
+### Parameters
+* **hLayer**: handle to the layer to write the feature.
+* **hFeat**: the feature to write.
+
+### Returns
+OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
+"""
 function setfeature(arg1::OGRLayerH,arg2::OGRFeatureH)
     ccall((:OGR_L_SetFeature,libgdal),OGRErr,(OGRLayerH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_CreateFeature(OGRLayerH,
+                        OGRFeatureH) -> OGRErr
+
+Create and write a new feature within a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the feature to.
+* **hFeat**: the handle of the feature to write to disk.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function createfeature(arg1::OGRLayerH,arg2::OGRFeatureH)
     ccall((:OGR_L_CreateFeature,libgdal),OGRErr,(OGRLayerH,OGRFeatureH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_DeleteFeature(OGRLayerH,
+                        GIntBig) -> OGRErr
+
+Delete feature from layer.
+
+### Parameters
+* **hLayer**: handle to the layer
+* **nFID**: the feature id to be deleted from the layer
+
+### Returns
+OGRERR_NONE if the operation works, otherwise an appropriate error code (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
+"""
 function deletefeature(arg1::OGRLayerH,arg2::GIntBig)
     ccall((:OGR_L_DeleteFeature,libgdal),OGRErr,(OGRLayerH,GIntBig),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetLayerDefn(OGRLayerH) -> OGRFeatureDefnH
+
+Fetch the schema information for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the schema information.
+
+### Returns
+an handle to the feature definition.
+"""
 function getlayerdefn(arg1::OGRLayerH)
     checknull(ccall((:OGR_L_GetLayerDefn,libgdal),OGRFeatureDefnH,(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_GetSpatialRef(OGRLayerH) -> OGRSpatialReferenceH
+
+Fetch the spatial reference system for this layer.
+
+### Parameters
+* **hLayer**: handle to the layer to get the spatial reference from.
+
+### Returns
+spatial reference, or NULL if there isn't one.
+"""
 function getspatialref(arg1::OGRLayerH)
     checknull(ccall((:OGR_L_GetSpatialRef,libgdal),OGRSpatialReferenceH,(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_FindFieldIndex(OGRLayerH,
+                         const char *,
+                         int bExactMatch) -> int
+
+Find the index of field in a layer.
+
+### Returns
+field index, or -1 if the field doesn't exist
+"""
 function findfieldindex(arg1::OGRLayerH,arg2::AbstractString,bExactMatch::Integer)
     ccall((:OGR_L_FindFieldIndex,libgdal),Cint,(OGRLayerH,Ptr{UInt8},Cint),arg1,arg2,bExactMatch)
 end
 
+
+"""
+    OGR_L_GetFeatureCount(OGRLayerH,
+                          int) -> GIntBig
+
+Fetch the feature count in this layer.
+
+### Parameters
+* **hLayer**: handle to the layer that owned the features.
+* **bForce**: Flag indicating whether the count should be computed even if it is expensive.
+
+### Returns
+feature count, -1 if count not known.
+"""
 function getfeaturecount(arg1::OGRLayerH,arg2::Integer)
     ccall((:OGR_L_GetFeatureCount,libgdal),GIntBig,(OGRLayerH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_L_GetExtent(OGRLayerH,
+                    OGREnvelope *,
+                    int) -> OGRErr
+
+Fetch the extent of this layer.
+
+### Parameters
+* **hLayer**: handle to the layer from which to get extent.
+* **psExtent**: the structure in which the extent value will be returned.
+* **bForce**: Flag indicating whether the extent should be computed even if it is expensive.
+
+### Returns
+OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
+"""
 function getextent(arg1::OGRLayerH,arg2::Ptr{OGREnvelope},arg3::Integer)
     ccall((:OGR_L_GetExtent,libgdal),OGRErr,(OGRLayerH,Ptr{OGREnvelope},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_L_GetExtentEx(OGRLayerH,
+                      int iGeomField,
+                      OGREnvelope * psExtent,
+                      int bForce) -> OGRErr
+
+Fetch the extent of this layer, on the specified geometry field.
+
+### Parameters
+* **hLayer**: handle to the layer from which to get extent.
+* **iGeomField**: the index of the geometry field on which to compute the extent.
+* **psExtent**: the structure in which the extent value will be returned.
+* **bForce**: Flag indicating whether the extent should be computed even if it is expensive.
+
+### Returns
+OGRERR_NONE on success, OGRERR_FAILURE if extent not known.
+"""
 function getextentex(arg1::OGRLayerH,iGeomField::Integer,psExtent::Ptr{OGREnvelope},bForce::Integer)
     ccall((:OGR_L_GetExtentEx,libgdal),OGRErr,(OGRLayerH,Cint,Ptr{OGREnvelope},Cint),arg1,iGeomField,psExtent,bForce)
 end
 
+
+"""
+    OGR_L_TestCapability(OGRLayerH,
+                         const char *) -> int
+
+Test if this layer supported the named capability.
+
+### Parameters
+* **hLayer**: handle to the layer to get the capability from.
+* **pszCap**: the name of the capability to test.
+
+### Returns
+TRUE if the layer has the requested capability, or FALSE otherwise. OGRLayers will return FALSE for any unrecognised capabilities.
+"""
 function testcapability(arg1::OGRLayerH,arg2::AbstractString)
     ccall((:OGR_L_TestCapability,libgdal),Cint,(OGRLayerH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_CreateField(OGRLayerH,
+                      OGRFieldDefnH,
+                      int) -> OGRErr
+
+Create a new field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the field definition.
+* **hField**: handle of the field definition to write to disk.
+* **bApproxOK**: If TRUE, the field may be created in a slightly different form depending on the limitations of the format driver.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function createfield(arg1::OGRLayerH,arg2::OGRFieldDefnH,arg3::Integer)
     ccall((:OGR_L_CreateField,libgdal),OGRErr,(OGRLayerH,OGRFieldDefnH,Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OGR_L_CreateGeomField(OGRLayerH hLayer,
+                          OGRGeomFieldDefnH hFieldDefn,
+                          int bForce) -> OGRErr
+
+Create a new geometry field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer to write the field definition.
+* **hField**: handle of the geometry field definition to write to disk.
+* **bApproxOK**: If TRUE, the field may be created in a slightly different form depending on the limitations of the format driver.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function creategeomfield(hLayer::OGRLayerH,hFieldDefn::OGRGeomFieldDefnH,bForce::Integer)
     ccall((:OGR_L_CreateGeomField,libgdal),OGRErr,(OGRLayerH,OGRGeomFieldDefnH,Cint),hLayer,hFieldDefn,bForce)
 end
 
+
+"""
+    OGR_L_DeleteField(OGRLayerH,
+                      int iField) -> OGRErr
+
+Create a new field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iField**: index of the field to delete.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function deletefield(arg1::OGRLayerH,iField::Integer)
     ccall((:OGR_L_DeleteField,libgdal),OGRErr,(OGRLayerH,Cint),arg1,iField)
 end
 
+
+"""
+    OGR_L_ReorderFields(OGRLayerH,
+                        int * panMap) -> OGRErr
+
+Reorder all the fields of a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **panMap**: an array of GetLayerDefn()->OGRFeatureDefn::GetFieldCount() elements which is a permutation of [0, GetLayerDefn()->OGRFeatureDefn::GetFieldCount()-1].
+
+### Returns
+OGRERR_NONE on success.
+"""
 function reorderfields(arg1::OGRLayerH,panMap::Vector{Cint})
     ccall((:OGR_L_ReorderFields,libgdal),OGRErr,(OGRLayerH,Ptr{Cint}),arg1,panMap)
 end
 
+
+"""
+    OGR_L_ReorderField(OGRLayerH,
+                       int iOldFieldPos,
+                       int iNewFieldPos) -> OGRErr
+
+Reorder an existing field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iOldFieldPos**: previous position of the field to move. Must be in the range [0,GetFieldCount()-1].
+* **iNewFieldPos**: new position of the field to move. Must be in the range [0,GetFieldCount()-1].
+
+### Returns
+OGRERR_NONE on success.
+"""
 function reorderfield(arg1::OGRLayerH,iOldFieldPos::Integer,iNewFieldPos::Integer)
     ccall((:OGR_L_ReorderField,libgdal),OGRErr,(OGRLayerH,Cint,Cint),arg1,iOldFieldPos,iNewFieldPos)
 end
 
+
+"""
+    OGR_L_AlterFieldDefn(OGRLayerH,
+                         int iField,
+                         OGRFieldDefnH hNewFieldDefn,
+                         int nFlags) -> OGRErr
+
+Alter the definition of an existing field on a layer.
+
+### Parameters
+* **hLayer**: handle to the layer.
+* **iField**: index of the field whose definition must be altered.
+* **hNewFieldDefn**: new field definition
+* **nFlags**: combination of ALTER_NAME_FLAG, ALTER_TYPE_FLAG, ALTER_WIDTH_PRECISION_FLAG, ALTER_NULLABLE_FLAG and ALTER_DEFAULT_FLAG to indicate which of the name and/or type and/or width and precision fields and/or nullability from the new field definition must be taken into account.
+
+### Returns
+OGRERR_NONE on success.
+"""
 function alterfielddefn(arg1::OGRLayerH,iField::Integer,hNewFieldDefn::OGRFieldDefnH,nFlags::Integer)
     ccall((:OGR_L_AlterFieldDefn,libgdal),OGRErr,(OGRLayerH,Cint,OGRFieldDefnH,Cint),arg1,iField,hNewFieldDefn,nFlags)
 end
 
+
+"""
+    OGR_L_StartTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, StartTransaction creates a transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function starttransaction(arg1::OGRLayerH)
     ccall((:OGR_L_StartTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_CommitTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, CommitTransaction commits a transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function committransaction(arg1::OGRLayerH)
     ccall((:OGR_L_CommitTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_RollbackTransaction(OGRLayerH) -> OGRErr
+
+For datasources which support transactions, RollbackTransaction will roll back a datasource to its state before the start of the current transaction.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE on success.
+"""
 function rollbacktransaction(arg1::OGRLayerH)
     ccall((:OGR_L_RollbackTransaction,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_Reference(OGRLayerH) -> int
+"""
 function reference(arg1::OGRLayerH)
     ccall((:OGR_L_Reference,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_Dereference(OGRLayerH) -> int
+"""
 function dereference(arg1::OGRLayerH)
     ccall((:OGR_L_Dereference,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetRefCount(OGRLayerH) -> int
+"""
 function getrefcount(arg1::OGRLayerH)
     ccall((:OGR_L_GetRefCount,libgdal),Cint,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_SyncToDisk(OGRLayerH) -> OGRErr
+
+Flush pending changes to disk.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+OGRERR_NONE if no error occurs (even if nothing is done) or an error code.
+"""
 function synctodisk(arg1::OGRLayerH)
     ccall((:OGR_L_SyncToDisk,libgdal),OGRErr,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetFeaturesRead(OGRLayerH) -> GIntBig
+"""
 function getfeaturesread(arg1::OGRLayerH)
     ccall((:OGR_L_GetFeaturesRead,libgdal),GIntBig,(OGRLayerH,),arg1)
 end
 
+
+"""
+    OGR_L_GetFIDColumn(OGRLayerH) -> const char *
+
+This method returns the name of the underlying database column being used as the FID column, or "" if not supported.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+fid column name.
+"""
 function getfidcolumn(arg1::OGRLayerH)
     bytestring(ccall((:OGR_L_GetFIDColumn,libgdal),Ptr{UInt8},(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_GetGeometryColumn(OGRLayerH) -> const char *
+
+This method returns the name of the underlying database column being used as the geometry column, or "" if not supported.
+
+### Parameters
+* **hLayer**: handle to the layer
+
+### Returns
+geometry column name.
+"""
 function getgeometrycolumn(arg1::OGRLayerH)
     bytestring(ccall((:OGR_L_GetGeometryColumn,libgdal),Ptr{UInt8},(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_GetStyleTable(OGRLayerH) -> OGRStyleTableH
+"""
 function getstyletable(arg1::OGRLayerH)
     checknull(ccall((:OGR_L_GetStyleTable,libgdal),OGRStyleTableH,(OGRLayerH,),arg1))
 end
 
+
+"""
+    OGR_L_SetStyleTableDirectly(OGRLayerH,
+                                OGRStyleTableH) -> void
+"""
 function setstyletabledirectly(arg1::OGRLayerH,arg2::OGRStyleTableH)
     ccall((:OGR_L_SetStyleTableDirectly,libgdal),Void,(OGRLayerH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetStyleTable(OGRLayerH,
+                        OGRStyleTableH) -> void
+"""
 function setstyletable(arg1::OGRLayerH,arg2::OGRStyleTableH)
     ccall((:OGR_L_SetStyleTable,libgdal),Void,(OGRLayerH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_L_SetIgnoredFields(OGRLayerH,
+                           const char **) -> OGRErr
+
+Set which fields can be omitted when retrieving features from the layer.
+
+### Parameters
+* **papszFields**: an array of field names terminated by NULL item. If NULL is passed, the ignored list is cleared.
+
+### Returns
+OGRERR_NONE if all field names have been resolved (even if the driver does not support this method)
+"""
 function setignoredfields(arg1::OGRLayerH,arg2::Vector{UTF8String})
     ccall((:OGR_L_SetIgnoredFields,libgdal),OGRErr,(OGRLayerH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OGR_L_Intersection(OGRLayerH,
+                       OGRLayerH,
+                       OGRLayerH,
+                       char **,
+                       GDALProgressFunc,
+                       void *) -> OGRErr
+
+Intersection of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function intersection(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Intersection,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Union(OGRLayerH,
+                OGRLayerH,
+                OGRLayerH,
+                char **,
+                GDALProgressFunc,
+                void *) -> OGRErr
+
+Union of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function union(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Union,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_SymDifference(OGRLayerH,
+                        OGRLayerH,
+                        OGRLayerH,
+                        char **,
+                        GDALProgressFunc,
+                        void *) -> OGRErr
+
+Symmetrical difference of two layers.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function symdifference(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_SymDifference,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Identity(OGRLayerH,
+                   OGRLayerH,
+                   OGRLayerH,
+                   char **,
+                   GDALProgressFunc,
+                   void *) -> OGRErr
+
+Identify the features of this layer with the ones from the identity layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function identity(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Identity,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Update(OGRLayerH,
+                 OGRLayerH,
+                 OGRLayerH,
+                 char **,
+                 GDALProgressFunc,
+                 void *) -> OGRErr
+
+Update this layer with features from the update layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function update(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Update,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Clip(OGRLayerH,
+               OGRLayerH,
+               OGRLayerH,
+               char **,
+               GDALProgressFunc,
+               void *) -> OGRErr
+
+Clip off areas that are not covered by the method layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function clip(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Clip,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_L_Erase(OGRLayerH,
+                OGRLayerH,
+                OGRLayerH,
+                char **,
+                GDALProgressFunc,
+                void *) -> OGRErr
+
+Remove areas that are covered by the method layer.
+
+### Parameters
+* **pLayerInput**: the input layer. Should not be NULL.
+* **pLayerMethod**: the method layer. Should not be NULL.
+* **pLayerResult**: the layer where the features resulting from the operation are inserted. Should not be NULL. See above the note about the schema.
+* **papszOptions**: NULL terminated list of options (may be NULL).
+* **pfnProgress**: a GDALProgressFunc() compatible callback function for reporting progress or NULL.
+* **pProgressArg**: argument to be passed to pfnProgress. May be NULL.
+
+### Returns
+an error code if there was an error or the execution was interrupted, OGRERR_NONE otherwise.
+"""
 function erase(arg1::OGRLayerH,arg2::OGRLayerH,arg3::OGRLayerH,arg4::Vector{UTF8String},arg5::GDALProgressFunc,arg6::Ptr{Void})
     ccall((:OGR_L_Erase,libgdal),OGRErr,(OGRLayerH,OGRLayerH,OGRLayerH,Ptr{Ptr{UInt8}},GDALProgressFunc,Ptr{Void}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OGR_DS_Destroy(OGRDataSourceH) -> void
+
+Closes opened datasource and releases allocated resources.
+
+### Parameters
+* **hDataSource**: handle to allocated datasource object.
+"""
 function destroy(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Destroy,libgdal),Void,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetName(OGRDataSourceH) -> const char *
+
+Returns the name of the data source.
+
+### Parameters
+* **hDS**: handle to the data source to get the name from.
+
+### Returns
+pointer to an internal name string which should not be modified or freed by the caller.
+"""
 function getname(arg1::OGRDataSourceH)
     bytestring(ccall((:OGR_DS_GetName,libgdal),Ptr{UInt8},(OGRDataSourceH,),arg1))
 end
 
+
+"""
+    OGR_DS_GetLayerCount(OGRDataSourceH) -> int
+
+Get the number of layers in this data source.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the number of layers.
+
+### Returns
+layer count.
+"""
 function getlayercount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetLayerCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetLayer(OGRDataSourceH,
+                    int) -> OGRLayerH
+
+Fetch a layer by index.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the layer.
+* **iLayer**: a layer number between 0 and OGR_DS_GetLayerCount()-1.
+
+### Returns
+an handle to the layer, or NULL if iLayer is out of range or an error occurs.
+"""
 function getlayer(arg1::OGRDataSourceH,arg2::Integer)
     checknull(ccall((:OGR_DS_GetLayer,libgdal),OGRLayerH,(OGRDataSourceH,Cint),arg1,arg2))
 end
 
+
+"""
+    OGR_DS_GetLayerByName(OGRDataSourceH,
+                          const char *) -> OGRLayerH
+
+Fetch a layer by name.
+
+### Parameters
+* **hDS**: handle to the data source from which to get the layer.
+* **pszLayerName**: Layer the layer name of the layer to fetch.
+
+### Returns
+an handle to the layer, or NULL if the layer is not found or an error occurs.
+"""
 function getlayerbyname(arg1::OGRDataSourceH,arg2::AbstractString)
     checknull(ccall((:OGR_DS_GetLayerByName,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8}),arg1,arg2))
 end
 
+
+"""
+    OGR_DS_DeleteLayer(OGRDataSourceH,
+                       int) -> OGRErr
+
+Delete the indicated layer from the datasource.
+
+### Parameters
+* **hDS**: handle to the datasource
+* **iLayer**: the index of the layer to delete.
+
+### Returns
+OGRERR_NONE on success, or OGRERR_UNSUPPORTED_OPERATION if deleting layers is not supported for this datasource.
+"""
 function deletelayer(arg1::OGRDataSourceH,arg2::Integer)
     ccall((:OGR_DS_DeleteLayer,libgdal),OGRErr,(OGRDataSourceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_GetDriver(OGRDataSourceH) -> OGRSFDriverH
+
+Returns the driver that the dataset was opened with.
+
+### Parameters
+* **hDS**: handle to the datasource
+
+### Returns
+NULL if driver info is not available, or pointer to a driver owned by the OGRSFDriverManager.
+"""
 function getdriver(arg1::OGRDataSourceH)
     checknull(ccall((:OGR_DS_GetDriver,libgdal),OGRSFDriverH,(OGRDataSourceH,),arg1))
 end
 
+
+"""
+    OGR_DS_CreateLayer(OGRDataSourceH,
+                       const char *,
+                       OGRSpatialReferenceH,
+                       OGRwkbGeometryType,
+                       char **) -> OGRLayerH
+
+This function attempts to create a new layer on the data source with the indicated name, coordinate system, geometry type.
+
+### Parameters
+* **hDS**: The dataset handle.
+* **pszName**: the name for the new layer. This should ideally not match any existing layer on the datasource.
+* **hSpatialRef**: handle to the coordinate system to use for the new layer, or NULL if no coordinate system is available.
+* **eType**: the geometry type for the layer. Use wkbUnknown if there are no constraints on the types geometry to be written.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRLayer handle on success.
+"""
 function createlayer(arg1::OGRDataSourceH,arg2::AbstractString,arg3::OGRSpatialReferenceH,arg4::OGRwkbGeometryType,arg5::Vector{UTF8String})
     checknull(ccall((:OGR_DS_CreateLayer,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8},OGRSpatialReferenceH,OGRwkbGeometryType,Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4,arg5))
 end
 
+
+"""
+    OGR_DS_CopyLayer(OGRDataSourceH,
+                     OGRLayerH,
+                     const char *,
+                     char **) -> OGRLayerH
+
+Duplicate an existing layer.
+
+### Parameters
+* **hDS**: handle to the data source where to create the new layer
+* **hSrcLayer**: handle to the source layer.
+* **pszNewName**: the name of the layer to create.
+* **papszOptions**: a StringList of name=value options. Options are driver specific.
+
+### Returns
+an handle to the layer, or NULL if an error occurs.
+"""
 function copylayer(arg1::OGRDataSourceH,arg2::OGRLayerH,arg3::AbstractString,arg4::Vector{UTF8String})
     checknull(ccall((:OGR_DS_CopyLayer,libgdal),OGRLayerH,(OGRDataSourceH,OGRLayerH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4))
 end
 
+
+"""
+    OGR_DS_TestCapability(OGRDataSourceH,
+                          const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDS**: handle to the data source against which to test the capability.
+* **pszCapability**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function testcapability(arg1::OGRDataSourceH,arg2::AbstractString)
     ccall((:OGR_DS_TestCapability,libgdal),Cint,(OGRDataSourceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_ExecuteSQL(OGRDataSourceH,
+                      const char *,
+                      OGRGeometryH,
+                      const char *) -> OGRLayerH
+
+Execute an SQL statement against the data store.
+
+### Parameters
+* **hDS**: handle to the data source on which the SQL query is executed.
+* **pszSQLCommand**: the SQL statement to execute.
+* **hSpatialFilter**: handle to a geometry which represents a spatial filter. Can be NULL.
+* **pszDialect**: allows control of the statement dialect. If set to NULL, the OGR SQL engine will be used, except for RDBMS drivers that will use their dedicated SQL engine, unless OGRSQL is explicitly passed as the dialect. Starting with OGR 1.10, the SQLITE dialect can also be used.
+
+### Returns
+an handle to a OGRLayer containing the results of the query. Deallocate with OGR_DS_ReleaseResultSet().
+"""
 function executesql(arg1::OGRDataSourceH,arg2::AbstractString,arg3::OGRGeometryH,arg4::AbstractString)
     checknull(ccall((:OGR_DS_ExecuteSQL,libgdal),OGRLayerH,(OGRDataSourceH,Ptr{UInt8},OGRGeometryH,Ptr{UInt8}),arg1,arg2,arg3,arg4))
 end
 
+
+"""
+    OGR_DS_ReleaseResultSet(OGRDataSourceH,
+                            OGRLayerH) -> void
+
+Release results of OGR_DS_ExecuteSQL().
+
+### Parameters
+* **hDS**: an handle to the data source on which was executed an SQL query.
+* **hLayer**: handle to the result of a previous OGR_DS_ExecuteSQL() call.
+"""
 function releaseresultset(arg1::OGRDataSourceH,arg2::OGRLayerH)
     ccall((:OGR_DS_ReleaseResultSet,libgdal),Void,(OGRDataSourceH,OGRLayerH),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_Reference(OGRDataSourceH) -> int
+"""
 function reference(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Reference,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_Dereference(OGRDataSourceH) -> int
+"""
 function dereference(arg1::OGRDataSourceH)
     ccall((:OGR_DS_Dereference,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetRefCount(OGRDataSourceH) -> int
+"""
 function getrefcount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetRefCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetSummaryRefCount(OGRDataSourceH) -> int
+"""
 function getsummaryrefcount(arg1::OGRDataSourceH)
     ccall((:OGR_DS_GetSummaryRefCount,libgdal),Cint,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_SyncToDisk(OGRDataSourceH) -> OGRErr
+"""
 function synctodisk(arg1::OGRDataSourceH)
     ccall((:OGR_DS_SyncToDisk,libgdal),OGRErr,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGR_DS_GetStyleTable(OGRDataSourceH) -> OGRStyleTableH
+"""
 function getstyletable(arg1::OGRDataSourceH)
     checknull(ccall((:OGR_DS_GetStyleTable,libgdal),OGRStyleTableH,(OGRDataSourceH,),arg1))
 end
 
+
+"""
+    OGR_DS_SetStyleTableDirectly(OGRDataSourceH,
+                                 OGRStyleTableH) -> void
+"""
 function setstyletabledirectly(arg1::OGRDataSourceH,arg2::OGRStyleTableH)
     ccall((:OGR_DS_SetStyleTableDirectly,libgdal),Void,(OGRDataSourceH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_DS_SetStyleTable(OGRDataSourceH,
+                         OGRStyleTableH) -> void
+"""
 function setstyletable(arg1::OGRDataSourceH,arg2::OGRStyleTableH)
     ccall((:OGR_DS_SetStyleTable,libgdal),Void,(OGRDataSourceH,OGRStyleTableH),arg1,arg2)
 end
 
+
+"""
+    OGR_Dr_GetName(OGRSFDriverH) -> const char *
+
+Fetch name of driver (file format).
+
+### Parameters
+* **hDriver**: handle to the the driver to get the name from.
+
+### Returns
+driver name. This is an internal string and should not be modified or freed.
+"""
 function getname(arg1::OGRSFDriverH)
     bytestring(ccall((:OGR_Dr_GetName,libgdal),Ptr{UInt8},(OGRSFDriverH,),arg1))
 end
 
+
+"""
+    OGR_Dr_Open(OGRSFDriverH,
+                const char *,
+                int) -> OGRDataSourceH
+
+Attempt to open file with this driver.
+
+### Parameters
+* **hDriver**: handle to the driver that is used to open file.
+* **pszName**: the name of the file, or data source to try and open.
+* **bUpdate**: TRUE if update access is required, otherwise FALSE (the default).
+
+### Returns
+NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
+"""
 function open(arg1::OGRSFDriverH,arg2::AbstractString,arg3::Integer)
     checknull(ccall((:OGR_Dr_Open,libgdal),OGRDataSourceH,(OGRSFDriverH,Ptr{UInt8},Cint),arg1,arg2,arg3))
 end
 
+
+"""
+    OGR_Dr_TestCapability(OGRSFDriverH,
+                          const char *) -> int
+
+Test if capability is available.
+
+### Parameters
+* **hDriver**: handle to the driver to test the capability against.
+* **pszCap**: the capability to test.
+
+### Returns
+TRUE if capability available otherwise FALSE.
+"""
 function testcapability(arg1::OGRSFDriverH,arg2::AbstractString)
     ccall((:OGR_Dr_TestCapability,libgdal),Cint,(OGRSFDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGR_Dr_CreateDataSource(OGRSFDriverH,
+                            const char *,
+                            char **) -> OGRDataSourceH
+
+This function attempts to create a new data source based on the passed driver.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source creation is based.
+* **pszName**: the name for the new data source. UTF-8 encoded.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRDataSource handle on success.
+"""
 function createdatasource(arg1::OGRSFDriverH,arg2::AbstractString,arg3::Vector{UTF8String})
     checknull(ccall((:OGR_Dr_CreateDataSource,libgdal),OGRDataSourceH,(OGRSFDriverH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3))
 end
 
+
+"""
+    OGR_Dr_CopyDataSource(OGRSFDriverH,
+                          OGRDataSourceH,
+                          const char *,
+                          char **) -> OGRDataSourceH
+
+This function creates a new datasource by copying all the layers from the source datasource.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source creation is based.
+* **hSrcDS**: source datasource
+* **pszNewName**: the name for the new data source.
+* **papszOptions**: a StringList of name=value options. Options are driver specific, and driver information can be found at the following url: http://www.gdal.org/ogr/ogr_formats.html
+
+### Returns
+NULL is returned on failure, or a new OGRDataSource handle on success.
+"""
 function copydatasource(arg1::OGRSFDriverH,arg2::OGRDataSourceH,arg3::AbstractString,arg4::Vector{UTF8String})
     checknull(ccall((:OGR_Dr_CopyDataSource,libgdal),OGRDataSourceH,(OGRSFDriverH,OGRDataSourceH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3,arg4))
 end
 
+
+"""
+    OGR_Dr_DeleteDataSource(OGRSFDriverH,
+                            const char *) -> OGRErr
+
+Delete a datasource.
+
+### Parameters
+* **hDriver**: handle to the driver on which data source deletion is based.
+* **pszDataSource**: the name of the datasource to delete.
+
+### Returns
+OGRERR_NONE on success, and OGRERR_UNSUPPORTED_OPERATION if this is not supported by this driver.
+"""
 function deletedatasource(arg1::OGRSFDriverH,arg2::AbstractString)
     ccall((:OGR_Dr_DeleteDataSource,libgdal),OGRErr,(OGRSFDriverH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OGROpen(const char *,
+            int,
+            OGRSFDriverH *) -> OGRDataSourceH
+
+Open a file / data source with one of the registered drivers.
+
+### Parameters
+* **pszName**: the name of the file, or data source to open.
+* **bUpdate**: FALSE for read-only access (the default) or TRUE for read-write access.
+* **pahDriverList**: if non-NULL, this argument will be updated with a pointer to the driver which was used to open the data source.
+
+### Returns
+NULL on error or if the pass name is not supported by this driver, otherwise an handle to a GDALDataset. This GDALDataset should be closed by deleting the object when it is no longer needed.
+"""
 function open(arg1::AbstractString,arg2::Integer,arg3::Ptr{OGRSFDriverH})
     checknull(ccall((:OGROpen,libgdal),OGRDataSourceH,(Ptr{UInt8},Cint,Ptr{OGRSFDriverH}),arg1,arg2,arg3))
 end
 
+
+"""
+    OGROpenShared(const char *,
+                  int,
+                  OGRSFDriverH *) -> OGRDataSourceH
+"""
 function openshared(arg1::AbstractString,arg2::Integer,arg3::Ptr{OGRSFDriverH})
     checknull(ccall((:OGROpenShared,libgdal),OGRDataSourceH,(Ptr{UInt8},Cint,Ptr{OGRSFDriverH}),arg1,arg2,arg3))
 end
 
+
+"""
+    OGRReleaseDataSource(OGRDataSourceH) -> OGRErr
+
+Drop a reference to this datasource, and if the reference count drops to zero close (destroy) the datasource.
+
+### Parameters
+* **hDS**: handle to the data source to release
+
+### Returns
+OGRERR_NONE on success or an error code.
+"""
 function releasedatasource(arg1::OGRDataSourceH)
     ccall((:OGRReleaseDataSource,libgdal),OGRErr,(OGRDataSourceH,),arg1)
 end
 
+
+"""
+    OGRRegisterDriver(OGRSFDriverH) -> void
+"""
 function registerdriver(arg1::OGRSFDriverH)
     ccall((:OGRRegisterDriver,libgdal),Void,(OGRSFDriverH,),arg1)
 end
 
+
+"""
+    OGRDeregisterDriver(OGRSFDriverH) -> void
+"""
 function deregisterdriver(arg1::OGRSFDriverH)
     ccall((:OGRDeregisterDriver,libgdal),Void,(OGRSFDriverH,),arg1)
 end
 
+
+"""
+    OGRGetDriverCount(void) -> int
+
+Fetch the number of registered drivers.
+
+### Returns
+the drivers count.
+"""
 function getdrivercount()
     ccall((:OGRGetDriverCount,libgdal),Cint,())
 end
 
+
+"""
+    OGRGetDriver(int) -> OGRSFDriverH
+
+Fetch the indicated driver.
+
+### Parameters
+* **iDriver**: the driver index, from 0 to GetDriverCount()-1.
+
+### Returns
+handle to the driver, or NULL if iDriver is out of range.
+"""
 function getdriver(arg1::Integer)
     checknull(ccall((:OGRGetDriver,libgdal),OGRSFDriverH,(Cint,),arg1))
 end
 
+
+"""
+    OGRGetDriverByName(const char *) -> OGRSFDriverH
+
+Fetch the indicated driver.
+
+### Parameters
+* **pszName**: the driver name
+
+### Returns
+the driver, or NULL if no driver with that name is found
+"""
 function getdriverbyname(arg1::AbstractString)
     checknull(ccall((:OGRGetDriverByName,libgdal),OGRSFDriverH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    OGRGetOpenDSCount(void) -> int
+"""
 function getopendscount()
     ccall((:OGRGetOpenDSCount,libgdal),Cint,())
 end
 
+
+"""
+    OGRGetOpenDS(int iDS) -> OGRDataSourceH
+"""
 function getopends(iDS::Integer)
     checknull(ccall((:OGRGetOpenDS,libgdal),OGRDataSourceH,(Cint,),iDS))
 end
 
+
+"""
+    OGRRegisterAll(void) -> void
+
+Register all drivers.
+"""
 function registerall()
     ccall((:OGRRegisterAll,libgdal),Void,())
 end
 
+
+"""
+    OGRCleanupAll(void) -> void
+
+Cleanup all OGR related resources.
+"""
 function cleanupall()
     ccall((:OGRCleanupAll,libgdal),Void,())
 end
 
+
+"""
+    OGR_SM_Create(OGRStyleTableH hStyleTable) -> OGRStyleMgrH
+
+OGRStyleMgr factory.
+
+### Parameters
+* **hStyleTable**: pointer to OGRStyleTable or NULL if not working with a style table.
+
+### Returns
+an handle to the new style manager object.
+"""
 function create(hStyleTable::OGRStyleTableH)
     checknull(ccall((:OGR_SM_Create,libgdal),OGRStyleMgrH,(OGRStyleTableH,),hStyleTable))
 end
 
+
+"""
+    OGR_SM_Destroy(OGRStyleMgrH hSM) -> void
+
+Destroy Style Manager.
+
+### Parameters
+* **hSM**: handle to the style manager to destroy.
+"""
 function destroy(hSM::OGRStyleMgrH)
     ccall((:OGR_SM_Destroy,libgdal),Void,(OGRStyleMgrH,),hSM)
 end
 
+
+"""
+    OGR_SM_InitFromFeature(OGRStyleMgrH hSM,
+                           OGRFeatureH hFeat) -> const char *
+
+Initialize style manager from the style string of a feature.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **hFeat**: handle to the new feature from which to read the style.
+
+### Returns
+a reference to the style string read from the feature, or NULL in case of error.
+"""
 function initfromfeature(hSM::OGRStyleMgrH,hFeat::OGRFeatureH)
     bytestring(ccall((:OGR_SM_InitFromFeature,libgdal),Ptr{UInt8},(OGRStyleMgrH,OGRFeatureH),hSM,hFeat))
 end
 
+
+"""
+    OGR_SM_InitStyleString(OGRStyleMgrH hSM,
+                           const char * pszStyleString) -> int
+
+Initialize style manager from the style string.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleString**: the style string to use (can be NULL).
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function initstylestring(hSM::OGRStyleMgrH,pszStyleString::AbstractString)
     ccall((:OGR_SM_InitStyleString,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8}),hSM,pszStyleString)
 end
 
+
+"""
+    OGR_SM_GetPartCount(OGRStyleMgrH hSM,
+                        const char * pszStyleString) -> int
+
+Get the number of parts in a style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleString**: (optional) the style string on which to operate. If NULL then the current style string stored in the style manager is used.
+
+### Returns
+the number of parts (style tools) in the style.
+"""
 function getpartcount(hSM::OGRStyleMgrH,pszStyleString::AbstractString)
     ccall((:OGR_SM_GetPartCount,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8}),hSM,pszStyleString)
 end
 
+
+"""
+    OGR_SM_GetPart(OGRStyleMgrH hSM,
+                   int nPartId,
+                   const char * pszStyleString) -> OGRStyleToolH
+
+Fetch a part (style tool) from the current style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **nPartId**: the part number (0-based index).
+* **pszStyleString**: (optional) the style string on which to operate. If NULL then the current style string stored in the style manager is used.
+
+### Returns
+OGRStyleToolH of the requested part (style tools) or NULL on error.
+"""
 function getpart(hSM::OGRStyleMgrH,nPartId::Integer,pszStyleString::AbstractString)
     checknull(ccall((:OGR_SM_GetPart,libgdal),OGRStyleToolH,(OGRStyleMgrH,Cint,Ptr{UInt8}),hSM,nPartId,pszStyleString))
 end
 
+
+"""
+    OGR_SM_AddPart(OGRStyleMgrH hSM,
+                   OGRStyleToolH hST) -> int
+
+Add a part (style tool) to the current style.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **hST**: the style tool defining the part to add.
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function addpart(hSM::OGRStyleMgrH,hST::OGRStyleToolH)
     ccall((:OGR_SM_AddPart,libgdal),Cint,(OGRStyleMgrH,OGRStyleToolH),hSM,hST)
 end
 
+
+"""
+    OGR_SM_AddStyle(OGRStyleMgrH hSM,
+                    const char * pszStyleName,
+                    const char * pszStyleString) -> int
+
+Add a style to the current style table.
+
+### Parameters
+* **hSM**: handle to the style manager.
+* **pszStyleName**: the name of the style to add.
+* **pszStyleString**: the style string to use, or NULL to use the style stored in the manager.
+
+### Returns
+TRUE on success, FALSE on errors.
+"""
 function addstyle(hSM::OGRStyleMgrH,pszStyleName::AbstractString,pszStyleString::AbstractString)
     ccall((:OGR_SM_AddStyle,libgdal),Cint,(OGRStyleMgrH,Ptr{UInt8},Ptr{UInt8}),hSM,pszStyleName,pszStyleString)
 end
 
+
+"""
+    OGR_ST_Create(OGRSTClassId eClassId) -> OGRStyleToolH
+
+OGRStyleTool factory.
+
+### Parameters
+* **eClassId**: subclass of style tool to create. One of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or OGRSTCLabel (4).
+
+### Returns
+an handle to the new style tool object or NULL if the creation failed.
+"""
 function create(eClassId::OGRSTClassId)
     checknull(ccall((:OGR_ST_Create,libgdal),OGRStyleToolH,(OGRSTClassId,),eClassId))
 end
 
+
+"""
+    OGR_ST_Destroy(OGRStyleToolH hST) -> void
+
+Destroy Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool to destroy.
+"""
 function destroy(hST::OGRStyleToolH)
     ccall((:OGR_ST_Destroy,libgdal),Void,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_GetType(OGRStyleToolH hST) -> OGRSTClassId
+
+Determine type of Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style tool type, one of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
+"""
 function gettype(hST::OGRStyleToolH)
     ccall((:OGR_ST_GetType,libgdal),OGRSTClassId,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_GetUnit(OGRStyleToolH hST) -> OGRSTUnitId
+
+Get Style Tool units.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style tool units.
+"""
 function getunit(hST::OGRStyleToolH)
     ccall((:OGR_ST_GetUnit,libgdal),OGRSTUnitId,(OGRStyleToolH,),hST)
 end
 
+
+"""
+    OGR_ST_SetUnit(OGRStyleToolH hST,
+                   OGRSTUnitId eUnit,
+                   double dfGroundPaperScale) -> void
+
+Set Style Tool units.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eUnit**: the new unit.
+* **dfGroundPaperScale**: ground to paper scale factor.
+"""
 function setunit(hST::OGRStyleToolH,eUnit::OGRSTUnitId,dfGroundPaperScale::Real)
     ccall((:OGR_ST_SetUnit,libgdal),Void,(OGRStyleToolH,OGRSTUnitId,Cdouble),hST,eUnit,dfGroundPaperScale)
 end
 
+
+"""
+    OGR_ST_GetParamStr(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> const char *
+
+Get Style Tool parameter value as string.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as string and sets bValueIsNull.
+"""
 function getparamstr(hST::OGRStyleToolH,eParam::Integer,bValueIsNull::Vector{Cint})
     bytestring(ccall((:OGR_ST_GetParamStr,libgdal),Ptr{UInt8},(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull))
 end
 
+
+"""
+    OGR_ST_GetParamNum(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> int
+
+Get Style Tool parameter value as an integer.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as integer and sets bValueIsNull.
+"""
 function getparamnum(hST::OGRStyleToolH,eParam::Integer,bValueIsNull::Vector{Cint})
     ccall((:OGR_ST_GetParamNum,libgdal),Cint,(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull)
 end
 
+
+"""
+    OGR_ST_GetParamDbl(OGRStyleToolH hST,
+                       int eParam,
+                       int * bValueIsNull) -> double
+
+Get Style Tool parameter value as a double.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **bValueIsNull**: pointer to an integer that will be set to TRUE or FALSE to indicate whether the parameter value is NULL.
+
+### Returns
+the parameter value as double and sets bValueIsNull.
+"""
 function getparamdbl(hST::OGRStyleToolH,eParam::Integer,bValueIsNull::Vector{Cint})
     ccall((:OGR_ST_GetParamDbl,libgdal),Cdouble,(OGRStyleToolH,Cint,Ptr{Cint}),hST,eParam,bValueIsNull)
 end
 
+
+"""
+    OGR_ST_SetParamStr(OGRStyleToolH hST,
+                       int eParam,
+                       const char * pszValue) -> void
+
+Set Style Tool parameter value from a string.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **pszValue**: the new parameter value
+"""
 function setparamstr(hST::OGRStyleToolH,eParam::Integer,pszValue::AbstractString)
     ccall((:OGR_ST_SetParamStr,libgdal),Void,(OGRStyleToolH,Cint,Ptr{UInt8}),hST,eParam,pszValue)
 end
 
+
+"""
+    OGR_ST_SetParamNum(OGRStyleToolH hST,
+                       int eParam,
+                       int nValue) -> void
+
+Set Style Tool parameter value from an integer.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **nValue**: the new parameter value
+"""
 function setparamnum(hST::OGRStyleToolH,eParam::Integer,nValue::Integer)
     ccall((:OGR_ST_SetParamNum,libgdal),Void,(OGRStyleToolH,Cint,Cint),hST,eParam,nValue)
 end
 
+
+"""
+    OGR_ST_SetParamDbl(OGRStyleToolH hST,
+                       int eParam,
+                       double dfValue) -> void
+
+Set Style Tool parameter value from a double.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **eParam**: the parameter id from the enumeration corresponding to the type of this style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam or OGRSTLabelParam enumerations)
+* **dfValue**: the new parameter value
+"""
 function setparamdbl(hST::OGRStyleToolH,eParam::Integer,dfValue::Real)
     ccall((:OGR_ST_SetParamDbl,libgdal),Void,(OGRStyleToolH,Cint,Cdouble),hST,eParam,dfValue)
 end
 
+
+"""
+    OGR_ST_GetStyleString(OGRStyleToolH hST) -> const char *
+
+Get the style string for this Style Tool.
+
+### Parameters
+* **hST**: handle to the style tool.
+
+### Returns
+the style string for this style tool or "" if the hST is invalid.
+"""
 function getstylestring(hST::OGRStyleToolH)
     bytestring(ccall((:OGR_ST_GetStyleString,libgdal),Ptr{UInt8},(OGRStyleToolH,),hST))
 end
 
+
+"""
+    OGR_ST_GetRGBFromString(OGRStyleToolH hST,
+                            const char * pszColor,
+                            int * pnRed,
+                            int * pnGreen,
+                            int * pnBlue,
+                            int * pnAlpha) -> int
+
+Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
+
+### Parameters
+* **hST**: handle to the style tool.
+* **pszColor**: the color to parse
+* **pnRed**: pointer to an int in which the red value will be returned
+* **pnGreen**: pointer to an int in which the green value will be returned
+* **pnBlue**: pointer to an int in which the blue value will be returned
+* **pnAlpha**: pointer to an int in which the (optional) alpha value will be returned
+
+### Returns
+TRUE if the color could be succesfully parsed, or FALSE in case of errors.
+"""
 function getrgbfromstring(hST::OGRStyleToolH,pszColor::AbstractString,pnRed::Vector{Cint},pnGreen::Vector{Cint},pnBlue::Vector{Cint},pnAlpha::Vector{Cint})
     ccall((:OGR_ST_GetRGBFromString,libgdal),Cint,(OGRStyleToolH,Ptr{UInt8},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),hST,pszColor,pnRed,pnGreen,pnBlue,pnAlpha)
 end
 
+
+"""
+    OGR_STBL_Create(void) -> OGRStyleTableH
+
+OGRStyleTable factory.
+
+### Returns
+an handle to the new style table object.
+"""
 function create()
     checknull(ccall((:OGR_STBL_Create,libgdal),OGRStyleTableH,()))
 end
 
+
+"""
+    OGR_STBL_Destroy(OGRStyleTableH hSTBL) -> void
+
+Destroy Style Table.
+
+### Parameters
+* **hSTBL**: handle to the style table to destroy.
+"""
 function destroy(hSTBL::OGRStyleTableH)
     ccall((:OGR_STBL_Destroy,libgdal),Void,(OGRStyleTableH,),hSTBL)
 end
 
+
+"""
+    OGR_STBL_AddStyle(OGRStyleTableH hStyleTable,
+                      const char * pszName,
+                      const char * pszStyleString) -> int
+
+Add a new style in the table.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszName**: the name the style to add.
+* **pszStyleString**: the style string to add.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function addstyle(hStyleTable::OGRStyleTableH,pszName::AbstractString,pszStyleString::AbstractString)
     ccall((:OGR_STBL_AddStyle,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8},Ptr{UInt8}),hStyleTable,pszName,pszStyleString)
 end
 
+
+"""
+    OGR_STBL_SaveStyleTable(OGRStyleTableH hStyleTable,
+                            const char * pszFilename) -> int
+
+Save a style table to a file.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszFilename**: the name of the file to save to.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function savestyletable(hStyleTable::OGRStyleTableH,pszFilename::AbstractString)
     ccall((:OGR_STBL_SaveStyleTable,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszFilename)
 end
 
+
+"""
+    OGR_STBL_LoadStyleTable(OGRStyleTableH hStyleTable,
+                            const char * pszFilename) -> int
+
+Load a style table from a file.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszFilename**: the name of the file to load from.
+
+### Returns
+TRUE on success, FALSE on error
+"""
 function loadstyletable(hStyleTable::OGRStyleTableH,pszFilename::AbstractString)
     ccall((:OGR_STBL_LoadStyleTable,libgdal),Cint,(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszFilename)
 end
 
+
+"""
+    OGR_STBL_Find(OGRStyleTableH hStyleTable,
+                  const char * pszName) -> const char *
+
+Get a style string by name.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+* **pszName**: the name of the style string to find.
+
+### Returns
+the style string matching the name or NULL if not found or error.
+"""
 function find(hStyleTable::OGRStyleTableH,pszName::AbstractString)
     bytestring(ccall((:OGR_STBL_Find,libgdal),Ptr{UInt8},(OGRStyleTableH,Ptr{UInt8}),hStyleTable,pszName))
 end
 
+
+"""
+    OGR_STBL_ResetStyleStringReading(OGRStyleTableH hStyleTable) -> void
+
+Reset the next style pointer to 0.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+"""
 function resetstylestringreading(hStyleTable::OGRStyleTableH)
     ccall((:OGR_STBL_ResetStyleStringReading,libgdal),Void,(OGRStyleTableH,),hStyleTable)
 end
 
+
+"""
+    OGR_STBL_GetNextStyle(OGRStyleTableH hStyleTable) -> const char *
+
+Get the next style string from the table.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+
+### Returns
+the next style string or NULL on error.
+"""
 function getnextstyle(hStyleTable::OGRStyleTableH)
     bytestring(ccall((:OGR_STBL_GetNextStyle,libgdal),Ptr{UInt8},(OGRStyleTableH,),hStyleTable))
 end
 
+
+"""
+    OGR_STBL_GetLastStyleName(OGRStyleTableH hStyleTable) -> const char *
+
+Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
+
+### Parameters
+* **hStyleTable**: handle to the style table.
+
+### Returns
+the Name of the last style string or NULL on error.
+"""
 function getlaststylename(hStyleTable::OGRStyleTableH)
     bytestring(ccall((:OGR_STBL_GetLastStyleName,libgdal),Ptr{UInt8},(OGRStyleTableH,),hStyleTable))
 end
-

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -1,576 +1,1829 @@
+
+
+"""
+    OSRAxisEnumToName(OGRAxisOrientation eOrientation) -> const char *
+
+Return the string representation for the OGRAxisOrientation enumeration.
+
+### Returns
+an internal string
+"""
 function axisenumtoname(eOrientation::OGRAxisOrientation)
     bytestring(ccall((:OSRAxisEnumToName,libgdal),Ptr{UInt8},(OGRAxisOrientation,),eOrientation))
 end
 
+
+"""
+    OSRNewSpatialReference(const char *) -> OGRSpatialReferenceH
+
+Constructor.
+"""
 function newspatialreference(arg1::AbstractString)
     checknull(ccall((:OSRNewSpatialReference,libgdal),OGRSpatialReferenceH,(Ptr{UInt8},),arg1))
 end
 
+
+"""
+    OSRCloneGeogCS(OGRSpatialReferenceH) -> OGRSpatialReferenceH
+
+Make a duplicate of the GEOGCS node of this OGRSpatialReference object.
+"""
 function clonegeogcs(arg1::OGRSpatialReferenceH)
     checknull(ccall((:OSRCloneGeogCS,libgdal),OGRSpatialReferenceH,(OGRSpatialReferenceH,),arg1))
 end
 
+
+"""
+    OSRClone(OGRSpatialReferenceH) -> OGRSpatialReferenceH
+
+Make a duplicate of this OGRSpatialReference.
+"""
 function clone(arg1::OGRSpatialReferenceH)
     checknull(ccall((:OSRClone,libgdal),OGRSpatialReferenceH,(OGRSpatialReferenceH,),arg1))
 end
 
+
+"""
+    OSRDestroySpatialReference(OGRSpatialReferenceH) -> void
+
+OGRSpatialReference destructor.
+
+### Parameters
+* **hSRS**: the object to delete
+"""
 function destroyspatialreference(arg1::OGRSpatialReferenceH)
     ccall((:OSRDestroySpatialReference,libgdal),Void,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRReference(OGRSpatialReferenceH) -> int
+
+Increments the reference count by one.
+"""
 function reference(arg1::OGRSpatialReferenceH)
     ccall((:OSRReference,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRDereference(OGRSpatialReferenceH) -> int
+
+Decrements the reference count by one.
+"""
 function dereference(arg1::OGRSpatialReferenceH)
     ccall((:OSRDereference,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRRelease(OGRSpatialReferenceH) -> void
+
+Decrements the reference count by one, and destroy if zero.
+"""
 function release(arg1::OGRSpatialReferenceH)
     ccall((:OSRRelease,libgdal),Void,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRValidate(OGRSpatialReferenceH) -> OGRErr
+
+Validate SRS tokens.
+"""
 function validate(arg1::OGRSpatialReferenceH)
     ccall((:OSRValidate,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRFixupOrdering(OGRSpatialReferenceH) -> OGRErr
+
+Correct parameter ordering to match CT Specification.
+"""
 function fixupordering(arg1::OGRSpatialReferenceH)
     ccall((:OSRFixupOrdering,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRFixup(OGRSpatialReferenceH) -> OGRErr
+
+Fixup as needed.
+"""
 function fixup(arg1::OGRSpatialReferenceH)
     ccall((:OSRFixup,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRStripCTParms(OGRSpatialReferenceH) -> OGRErr
+
+Strip OGC CT Parameters.
+"""
 function stripctparms(arg1::OGRSpatialReferenceH)
     ccall((:OSRStripCTParms,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRImportFromEPSG(OGRSpatialReferenceH hSRS,
+                      int nCode) -> OGRErr
+
+Initialize SRS based on EPSG GCS or PCS code.
+"""
 function importfromepsg(arg1::OGRSpatialReferenceH,arg2::Integer)
     ccall((:OSRImportFromEPSG,libgdal),OGRErr,(OGRSpatialReferenceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromEPSGA(OGRSpatialReferenceH hSRS,
+                       int nCode) -> OGRErr
+
+Initialize SRS based on EPSG GCS or PCS code.
+"""
 function importfromepsga(arg1::OGRSpatialReferenceH,arg2::Integer)
     ccall((:OSRImportFromEPSGA,libgdal),OGRErr,(OGRSpatialReferenceH,Cint),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromWkt(OGRSpatialReferenceH,
+                     char **) -> OGRErr
+
+Import from WKT string.
+"""
 function importfromwkt(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRImportFromWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromProj4(OGRSpatialReferenceH,
+                       const char *) -> OGRErr
+
+Import PROJ.4 coordinate string.
+"""
 function importfromproj4(arg1::OGRSpatialReferenceH,arg2::AbstractString)
     ccall((:OSRImportFromProj4,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromESRI(OGRSpatialReferenceH,
+                      char **) -> OGRErr
+
+Import coordinate system from ESRI .prj format(s).
+"""
 function importfromesri(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRImportFromESRI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromPCI(OGRSpatialReferenceH hSRS,
+                     const char *,
+                     const char *,
+                     double *) -> OGRErr
+
+Import coordinate system from PCI projection definition.
+"""
 function importfrompci(hSRS::OGRSpatialReferenceH,arg1::AbstractString,arg2::AbstractString,arg3::Vector{Float64})
     ccall((:OSRImportFromPCI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{Cdouble}),hSRS,arg1,arg2,arg3)
 end
 
+
+"""
+    OSRImportFromUSGS(OGRSpatialReferenceH,
+                      long,
+                      long,
+                      double *,
+                      long) -> OGRErr
+
+Import coordinate system from USGS projection definition.
+"""
 function importfromusgs(arg1::OGRSpatialReferenceH,arg2::Clong,arg3::Clong,arg4::Vector{Float64},arg5::Clong)
     ccall((:OSRImportFromUSGS,libgdal),OGRErr,(OGRSpatialReferenceH,Clong,Clong,Ptr{Cdouble},Clong),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRImportFromXML(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Import coordinate system from XML format (GML only currently).
+"""
 function importfromxml(arg1::OGRSpatialReferenceH,arg2::AbstractString)
     ccall((:OSRImportFromXML,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromDict(OGRSpatialReferenceH,
+                      const char *,
+                      const char *) -> OGRErr
+"""
 function importfromdict(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::AbstractString)
     ccall((:OSRImportFromDict,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRImportFromPanorama(OGRSpatialReferenceH,
+                          long,
+                          long,
+                          long,
+                          double *) -> OGRErr
+"""
 function importfrompanorama(arg1::OGRSpatialReferenceH,arg2::Clong,arg3::Clong,arg4::Clong,arg5::Vector{Float64})
     ccall((:OSRImportFromPanorama,libgdal),OGRErr,(OGRSpatialReferenceH,Clong,Clong,Clong,Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRImportFromOzi(OGRSpatialReferenceH,
+                     const char *const *) -> OGRErr
+
+Import coordinate system from OziExplorer projection definition.
+
+### Parameters
+* **hSRS**: spatial reference object.
+* **papszLines**: Map file lines. This is an array of strings containing the whole OziExplorer .MAP file. The array is terminated by a NULL pointer.
+
+### Returns
+OGRERR_NONE on success or an error code in case of failure.
+"""
 function importfromozi(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRImportFromOzi,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromMICoordSys(OGRSpatialReferenceH,
+                            const char *) -> OGRErr
+
+Import Mapinfo style CoordSys definition.
+"""
 function importfrommicoordsys(arg1::OGRSpatialReferenceH,arg2::AbstractString)
     ccall((:OSRImportFromMICoordSys,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRImportFromERM(OGRSpatialReferenceH,
+                     const char *,
+                     const char *,
+                     const char *) -> OGRErr
+
+Create OGR WKT from ERMapper projection definitions.
+"""
 function importfromerm(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::AbstractString,arg4::AbstractString)
     ccall((:OSRImportFromERM,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRImportFromUrl(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Set spatial reference from a URL.
+"""
 function importfromurl(arg1::OGRSpatialReferenceH,arg2::AbstractString)
     ccall((:OSRImportFromUrl,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToWkt(OGRSpatialReferenceH,
+                   char **) -> OGRErr
+
+Convert this SRS into WKT format.
+"""
 function exporttowkt(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRExportToWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToPrettyWkt(OGRSpatialReferenceH,
+                         char **,
+                         int) -> OGRErr
+
+Convert this SRS into a a nicely formatted WKT string for display to a person.
+"""
 function exporttoprettywkt(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String},arg3::Integer)
     ccall((:OSRExportToPrettyWkt,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Cint),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRExportToProj4(OGRSpatialReferenceH,
+                     char **) -> OGRErr
+
+Export coordinate system in PROJ.4 format.
+"""
 function exporttoproj4(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRExportToProj4,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToPCI(OGRSpatialReferenceH,
+                   char **,
+                   char **,
+                   double **) -> OGRErr
+
+Export coordinate system in PCI projection definition.
+"""
 function exporttopci(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String},arg3::Vector{UTF8String},arg4::Ptr{Ptr{Cdouble}})
     ccall((:OSRExportToPCI,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Ptr{Cdouble}}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRExportToUSGS(OGRSpatialReferenceH,
+                    long *,
+                    long *,
+                    double **,
+                    long *) -> OGRErr
+
+Export coordinate system in USGS GCTP projection definition.
+"""
 function exporttousgs(arg1::OGRSpatialReferenceH,arg2::Ptr{Clong},arg3::Ptr{Clong},arg4::Ptr{Ptr{Cdouble}},arg5::Ptr{Clong})
     ccall((:OSRExportToUSGS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Clong},Ptr{Clong},Ptr{Ptr{Cdouble}},Ptr{Clong}),arg1,arg2,arg3,arg4,arg5)
 end
 
+
+"""
+    OSRExportToXML(OGRSpatialReferenceH,
+                   char **,
+                   const char *) -> OGRErr
+
+Export coordinate system in XML format.
+"""
 function exporttoxml(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String},arg3::AbstractString)
     ccall((:OSRExportToXML,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}},Ptr{UInt8}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRExportToPanorama(OGRSpatialReferenceH,
+                        long *,
+                        long *,
+                        long *,
+                        long *,
+                        double *) -> OGRErr
+"""
 function exporttopanorama(arg1::OGRSpatialReferenceH,arg2::Ptr{Clong},arg3::Ptr{Clong},arg4::Ptr{Clong},arg5::Ptr{Clong},arg6::Vector{Float64})
     ccall((:OSRExportToPanorama,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cdouble}),arg1,arg2,arg3,arg4,arg5,arg6)
 end
 
+
+"""
+    OSRExportToMICoordSys(OGRSpatialReferenceH,
+                          char **) -> OGRErr
+
+Export coordinate system in Mapinfo style CoordSys format.
+"""
 function exporttomicoordsys(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRExportToMICoordSys,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRExportToERM(OGRSpatialReferenceH,
+                   char *,
+                   char *,
+                   char *) -> OGRErr
+
+Convert coordinate system to ERMapper format.
+"""
 function exporttoerm(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::AbstractString,arg4::AbstractString)
     ccall((:OSRExportToERM,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8}),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRMorphToESRI(OGRSpatialReferenceH) -> OGRErr
+
+Convert in place to ESRI WKT format.
+"""
 function morphtoesri(arg1::OGRSpatialReferenceH)
     ccall((:OSRMorphToESRI,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRMorphFromESRI(OGRSpatialReferenceH) -> OGRErr
+
+Convert in place from ESRI WKT format.
+"""
 function morphfromesri(arg1::OGRSpatialReferenceH)
     ccall((:OSRMorphFromESRI,libgdal),OGRErr,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRSetAttrValue(OGRSpatialReferenceH hSRS,
+                    const char * pszNodePath,
+                    const char * pszNewNodeValue) -> OGRErr
+
+Set attribute value in spatial reference.
+"""
 function setattrvalue(hSRS::OGRSpatialReferenceH,pszNodePath::AbstractString,pszNewNodeValue::AbstractString)
     ccall((:OSRSetAttrValue,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8}),hSRS,pszNodePath,pszNewNodeValue)
 end
 
+
+"""
+    OSRGetAttrValue(OGRSpatialReferenceH hSRS,
+                    const char * pszName,
+                    int iChild) -> const char *
+
+Fetch indicated attribute of named node.
+"""
 function getattrvalue(hSRS::OGRSpatialReferenceH,pszName::AbstractString,iChild::Integer)
     bytestring(ccall((:OSRGetAttrValue,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8},Cint),hSRS,pszName,iChild))
 end
 
+
+"""
+    OSRSetAngularUnits(OGRSpatialReferenceH,
+                       const char *,
+                       double) -> OGRErr
+
+Set the angular units for the geographic coordinate system.
+"""
 function setangularunits(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Real)
     ccall((:OSRSetAngularUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetAngularUnits(OGRSpatialReferenceH,
+                       char **) -> double
+
+Fetch angular geographic coordinate system units.
+"""
 function getangularunits(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRGetAngularUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRSetLinearUnits(OGRSpatialReferenceH,
+                      const char *,
+                      double) -> OGRErr
+
+Set the linear units for the projection.
+"""
 function setlinearunits(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Real)
     ccall((:OSRSetLinearUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRSetTargetLinearUnits(OGRSpatialReferenceH,
+                            const char *,
+                            const char *,
+                            double) -> OGRErr
+
+Set the linear units for the target node.
+"""
 function settargetlinearunits(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::AbstractString,arg4::Real)
     ccall((:OSRSetTargetLinearUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cdouble),arg1,arg2,arg3,arg4)
 end
 
+
+"""
+    OSRSetLinearUnitsAndUpdateParameters(OGRSpatialReferenceH,
+                                         const char *,
+                                         double) -> OGRErr
+
+Set the linear units for the projection.
+"""
 function setlinearunitsandupdateparameters(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Real)
     ccall((:OSRSetLinearUnitsAndUpdateParameters,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetLinearUnits(OGRSpatialReferenceH,
+                      char **) -> double
+
+Fetch linear projection units.
+"""
 function getlinearunits(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRGetLinearUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRGetTargetLinearUnits(OGRSpatialReferenceH,
+                            const char *,
+                            char **) -> double
+
+Fetch linear projection units.
+"""
 function gettargetlinearunits(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Vector{UTF8String})
     ccall((:OSRGetTargetLinearUnits,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{Ptr{UInt8}}),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetPrimeMeridian(OGRSpatialReferenceH,
+                        char **) -> double
+
+Fetch prime meridian info.
+"""
 function getprimemeridian(arg1::OGRSpatialReferenceH,arg2::Vector{UTF8String})
     ccall((:OSRGetPrimeMeridian,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{Ptr{UInt8}}),arg1,arg2)
 end
 
+
+"""
+    OSRIsGeographic(OGRSpatialReferenceH) -> int
+
+Check if geographic coordinate system.
+"""
 function isgeographic(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsGeographic,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsLocal(OGRSpatialReferenceH) -> int
+
+Check if local coordinate system.
+"""
 function islocal(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsLocal,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsProjected(OGRSpatialReferenceH) -> int
+
+Check if projected coordinate system.
+"""
 function isprojected(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsProjected,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsCompound(OGRSpatialReferenceH) -> int
+
+Check if the coordinate system is compound.
+"""
 function iscompound(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsCompound,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsGeocentric(OGRSpatialReferenceH) -> int
+
+Check if geocentric coordinate system.
+"""
 function isgeocentric(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsGeocentric,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsVertical(OGRSpatialReferenceH) -> int
+
+Check if vertical coordinate system.
+"""
 function isvertical(arg1::OGRSpatialReferenceH)
     ccall((:OSRIsVertical,libgdal),Cint,(OGRSpatialReferenceH,),arg1)
 end
 
+
+"""
+    OSRIsSameGeogCS(OGRSpatialReferenceH,
+                    OGRSpatialReferenceH) -> int
+
+Do the GeogCS'es match?
+"""
 function issamegeogcs(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSameGeogCS,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRIsSameVertCS(OGRSpatialReferenceH,
+                    OGRSpatialReferenceH) -> int
+
+Do the VertCS'es match?
+"""
 function issamevertcs(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSameVertCS,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRIsSame(OGRSpatialReferenceH,
+              OGRSpatialReferenceH) -> int
+
+Do these two spatial references describe the same system ?
+"""
 function issame(arg1::OGRSpatialReferenceH,arg2::OGRSpatialReferenceH)
     ccall((:OSRIsSame,libgdal),Cint,(OGRSpatialReferenceH,OGRSpatialReferenceH),arg1,arg2)
 end
 
+
+"""
+    OSRSetLocalCS(OGRSpatialReferenceH hSRS,
+                  const char * pszName) -> OGRErr
+
+Set the user visible LOCAL_CS name.
+"""
 function setlocalcs(hSRS::OGRSpatialReferenceH,pszName::AbstractString)
     ccall((:OSRSetLocalCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetProjCS(OGRSpatialReferenceH hSRS,
+                 const char * pszName) -> OGRErr
+
+Set the user visible PROJCS name.
+"""
 function setprojcs(hSRS::OGRSpatialReferenceH,pszName::AbstractString)
     ccall((:OSRSetProjCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetGeocCS(OGRSpatialReferenceH hSRS,
+                 const char * pszName) -> OGRErr
+
+Set the user visible PROJCS name.
+"""
 function setgeoccs(hSRS::OGRSpatialReferenceH,pszName::AbstractString)
     ccall((:OSRSetGeocCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetWellKnownGeogCS(OGRSpatialReferenceH hSRS,
+                          const char * pszName) -> OGRErr
+
+Set a GeogCS based on well known name.
+"""
 function setwellknowngeogcs(hSRS::OGRSpatialReferenceH,pszName::AbstractString)
     ccall((:OSRSetWellKnownGeogCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszName)
 end
 
+
+"""
+    OSRSetFromUserInput(OGRSpatialReferenceH hSRS,
+                        const char *) -> OGRErr
+
+Set spatial reference from various text formats.
+"""
 function setfromuserinput(hSRS::OGRSpatialReferenceH,arg1::AbstractString)
     ccall((:OSRSetFromUserInput,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,arg1)
 end
 
+
+"""
+    OSRCopyGeogCSFrom(OGRSpatialReferenceH hSRS,
+                      OGRSpatialReferenceH hSrcSRS) -> OGRErr
+
+Copy GEOGCS from another OGRSpatialReference.
+"""
 function copygeogcsfrom(hSRS::OGRSpatialReferenceH,hSrcSRS::OGRSpatialReferenceH)
     ccall((:OSRCopyGeogCSFrom,libgdal),OGRErr,(OGRSpatialReferenceH,OGRSpatialReferenceH),hSRS,hSrcSRS)
 end
 
+
+"""
+    OSRSetTOWGS84(OGRSpatialReferenceH hSRS,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double,
+                  double) -> OGRErr
+
+Set the Bursa-Wolf conversion to WGS84.
+"""
 function settowgs84(hSRS::OGRSpatialReferenceH,arg1::Real,arg2::Real,arg3::Real,arg4::Real,arg5::Real,arg6::Real,arg7::Real)
     ccall((:OSRSetTOWGS84,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,arg1,arg2,arg3,arg4,arg5,arg6,arg7)
 end
 
+
+"""
+    OSRGetTOWGS84(OGRSpatialReferenceH hSRS,
+                  double *,
+                  int) -> OGRErr
+
+Fetch TOWGS84 parameters, if available.
+"""
 function gettowgs84(hSRS::OGRSpatialReferenceH,arg1::Vector{Float64},arg2::Integer)
     ccall((:OSRGetTOWGS84,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{Cdouble},Cint),hSRS,arg1,arg2)
 end
 
+
+"""
+    OSRSetCompoundCS(OGRSpatialReferenceH hSRS,
+                     const char * pszName,
+                     OGRSpatialReferenceH hHorizSRS,
+                     OGRSpatialReferenceH hVertSRS) -> OGRErr
+
+Setup a compound coordinate system.
+"""
 function setcompoundcs(hSRS::OGRSpatialReferenceH,pszName::AbstractString,hHorizSRS::OGRSpatialReferenceH,hVertSRS::OGRSpatialReferenceH)
     ccall((:OSRSetCompoundCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},OGRSpatialReferenceH,OGRSpatialReferenceH),hSRS,pszName,hHorizSRS,hVertSRS)
 end
 
+
+"""
+    OSRSetGeogCS(OGRSpatialReferenceH hSRS,
+                 const char * pszGeogName,
+                 const char * pszDatumName,
+                 const char * pszEllipsoidName,
+                 double dfSemiMajor,
+                 double dfInvFlattening,
+                 const char * pszPMName,
+                 double dfPMOffset,
+                 const char * pszUnits,
+                 double dfConvertToRadians) -> OGRErr
+
+Set geographic coordinate system.
+"""
 function setgeogcs(hSRS::OGRSpatialReferenceH,pszGeogName::AbstractString,pszDatumName::AbstractString,pszEllipsoidName::AbstractString,dfSemiMajor::Real,dfInvFlattening::Real,pszPMName::AbstractString,dfPMOffset::Real,pszUnits::AbstractString,dfConvertToRadians::Real)
     ccall((:OSRSetGeogCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Cdouble,Cdouble,Ptr{UInt8},Cdouble,Ptr{UInt8},Cdouble),hSRS,pszGeogName,pszDatumName,pszEllipsoidName,dfSemiMajor,dfInvFlattening,pszPMName,dfPMOffset,pszUnits,dfConvertToRadians)
 end
 
+
+"""
+    OSRSetVertCS(OGRSpatialReferenceH hSRS,
+                 const char * pszVertCSName,
+                 const char * pszVertDatumName,
+                 int nVertDatumType) -> OGRErr
+
+Setup the vertical coordinate system.
+"""
 function setvertcs(hSRS::OGRSpatialReferenceH,pszVertCSName::AbstractString,pszVertDatumName::AbstractString,nVertDatumType::Integer)
     ccall((:OSRSetVertCS,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cint),hSRS,pszVertCSName,pszVertDatumName,nVertDatumType)
 end
 
+
+"""
+    OSRGetSemiMajor(OGRSpatialReferenceH,
+                    OGRErr *) -> double
+
+Get spheroid semi major axis.
+"""
 function getsemimajor(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetSemiMajor,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRGetSemiMinor(OGRSpatialReferenceH,
+                    OGRErr *) -> double
+
+Get spheroid semi minor axis.
+"""
 function getsemiminor(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetSemiMinor,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRGetInvFlattening(OGRSpatialReferenceH,
+                        OGRErr *) -> double
+
+Get spheroid inverse flattening.
+"""
 function getinvflattening(arg1::OGRSpatialReferenceH,arg2::Ptr{OGRErr})
     ccall((:OSRGetInvFlattening,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{OGRErr}),arg1,arg2)
 end
 
+
+"""
+    OSRSetAuthority(OGRSpatialReferenceH hSRS,
+                    const char * pszTargetKey,
+                    const char * pszAuthority,
+                    int nCode) -> OGRErr
+
+Set the authority for a node.
+"""
 function setauthority(hSRS::OGRSpatialReferenceH,pszTargetKey::AbstractString,pszAuthority::AbstractString,nCode::Integer)
     ccall((:OSRSetAuthority,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Ptr{UInt8},Cint),hSRS,pszTargetKey,pszAuthority,nCode)
 end
 
+
+"""
+    OSRGetAuthorityCode(OGRSpatialReferenceH hSRS,
+                        const char * pszTargetKey) -> const char *
+
+Get the authority code for a node.
+"""
 function getauthoritycode(hSRS::OGRSpatialReferenceH,pszTargetKey::AbstractString)
     bytestring(ccall((:OSRGetAuthorityCode,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszTargetKey))
 end
 
+
+"""
+    OSRGetAuthorityName(OGRSpatialReferenceH hSRS,
+                        const char * pszTargetKey) -> const char *
+
+Get the authority name for a node.
+"""
 function getauthorityname(hSRS::OGRSpatialReferenceH,pszTargetKey::AbstractString)
     bytestring(ccall((:OSRGetAuthorityName,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8}),hSRS,pszTargetKey))
 end
 
+
+"""
+    OSRSetProjection(OGRSpatialReferenceH,
+                     const char *) -> OGRErr
+
+Set a projection name.
+"""
 function setprojection(arg1::OGRSpatialReferenceH,arg2::AbstractString)
     ccall((:OSRSetProjection,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8}),arg1,arg2)
 end
 
+
+"""
+    OSRSetProjParm(OGRSpatialReferenceH,
+                   const char *,
+                   double) -> OGRErr
+
+Set a projection parameter value.
+"""
 function setprojparm(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Real)
     ccall((:OSRSetProjParm,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetProjParm(OGRSpatialReferenceH hSRS,
+                   const char * pszParmName,
+                   double dfDefault,
+                   OGRErr *) -> double
+
+Fetch a projection parameter value.
+"""
 function getprojparm(hSRS::OGRSpatialReferenceH,pszParmName::AbstractString,dfDefault::Real,arg1::Ptr{OGRErr})
     ccall((:OSRGetProjParm,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Ptr{OGRErr}),hSRS,pszParmName,dfDefault,arg1)
 end
 
+
+"""
+    OSRSetNormProjParm(OGRSpatialReferenceH,
+                       const char *,
+                       double) -> OGRErr
+
+Set a projection parameter with a normalized value.
+"""
 function setnormprojparm(arg1::OGRSpatialReferenceH,arg2::AbstractString,arg3::Real)
     ccall((:OSRSetNormProjParm,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble),arg1,arg2,arg3)
 end
 
+
+"""
+    OSRGetNormProjParm(OGRSpatialReferenceH hSRS,
+                       const char * pszParmName,
+                       double dfDefault,
+                       OGRErr *) -> double
+
+This function is the same as OGRSpatialReference::
+"""
 function getnormprojparm(hSRS::OGRSpatialReferenceH,pszParmName::AbstractString,dfDefault::Real,arg1::Ptr{OGRErr})
     ccall((:OSRGetNormProjParm,libgdal),Cdouble,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Ptr{OGRErr}),hSRS,pszParmName,dfDefault,arg1)
 end
 
+
+"""
+    OSRSetUTM(OGRSpatialReferenceH hSRS,
+              int nZone,
+              int bNorth) -> OGRErr
+
+Set UTM projection definition.
+"""
 function setutm(hSRS::OGRSpatialReferenceH,nZone::Integer,bNorth::Integer)
     ccall((:OSRSetUTM,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint),hSRS,nZone,bNorth)
 end
 
+
+"""
+    OSRGetUTMZone(OGRSpatialReferenceH hSRS,
+                  int * pbNorth) -> int
+
+Get utm zone information.
+"""
 function getutmzone(hSRS::OGRSpatialReferenceH,pbNorth::Vector{Cint})
     ccall((:OSRGetUTMZone,libgdal),Cint,(OGRSpatialReferenceH,Ptr{Cint}),hSRS,pbNorth)
 end
 
+
+"""
+    OSRSetStatePlane(OGRSpatialReferenceH hSRS,
+                     int nZone,
+                     int bNAD83) -> OGRErr
+
+Set State Plane projection definition.
+"""
 function setstateplane(hSRS::OGRSpatialReferenceH,nZone::Integer,bNAD83::Integer)
     ccall((:OSRSetStatePlane,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint),hSRS,nZone,bNAD83)
 end
 
+
+"""
+    OSRSetStatePlaneWithUnits(OGRSpatialReferenceH hSRS,
+                              int nZone,
+                              int bNAD83,
+                              const char * pszOverrideUnitName,
+                              double dfOverrideUnit) -> OGRErr
+
+Set State Plane projection definition.
+"""
 function setstateplanewithunits(hSRS::OGRSpatialReferenceH,nZone::Integer,bNAD83::Integer,pszOverrideUnitName::AbstractString,dfOverrideUnit::Real)
     ccall((:OSRSetStatePlaneWithUnits,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cint,Ptr{UInt8},Cdouble),hSRS,nZone,bNAD83,pszOverrideUnitName,dfOverrideUnit)
 end
 
+
+"""
+    OSRAutoIdentifyEPSG(OGRSpatialReferenceH hSRS) -> OGRErr
+
+Set EPSG authority info if possible.
+"""
 function autoidentifyepsg(hSRS::OGRSpatialReferenceH)
     ccall((:OSRAutoIdentifyEPSG,libgdal),OGRErr,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSREPSGTreatsAsLatLong(OGRSpatialReferenceH hSRS) -> int
+
+This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having lat/long coordinate ordering.
+"""
 function epsgtreatsaslatlong(hSRS::OGRSpatialReferenceH)
     ccall((:OSREPSGTreatsAsLatLong,libgdal),Cint,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH hSRS) -> int
+
+This function returns TRUE if EPSG feels this geographic coordinate system should be treated as having northing/easting coordinate ordering.
+"""
 function epsgtreatsasnorthingeasting(hSRS::OGRSpatialReferenceH)
     ccall((:OSREPSGTreatsAsNorthingEasting,libgdal),Cint,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSRGetAxis(OGRSpatialReferenceH hSRS,
+               const char * pszTargetKey,
+               int iAxis,
+               OGRAxisOrientation * peOrientation) -> const char *
+
+Fetch the orientation of one axis.
+"""
 function getaxis(hSRS::OGRSpatialReferenceH,pszTargetKey::AbstractString,iAxis::Integer,peOrientation::Ptr{OGRAxisOrientation})
     bytestring(ccall((:OSRGetAxis,libgdal),Ptr{UInt8},(OGRSpatialReferenceH,Ptr{UInt8},Cint,Ptr{OGRAxisOrientation}),hSRS,pszTargetKey,iAxis,peOrientation))
 end
 
+
+"""
+    OSRSetAxes(const char * pszTargetKey,
+               const char * pszXAxisName,
+               OGRAxisOrientation eXAxisOrientation,
+               const char * pszYAxisName,
+               OGRAxisOrientation eYAxisOrientation) -> OGRErr
+"""
 function setaxes(pszTargetKey::AbstractString,pszXAxisName::AbstractString,eXAxisOrientation::OGRAxisOrientation,pszYAxisName::AbstractString,eYAxisOrientation::OGRAxisOrientation)
     ccall((:OSRSetAxes,libgdal),OGRErr,(Ptr{UInt8},Ptr{UInt8},OGRAxisOrientation,Ptr{UInt8},OGRAxisOrientation),pszTargetKey,pszXAxisName,eXAxisOrientation,pszYAxisName,eYAxisOrientation)
 end
 
+
+"""
+    OSRSetACEA(OGRSpatialReferenceH hSRS,
+               double dfStdP1,
+               double dfStdP2,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Albers Conic Equal Area.
+"""
 function setacea(hSRS::OGRSpatialReferenceH,dfStdP1::Real,dfStdP2::Real,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetACEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetAE(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Azimuthal Equidistant.
+"""
 function setae(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetAE,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetBonne(OGRSpatialReferenceH hSRS,
+                double dfStandardParallel,
+                double dfCentralMeridian,
+                double dfFalseEasting,
+                double dfFalseNorthing) -> OGRErr
+
+Bonne.
+"""
 function setbonne(hSRS::OGRSpatialReferenceH,dfStandardParallel::Real,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetBonne,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStandardParallel,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetCEA(OGRSpatialReferenceH hSRS,
+              double dfStdP1,
+              double dfCentralMeridian,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Cylindrical Equal Area.
+"""
 function setcea(hSRS::OGRSpatialReferenceH,dfStdP1::Real,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetCEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetCS(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Cassini-Soldner.
+"""
 function setcs(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetCS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEC(OGRSpatialReferenceH hSRS,
+             double dfStdP1,
+             double dfStdP2,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Equidistant Conic.
+"""
 function setec(hSRS::OGRSpatialReferenceH,dfStdP1::Real,dfStdP2::Real,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckert(OGRSpatialReferenceH hSRS,
+                 int nVariation,
+                 double dfCentralMeridian,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Eckert I-VI.
+"""
 function seteckert(hSRS::OGRSpatialReferenceH,nVariation::Integer,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEckert,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cdouble,Cdouble,Cdouble),hSRS,nVariation,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckertIV(OGRSpatialReferenceH hSRS,
+                   double dfCentralMeridian,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Eckert IV.
+"""
 function seteckertiv(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEckertIV,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEckertVI(OGRSpatialReferenceH hSRS,
+                   double dfCentralMeridian,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Eckert VI.
+"""
 function seteckertvi(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEckertVI,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEquirectangular(OGRSpatialReferenceH hSRS,
+                          double dfCenterLat,
+                          double dfCenterLong,
+                          double dfFalseEasting,
+                          double dfFalseNorthing) -> OGRErr
+
+Equirectangular.
+"""
 function setequirectangular(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEquirectangular,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetEquirectangular2(OGRSpatialReferenceH hSRS,
+                           double dfCenterLat,
+                           double dfCenterLong,
+                           double dfPseudoStdParallel1,
+                           double dfFalseEasting,
+                           double dfFalseNorthing) -> OGRErr
+
+Equirectangular generalized form.
+"""
 function setequirectangular2(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfPseudoStdParallel1::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetEquirectangular2,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfPseudoStdParallel1,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGS(OGRSpatialReferenceH hSRS,
+             double dfCentralMeridian,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Gall Stereograpic.
+"""
 function setgs(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetGS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGH(OGRSpatialReferenceH hSRS,
+             double dfCentralMeridian,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Goode Homolosine.
+"""
 function setgh(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetGH,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetIGH(OGRSpatialReferenceH hSRS) -> OGRErr
+
+Interrupted Goode Homolosine.
+"""
 function setigh(hSRS::OGRSpatialReferenceH)
     ccall((:OSRSetIGH,libgdal),OGRErr,(OGRSpatialReferenceH,),hSRS)
 end
 
+
+"""
+    OSRSetGEOS(OGRSpatialReferenceH hSRS,
+               double dfCentralMeridian,
+               double dfSatelliteHeight,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+GEOS - Geostationary Satellite View.
+"""
 function setgeos(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfSatelliteHeight::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetGEOS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfSatelliteHeight,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGaussSchreiberTMercator(OGRSpatialReferenceH hSRS,
+                                  double dfCenterLat,
+                                  double dfCenterLong,
+                                  double dfScale,
+                                  double dfFalseEasting,
+                                  double dfFalseNorthing) -> OGRErr
+
+Gauss Schreiber Transverse Mercator.
+"""
 function setgaussschreibertmercator(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetGaussSchreiberTMercator,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetGnomonic(OGRSpatialReferenceH hSRS,
+                   double dfCenterLat,
+                   double dfCenterLong,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Gnomonic.
+"""
 function setgnomonic(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetGnomonic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOM(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfAzimuth,
+             double dfRectToSkew,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Oblique Mercator (aka HOM (variant B)
+"""
 function setom(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfAzimuth::Real,dfRectToSkew::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetOM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfRectToSkew,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetHOM(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfAzimuth,
+              double dfRectToSkew,
+              double dfScale,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Hotine Oblique Mercator using azimuth angle.
+"""
 function sethom(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfAzimuth::Real,dfRectToSkew::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetHOM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfRectToSkew,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetHOM2PNO(OGRSpatialReferenceH hSRS,
+                  double dfCenterLat,
+                  double dfLat1,
+                  double dfLong1,
+                  double dfLat2,
+                  double dfLong2,
+                  double dfScale,
+                  double dfFalseEasting,
+                  double dfFalseNorthing) -> OGRErr
+
+Hotine Oblique Mercator using two points on centerline.
+"""
 function sethom2pno(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfLat1::Real,dfLong1::Real,dfLat2::Real,dfLong2::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetHOM2PNO,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfLat1,dfLong1,dfLat2,dfLong2,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetIWMPolyconic(OGRSpatialReferenceH hSRS,
+                       double dfLat1,
+                       double dfLat2,
+                       double dfCenterLong,
+                       double dfFalseEasting,
+                       double dfFalseNorthing) -> OGRErr
+
+International Map of the World Polyconic.
+"""
 function setiwmpolyconic(hSRS::OGRSpatialReferenceH,dfLat1::Real,dfLat2::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetIWMPolyconic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfLat1,dfLat2,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetKrovak(OGRSpatialReferenceH hSRS,
+                 double dfCenterLat,
+                 double dfCenterLong,
+                 double dfAzimuth,
+                 double dfPseudoStdParallelLat,
+                 double dfScale,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Krovak Oblique Conic Conformal.
+"""
 function setkrovak(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfAzimuth::Real,dfPseudoStdParallelLat::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetKrovak,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfAzimuth,dfPseudoStdParallelLat,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLAEA(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Lambert Azimuthal Equal-Area.
+"""
 function setlaea(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetLAEA,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCC(OGRSpatialReferenceH hSRS,
+              double dfStdP1,
+              double dfStdP2,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic.
+"""
 function setlcc(hSRS::OGRSpatialReferenceH,dfStdP1::Real,dfStdP2::Real,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetLCC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCC1SP(OGRSpatialReferenceH hSRS,
+                 double dfCenterLat,
+                 double dfCenterLong,
+                 double dfScale,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic 1SP.
+"""
 function setlcc1sp(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetLCC1SP,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetLCCB(OGRSpatialReferenceH hSRS,
+               double dfStdP1,
+               double dfStdP2,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Lambert Conformal Conic (Belgium)
+"""
 function setlccb(hSRS::OGRSpatialReferenceH,dfStdP1::Real,dfStdP2::Real,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetLCCB,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfStdP1,dfStdP2,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMC(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Miller Cylindrical.
+"""
 function setmc(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetMC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMercator(OGRSpatialReferenceH hSRS,
+                   double dfCenterLat,
+                   double dfCenterLong,
+                   double dfScale,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Mercator.
+"""
 function setmercator(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetMercator,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetMollweide(OGRSpatialReferenceH hSRS,
+                    double dfCentralMeridian,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Mollweide.
+"""
 function setmollweide(hSRS::OGRSpatialReferenceH,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetMollweide,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetNZMG(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+New Zealand Map Grid.
+"""
 function setnzmg(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetNZMG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOS(OGRSpatialReferenceH hSRS,
+             double dfOriginLat,
+             double dfCMeridian,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Oblique Stereographic.
+"""
 function setos(hSRS::OGRSpatialReferenceH,dfOriginLat::Real,dfCMeridian::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetOS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfOriginLat,dfCMeridian,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetOrthographic(OGRSpatialReferenceH hSRS,
+                       double dfCenterLat,
+                       double dfCenterLong,
+                       double dfFalseEasting,
+                       double dfFalseNorthing) -> OGRErr
+
+Orthographic.
+"""
 function setorthographic(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetOrthographic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetPolyconic(OGRSpatialReferenceH hSRS,
+                    double dfCenterLat,
+                    double dfCenterLong,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Polyconic.
+"""
 function setpolyconic(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetPolyconic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetPS(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Polar Stereographic.
+"""
 function setps(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetPS,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetRobinson(OGRSpatialReferenceH hSRS,
+                   double dfCenterLong,
+                   double dfFalseEasting,
+                   double dfFalseNorthing) -> OGRErr
+
+Robinson.
+"""
 function setrobinson(hSRS::OGRSpatialReferenceH,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetRobinson,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetSinusoidal(OGRSpatialReferenceH hSRS,
+                     double dfCenterLong,
+                     double dfFalseEasting,
+                     double dfFalseNorthing) -> OGRErr
+
+Sinusoidal.
+"""
 function setsinusoidal(hSRS::OGRSpatialReferenceH,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetSinusoidal,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetStereographic(OGRSpatialReferenceH hSRS,
+                        double dfCenterLat,
+                        double dfCenterLong,
+                        double dfScale,
+                        double dfFalseEasting,
+                        double dfFalseNorthing) -> OGRErr
+
+Stereographic.
+"""
 function setstereographic(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetStereographic,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetSOC(OGRSpatialReferenceH hSRS,
+              double dfLatitudeOfOrigin,
+              double dfCentralMeridian,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Swiss Oblique Cylindrical.
+"""
 function setsoc(hSRS::OGRSpatialReferenceH,dfLatitudeOfOrigin::Real,dfCentralMeridian::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetSOC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfLatitudeOfOrigin,dfCentralMeridian,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTM(OGRSpatialReferenceH hSRS,
+             double dfCenterLat,
+             double dfCenterLong,
+             double dfScale,
+             double dfFalseEasting,
+             double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator.
+"""
 function settm(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetTM,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMVariant(OGRSpatialReferenceH hSRS,
+                    const char * pszVariantName,
+                    double dfCenterLat,
+                    double dfCenterLong,
+                    double dfScale,
+                    double dfFalseEasting,
+                    double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator variant.
+"""
 function settmvariant(hSRS::OGRSpatialReferenceH,pszVariantName::AbstractString,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetTMVariant,libgdal),OGRErr,(OGRSpatialReferenceH,Ptr{UInt8},Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,pszVariantName,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMG(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+Tunesia Mining Grid.
+"""
 function settmg(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetTMG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetTMSO(OGRSpatialReferenceH hSRS,
+               double dfCenterLat,
+               double dfCenterLong,
+               double dfScale,
+               double dfFalseEasting,
+               double dfFalseNorthing) -> OGRErr
+
+Transverse Mercator (South Oriented)
+"""
 function settmso(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real,dfScale::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetTMSO,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong,dfScale,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetVDG(OGRSpatialReferenceH hSRS,
+              double dfCenterLong,
+              double dfFalseEasting,
+              double dfFalseNorthing) -> OGRErr
+
+VanDerGrinten.
+"""
 function setvdg(hSRS::OGRSpatialReferenceH,dfCenterLong::Real,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetVDG,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble,Cdouble),hSRS,dfCenterLong,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetWagner(OGRSpatialReferenceH hSRS,
+                 int nVariation,
+                 double dfFalseEasting,
+                 double dfFalseNorthing) -> OGRErr
+
+Wagner I  VII.
+"""
 function setwagner(hSRS::OGRSpatialReferenceH,nVariation::Integer,dfFalseEasting::Real,dfFalseNorthing::Real)
     ccall((:OSRSetWagner,libgdal),OGRErr,(OGRSpatialReferenceH,Cint,Cdouble,Cdouble),hSRS,nVariation,dfFalseEasting,dfFalseNorthing)
 end
 
+
+"""
+    OSRSetQSC(OGRSpatialReferenceH hSRS,
+              double dfCenterLat,
+              double dfCenterLong) -> OGRErr
+
+Quadrilateralized Spherical Cube.
+"""
 function setqsc(hSRS::OGRSpatialReferenceH,dfCenterLat::Real,dfCenterLong::Real)
     ccall((:OSRSetQSC,libgdal),OGRErr,(OGRSpatialReferenceH,Cdouble,Cdouble),hSRS,dfCenterLat,dfCenterLong)
 end
 
+
+"""
+    OSRCalcInvFlattening(double dfSemiMajor,
+                         double dfSemiMinor) -> double
+
+Compute inverse flattening from semi-major and semi-minor axis.
+
+### Parameters
+* **dfSemiMajor**: Semi-major axis length.
+* **dfSemiMinor**: Semi-minor axis length.
+
+### Returns
+inverse flattening, or 0 if both axis are equal.
+"""
 function calcinvflattening(dfSemiMajor::Real,dfSemiMinor::Real)
     ccall((:OSRCalcInvFlattening,libgdal),Cdouble,(Cdouble,Cdouble),dfSemiMajor,dfSemiMinor)
 end
 
+
+"""
+    OSRCalcSemiMinorFromInvFlattening(double dfSemiMajor,
+                                      double dfInvFlattening) -> double
+
+Compute semi-minor axis from semi-major axis and inverse flattening.
+
+### Parameters
+* **dfSemiMajor**: Semi-major axis length.
+* **dfInvFlattening**: Inverse flattening or 0 for sphere.
+
+### Returns
+semi-minor axis
+"""
 function calcsemiminorfrominvflattening(dfSemiMajor::Real,dfInvFlattening::Real)
     ccall((:OSRCalcSemiMinorFromInvFlattening,libgdal),Cdouble,(Cdouble,Cdouble),dfSemiMajor,dfInvFlattening)
 end
 
+
+"""
+    OSRCleanup(void) -> void
+
+Cleanup cached SRS related memory.
+"""
 function cleanup()
     ccall((:OSRCleanup,libgdal),Void,())
 end
 
+
+"""
+    OCTNewCoordinateTransformation(OGRSpatialReferenceH hSourceSRS,
+                                   OGRSpatialReferenceH hTargetSRS) -> OGRCoordinateTransformationH
+
+Create transformation object.
+
+### Parameters
+* **hSourceSRS**: source spatial reference system.
+* **hTargetSRS**: target spatial reference system.
+
+### Returns
+NULL on failure or a ready to use transformation object.
+"""
 function octnewcoordinatetransformation(hSourceSRS::OGRSpatialReferenceH,hTargetSRS::OGRSpatialReferenceH)
     checknull(ccall((:OCTNewCoordinateTransformation,libgdal),OGRCoordinateTransformationH,(OGRSpatialReferenceH,OGRSpatialReferenceH),hSourceSRS,hTargetSRS))
 end
 
+
+"""
+    OCTDestroyCoordinateTransformation(OGRCoordinateTransformationH) -> void
+
+OGRCoordinateTransformation destructor.
+
+### Parameters
+* **hCT**: the object to delete
+"""
 function octdestroycoordinatetransformation(arg1::OGRCoordinateTransformationH)
     ccall((:OCTDestroyCoordinateTransformation,libgdal),Void,(OGRCoordinateTransformationH,),arg1)
 end
 
+
+"""
+    OCTTransform(OGRCoordinateTransformationH hCT,
+                 int nCount,
+                 double * x,
+                 double * y,
+                 double * z) -> int
+"""
 function octtransform(hCT::OGRCoordinateTransformationH,nCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64})
     ccall((:OCTTransform,libgdal),Cint,(OGRCoordinateTransformationH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),hCT,nCount,x,y,z)
 end
 
+
+"""
+    OCTTransformEx(OGRCoordinateTransformationH hCT,
+                   int nCount,
+                   double * x,
+                   double * y,
+                   double * z,
+                   int * pabSuccess) -> int
+"""
 function octtransformex(hCT::OGRCoordinateTransformationH,nCount::Integer,x::Vector{Float64},y::Vector{Float64},z::Vector{Float64},pabSuccess::Vector{Cint})
     ccall((:OCTTransformEx,libgdal),Cint,(OGRCoordinateTransformationH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cint}),hCT,nCount,x,y,z,pabSuccess)
 end
 
+
+"""
+    OCTProj4Normalize(const char * pszProj4Src) -> char *
+"""
 function octproj4normalize(pszProj4Src::AbstractString)
     bytestring(ccall((:OCTProj4Normalize,libgdal),Ptr{UInt8},(Ptr{UInt8},),pszProj4Src))
 end
 
+
+"""
+    OCTCleanupProjMutex(void) -> void
+"""
 function octcleanupprojmutex()
     ccall((:OCTCleanupProjMutex,libgdal),Void,())
 end
 
+
+"""
+    OPTGetProjectionMethods() -> char **
+
+Fetch list of possible projection methods.
+
+### Returns
+Returns NULL terminated list of projection methods. This should be freed with CSLDestroy() when no longer needed.
+"""
 function optgetprojectionmethods()
     bytestring(unsafe_load(ccall((:OPTGetProjectionMethods,libgdal),Ptr{Ptr{UInt8}},())))
 end
 
+
+"""
+    OPTGetParameterList(const char * pszProjectionMethod,
+                        char ** ppszUserName) -> char **
+
+Fetch the parameters for a given projection method.
+
+### Parameters
+* **pszProjectionMethod**: internal name of projection methods to fetch the parameters for, such as "Transverse_Mercator" (SRS_PT_TRANSVERSE_MERCATOR).
+* **ppszUserName**: pointer in which to return a user visible name for the projection name. The returned string should not be modified or freed by the caller. Legal to pass in NULL if user name not required.
+
+### Returns
+returns a NULL terminated list of internal parameter names that should be freed by the caller when no longer needed. Returns NULL if projection method is unknown.
+"""
 function optgetparameterlist(pszProjectionMethod::AbstractString,ppszUserName::Vector{UTF8String})
     bytestring(unsafe_load(ccall((:OPTGetParameterList,libgdal),Ptr{Ptr{UInt8}},(Ptr{UInt8},Ptr{Ptr{UInt8}}),pszProjectionMethod,ppszUserName)))
 end
 
+
+"""
+    OPTGetParameterInfo(const char * pszProjectionMethod,
+                        const char * pszParameterName,
+                        char ** ppszUserName,
+                        char ** ppszType,
+                        double * pdfDefaultValue) -> int
+
+Fetch information about a single parameter of a projection method.
+
+### Parameters
+* **pszProjectionMethod**: name of projection method for which the parameter applies. Not currently used, but in the future this could affect defaults. This is the internal projection method name, such as "Tranverse_Mercator".
+* **pszParameterName**: name of the parameter to fetch information about. This is the internal name such as "central_meridian" (SRS_PP_CENTRAL_MERIDIAN).
+* **ppszUserName**: location at which to return the user visible name for the parameter. This pointer may be NULL to skip the user name. The returned name should not be modified or freed.
+* **ppszType**: location at which to return the parameter type for the parameter. This pointer may be NULL to skip. The returned type should not be modified or freed. The type values are described above.
+* **pdfDefaultValue**: location at which to put the default value for this parameter. The pointer may be NULL.
+
+### Returns
+TRUE if parameter found, or FALSE otherwise.
+"""
 function optgetparameterinfo(pszProjectionMethod::AbstractString,pszParameterName::AbstractString,ppszUserName::Vector{UTF8String},ppszType::Vector{UTF8String},pdfDefaultValue::Vector{Float64})
     ccall((:OPTGetParameterInfo,libgdal),Cint,(Ptr{UInt8},Ptr{UInt8},Ptr{Ptr{UInt8}},Ptr{Ptr{UInt8}},Ptr{Cdouble}),pszProjectionMethod,pszParameterName,ppszUserName,ppszType,pdfDefaultValue)
 end
-


### PR DESCRIPTION
Todo:
- [x] Convert to Markdown syntax
- [x] Settle on a good format that also handles missing fields
- [x] Add these docs to the main module's generated functions as well

It coud be confusing that the input parameters are presented as C types. We could decide to replace it by the Julia conversion, but often these are unhelpful `arg1`, `arg2` as in:
```julia
"""
    GDALTermProgress(CPL_UNUSED double dfComplete, CPL_UNUSED const char *pszMessage, void *pProgressArg)

Simple progress report to terminal.

Returns int
"""
function GDALTermProgress(arg1::Cdouble,arg2::Ptr{UInt8},arg3::Ptr{Void})
    ccall((:GDALTermProgress,libgdal),Cint,(Cdouble,Ptr{UInt8},Ptr{Void}),arg1,arg2,arg3)
end
```

Part of #5
