### PR TITLE
disambiguate create() functions

### DIFF
--- a/gen/rewriter.jl
+++ b/gen/rewriter.jl
@@ -25,6 +25,15 @@ custom_rename = Dict{ASCIIString, ASCIIString}(
     "ogr_fld_create" => "fld_create",
     "ogr_gfld_create" => "gfld_create",
 
+    # these don't directly clash, but otherwise all are renamed to `create`
+    # this makes it easier to disambiguate them
+    "ogr_fd_create" => "fd_create",
+    "ogr_f_create" => "f_create",
+    "gdal_cg_create" => "cg_create",
+    "ogr_sm_create" => "sm_create",
+    "ogr_st_create" => "st_create",
+    "ogr_stbl_create" => "stbl_create",
+
     "ogrgetdrivercount" => "ogrgetdrivercount",
     "ogrgetdriver" => "ogrgetdriver"
 )

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -845,7 +845,7 @@ end
                    GDALContourWriter pfnWriter,
                    void * pCBData) -> GDALContourGeneratorH
 """
-function create(nWidth::Integer,nHeight::Integer,bNoDataSet::Integer,dfNoDataValue::Real,dfContourInterval::Real,dfContourBase::Real,pfnWriter::Ptr{GDALContourWriter},pCBData)
+function cg_create(nWidth::Integer,nHeight::Integer,bNoDataSet::Integer,dfNoDataValue::Real,dfContourInterval::Real,dfContourBase::Real,pfnWriter::Ptr{GDALContourWriter},pCBData)
     checknull(ccall((:GDAL_CG_Create,libgdal),Ptr{GDALContourGeneratorH},(Cint,Cint,Cint,Cdouble,Cdouble,Cdouble,Ptr{GDALContourWriter},Ptr{Void}),nWidth,nHeight,bNoDataSet,dfNoDataValue,dfContourInterval,dfContourBase,pfnWriter,pCBData))
 end
 

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -2356,7 +2356,7 @@ Create a new feature definition object to hold the field definitions.
 ### Returns
 handle to the newly created feature definition.
 """
-function create(arg1)
+function fd_create(arg1)
     checknull(ccall((:OGR_FD_Create,libgdal),Ptr{OGRFeatureDefnH},(Cstring,),arg1))
 end
 
@@ -2761,7 +2761,7 @@ Feature factory.
 ### Returns
 an handle to the new feature object with null fields and no geometry, or, starting with GDAL 2.1, NULL in case out of memory situation.
 """
-function create(arg1::Ptr{OGRFeatureDefnH})
+function f_create(arg1::Ptr{OGRFeatureDefnH})
     checknull(ccall((:OGR_F_Create,libgdal),Ptr{OGRFeatureH},(Ptr{OGRFeatureDefnH},),arg1))
 end
 
@@ -5246,7 +5246,7 @@ OGRStyleMgr factory.
 ### Returns
 an handle to the new style manager object.
 """
-function create(hStyleTable::Ptr{OGRStyleTableH})
+function sm_create(hStyleTable::Ptr{OGRStyleTableH})
     checknull(ccall((:OGR_SM_Create,libgdal),Ptr{OGRStyleMgrH},(Ptr{OGRStyleTableH},),hStyleTable))
 end
 
@@ -5387,7 +5387,7 @@ OGRStyleTool factory.
 ### Returns
 an handle to the new style tool object or NULL if the creation failed.
 """
-function create(eClassId::OGRSTClassId)
+function st_create(eClassId::OGRSTClassId)
     checknull(ccall((:OGR_ST_Create,libgdal),Ptr{OGRStyleToolH},(OGRSTClassId,),eClassId))
 end
 
@@ -5615,7 +5615,7 @@ OGRStyleTable factory.
 ### Returns
 an handle to the new style table object.
 """
-function create()
+function stbl_create()
     checknull(ccall((:OGR_STBL_Create,libgdal),Ptr{OGRStyleTableH},()))
 end
 

--- a/test/tutorial_vector.jl
+++ b/test/tutorial_vector.jl
@@ -53,17 +53,14 @@ driver = GDAL.getdriverbyname("ESRI Shapefile")
 dataset = GDAL.create(driver, "$pointshapefile.shp", 0, 0, 0, GDAL.GDT_Unknown, C_NULL)
 nosrs = convert(Ptr{GDAL.OGRSpatialReferenceH}, C_NULL)
 layer = GDAL.datasetcreatelayer(dataset, "point_out", nosrs, GDAL.wkbPoint, C_NULL)
-# the GDAL.create function is overwritten, needs to be fixed, probably by better renaming
-# use the C submodule instead of now
-# fielddefn = GDAL.create("Name", GDAL.OFTString)
-fielddefn = convert(Ptr{GDAL.OGRFieldDefnH}, GDAL.C.OGR_Fld_Create("Name", GDAL.OFTString))
+fielddefn = GDAL.fld_create("Name", GDAL.OFTString)
 GDAL.setwidth(fielddefn, 32)
 @test GDAL.createfield(layer, fielddefn, GDAL.TRUE) == GDAL.OGRERR_NONE
 GDAL.destroy(fielddefn)
 
 # repeat to add multiple features
 featuredefn = GDAL.getlayerdefn(layer)
-feature = GDAL.create(featuredefn)
+feature = GDAL.f_create(featuredefn)
 GDAL.setfieldstring(feature, GDAL.getfieldindex(feature, "Name"), "myname")
 point = GDAL.creategeometry(GDAL.wkbPoint)
 GDAL.setpoint_2d(point, 0, 100.123, 0.123)


### PR DESCRIPTION
closes #15

These functions did not have clashing signatures,
but `create` is not a very helpful name.

Now the only `create` function left is `GDALCreate`.
