### PR TITLE
update to GDAL 2.1.0 release

### DIFF
--- a/gen/rewriter.jl
+++ b/gen/rewriter.jl
@@ -238,8 +238,10 @@ common_file = "common.jl"
 expr = parsefile(joinpath(srcdir, "C", common_file))
 open(joinpath(srcdir, common_file), "w") do io
     for el in expr.args[1].args
-        if isa(el, Expr)
-            commonrewriter(io, el)
+        # second part keeps out LineNumberNode
+        # which would print as a comment
+        if isa(el, Expr) && (el.head != :line)
+                commonrewriter(io, el)
         end
     end
 end

--- a/src/C/common.jl
+++ b/src/C/common.jl
@@ -13,6 +13,12 @@ const CPLE_AssertionFailed = 7
 const CPLE_NoWriteAccess = 8
 const CPLE_UserInterrupt = 9
 const CPLE_ObjectNull = 10
+const CPLE_HttpResponse = 11
+const CPLE_AWSBucketNotFound = 12
+const CPLE_AWSObjectNotFound = 13
+const CPLE_AWSAccessDenied = 14
+const CPLE_AWSInvalidCredentials = 15
+const CPLE_AWSSignatureDoesNotMatch = 16
 
 # const CPLAssert = expr
 
@@ -132,8 +138,6 @@ const CPL_IS_LSB = 1
 # Skipping MacroDefinition: CPL_NO_RETURN __attribute__ ( ( noreturn ) )
 # Skipping MacroDefinition: CPL_RETURNS_NONNULL __attribute__ ( ( returns_nonnull ) )
 # Skipping MacroDefinition: CPL_WARN_DEPRECATED ( x ) __attribute__ ( ( deprecated ( x ) ) )
-
-# const CPL_WARN_DEPRECATED_IF_GDAL_COMPILATION = x
 # Skipping MacroDefinition: CPL_IS_DOUBLE_A_INT ( d ) ( ( double ) ( int ) ( d ) == ( d ) )
 # Skipping MacroDefinition: CPL_FALLTHROUGH [ [ clang : : fallthrough ] ] ;
 
@@ -402,42 +406,6 @@ end
 
 typealias GDALDerivedPixelFunc Ptr{Void}
 
-immutable Array_2_Cdouble
-    d1::Cdouble
-    d2::Cdouble
-end
-
-zero(::Type{Array_2_Cdouble}) = begin  # /home/martijn/.julia/v0.5/Clang/src/wrap_c.jl, line 269:
-        Array_2_Cdouble(fill(zero(Cdouble),2)...)
-    end
-
-immutable Array_20_Cdouble
-    d1::Cdouble
-    d2::Cdouble
-    d3::Cdouble
-    d4::Cdouble
-    d5::Cdouble
-    d6::Cdouble
-    d7::Cdouble
-    d8::Cdouble
-    d9::Cdouble
-    d10::Cdouble
-    d11::Cdouble
-    d12::Cdouble
-    d13::Cdouble
-    d14::Cdouble
-    d15::Cdouble
-    d16::Cdouble
-    d17::Cdouble
-    d18::Cdouble
-    d19::Cdouble
-    d20::Cdouble
-end
-
-zero(::Type{Array_20_Cdouble}) = begin  # /home/martijn/.julia/v0.5/Clang/src/wrap_c.jl, line 269:
-        Array_20_Cdouble(fill(zero(Cdouble),20)...)
-    end
-
 type GDALRPCInfo
     dfLINE_OFF::Cdouble
     dfSAMP_OFF::Cdouble
@@ -449,10 +417,10 @@ type GDALRPCInfo
     dfLAT_SCALE::Cdouble
     dfLONG_SCALE::Cdouble
     dfHEIGHT_SCALE::Cdouble
-    adfLINE_NUM_COEFF::Array_20_Cdouble
-    adfLINE_DEN_COEFF::Array_20_Cdouble
-    adfSAMP_NUM_COEFF::Array_20_Cdouble
-    adfSAMP_DEN_COEFF::Array_20_Cdouble
+    adfLINE_NUM_COEFF::NTuple{20,Cdouble}
+    adfLINE_DEN_COEFF::NTuple{20,Cdouble}
+    adfSAMP_NUM_COEFF::NTuple{20,Cdouble}
+    adfSAMP_DEN_COEFF::NTuple{20,Cdouble}
     dfMIN_LONG::Cdouble
     dfMIN_LAT::Cdouble
     dfMAX_LONG::Cdouble
@@ -544,19 +512,8 @@ const GDAL_GTI2_SIGNATURE = "GTI2"
 
 typealias GDALTransformerFunc Ptr{Void}
 
-immutable Array_4_GByte
-    d1::GByte
-    d2::GByte
-    d3::GByte
-    d4::GByte
-end
-
-zero(::Type{Array_4_GByte}) = begin  # /home/martijn/.julia/v0.5/Clang/src/wrap_c.jl, line 269:
-        Array_4_GByte(fill(zero(GByte),4)...)
-    end
-
 type GDALTransformerInfo
-    abySignature::Array_4_GByte
+    abySignature::NTuple{4,GByte}
     pszClassName::Cstring
     pfnTransform::GDALTransformerFunc
     pfnCleanup::Ptr{Void}
@@ -567,22 +524,9 @@ end
 typealias GDALContourWriter Ptr{Void}
 typealias GDALContourGeneratorH Ptr{Void}
 
-immutable Array_6_Cdouble
-    d1::Cdouble
-    d2::Cdouble
-    d3::Cdouble
-    d4::Cdouble
-    d5::Cdouble
-    d6::Cdouble
-end
-
-zero(::Type{Array_6_Cdouble}) = begin  # /home/martijn/.julia/v0.5/Clang/src/wrap_c.jl, line 269:
-        Array_6_Cdouble(fill(zero(Cdouble),6)...)
-    end
-
 type OGRContourWriterInfo
     hLayer::Ptr{Void}
-    adfGeoTransform::Array_6_Cdouble
+    adfGeoTransform::NTuple{6,Cdouble}
     nElevField::Cint
     nIDField::Cint
     nNextID::Cint
@@ -670,19 +614,9 @@ end
 type GDALGridContext
 end
 
-immutable Array_3_Cint
-    d1::Cint
-    d2::Cint
-    d3::Cint
-end
-
-zero(::Type{Array_3_Cint}) = begin  # /home/martijn/.julia/v0.5/Clang/src/wrap_c.jl, line 269:
-        Array_3_Cint(fill(zero(Cint),3)...)
-    end
-
 type GDALTriFacet
-    anVertexIdx::Array_3_Cint
-    anNeighborIdx::Array_3_Cint
+    anVertexIdx::NTuple{3,Cint}
+    anNeighborIdx::NTuple{3,Cint}
 end
 
 type GDALTriBarycentricCoefficients
@@ -732,15 +666,13 @@ const OGRERR_FAILURE = 6
 const OGRERR_UNSUPPORTED_SRS = 7
 const OGRERR_INVALID_HANDLE = 8
 const OGRERR_NON_EXISTING_FEATURE = 9
-
-# Skipping MacroDefinition: wkbCurve ( ( OGRwkbGeometryType ) 13 )
-# Skipping MacroDefinition: wkbSurface ( ( OGRwkbGeometryType ) 14 )
-
 const wkb25DBit = 0x80000000
 
 # Skipping MacroDefinition: wkbFlatten ( x ) OGR_GT_Flatten ( ( OGRwkbGeometryType ) ( x ) )
-# Skipping MacroDefinition: wkbHasZ ( x ) OGR_GT_HasZ ( x )
+# Skipping MacroDefinition: wkbHasZ ( x ) ( OGR_GT_HasZ ( x ) != 0 )
 # Skipping MacroDefinition: wkbSetZ ( x ) OGR_GT_SetZ ( x )
+# Skipping MacroDefinition: wkbHasM ( x ) ( OGR_GT_HasM ( x ) != 0 )
+# Skipping MacroDefinition: wkbSetM ( x ) OGR_GT_SetM ( x )
 
 const ogrZMarker = 0x21125711
 
@@ -757,7 +689,10 @@ const OGR_F_VAL_NULL = 0x00000001
 const OGR_F_VAL_GEOM_TYPE = 0x00000002
 const OGR_F_VAL_WIDTH = 0x00000004
 const OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT = 0x00000008
-const OGR_F_VAL_ALL = 0x07ffffff
+const OGR_F_VAL_ALLOW_DIFFERENT_GEOM_DIM = 0x00000010
+
+# Skipping MacroDefinition: OGR_F_VAL_ALL ( 0x7FFFFFFF & ~ OGR_F_VAL_ALLOW_DIFFERENT_GEOM_DIM )
+
 const OGRNullFID = -1
 const OGRUnsetMarker = -21121
 
@@ -780,12 +715,14 @@ const OLCStringsAsUTF8 = "StringsAsUTF8"
 const OLCIgnoreFields = "IgnoreFields"
 const OLCCreateGeomField = "CreateGeomField"
 const OLCCurveGeometries = "CurveGeometries"
+const OLCMeasuredGeometries = "MeasuredGeometries"
 const ODsCCreateLayer = "CreateLayer"
 const ODsCDeleteLayer = "DeleteLayer"
 const ODsCCreateGeomFieldAfterCreateLayer = "CreateGeomFieldAfterCreateLayer"
 const ODsCCurveGeometries = "CurveGeometries"
 const ODsCTransactions = "Transactions"
 const ODsCEmulatedTransactions = "EmulatedTransactions"
+const ODsCMeasuredGeometries = "MeasuredGeometries"
 const ODrCCreateDataSource = "CreateDataSource"
 const ODrCDeleteDataSource = "DeleteDataSource"
 const OLMD_FID64 = "OLMD_FID64"
@@ -826,6 +763,11 @@ const wkbCompoundCurve = (UInt32)(9)
 const wkbCurvePolygon = (UInt32)(10)
 const wkbMultiCurve = (UInt32)(11)
 const wkbMultiSurface = (UInt32)(12)
+const wkbCurve = (UInt32)(13)
+const wkbSurface = (UInt32)(14)
+const wkbPolyhedralSurface = (UInt32)(15)
+const wkbTIN = (UInt32)(16)
+const wkbTriangle = (UInt32)(17)
 const wkbNone = (UInt32)(100)
 const wkbLinearRing = (UInt32)(101)
 const wkbCircularStringZ = (UInt32)(1008)
@@ -833,6 +775,45 @@ const wkbCompoundCurveZ = (UInt32)(1009)
 const wkbCurvePolygonZ = (UInt32)(1010)
 const wkbMultiCurveZ = (UInt32)(1011)
 const wkbMultiSurfaceZ = (UInt32)(1012)
+const wkbCurveZ = (UInt32)(1013)
+const wkbSurfaceZ = (UInt32)(1014)
+const wkbPolyhedralSurfaceZ = (UInt32)(1015)
+const wkbTINZ = (UInt32)(1016)
+const wkbTriangleZ = (UInt32)(1017)
+const wkbPointM = (UInt32)(2001)
+const wkbLineStringM = (UInt32)(2002)
+const wkbPolygonM = (UInt32)(2003)
+const wkbMultiPointM = (UInt32)(2004)
+const wkbMultiLineStringM = (UInt32)(2005)
+const wkbMultiPolygonM = (UInt32)(2006)
+const wkbGeometryCollectionM = (UInt32)(2007)
+const wkbCircularStringM = (UInt32)(2008)
+const wkbCompoundCurveM = (UInt32)(2009)
+const wkbCurvePolygonM = (UInt32)(2010)
+const wkbMultiCurveM = (UInt32)(2011)
+const wkbMultiSurfaceM = (UInt32)(2012)
+const wkbCurveM = (UInt32)(2013)
+const wkbSurfaceM = (UInt32)(2014)
+const wkbPolyhedralSurfaceM = (UInt32)(2015)
+const wkbTINM = (UInt32)(2016)
+const wkbTriangleM = (UInt32)(2017)
+const wkbPointZM = (UInt32)(3001)
+const wkbLineStringZM = (UInt32)(3002)
+const wkbPolygonZM = (UInt32)(3003)
+const wkbMultiPointZM = (UInt32)(3004)
+const wkbMultiLineStringZM = (UInt32)(3005)
+const wkbMultiPolygonZM = (UInt32)(3006)
+const wkbGeometryCollectionZM = (UInt32)(3007)
+const wkbCircularStringZM = (UInt32)(3008)
+const wkbCompoundCurveZM = (UInt32)(3009)
+const wkbCurvePolygonZM = (UInt32)(3010)
+const wkbMultiCurveZM = (UInt32)(3011)
+const wkbMultiSurfaceZM = (UInt32)(3012)
+const wkbCurveZM = (UInt32)(3013)
+const wkbSurfaceZM = (UInt32)(3014)
+const wkbPolyhedralSurfaceZM = (UInt32)(3015)
+const wkbTINZM = (UInt32)(3016)
+const wkbTriangleZM = (UInt32)(3017)
 const wkbPoint25D = (UInt32)(0x0000000080000001)
 const wkbLineString25D = (UInt32)(0x0000000080000002)
 const wkbPolygon25D = (UInt32)(0x0000000080000003)
@@ -857,6 +838,11 @@ const wkbCompoundCurve = (UInt32)(9)
 const wkbCurvePolygon = (UInt32)(10)
 const wkbMultiCurve = (UInt32)(11)
 const wkbMultiSurface = (UInt32)(12)
+const wkbCurve = (UInt32)(13)
+const wkbSurface = (UInt32)(14)
+const wkbPolyhedralSurface = (UInt32)(15)
+const wkbTIN = (UInt32)(16)
+const wkbTriangle = (UInt32)(17)
 const wkbNone = (UInt32)(100)
 const wkbLinearRing = (UInt32)(101)
 const wkbCircularStringZ = (UInt32)(1008)
@@ -864,6 +850,45 @@ const wkbCompoundCurveZ = (UInt32)(1009)
 const wkbCurvePolygonZ = (UInt32)(1010)
 const wkbMultiCurveZ = (UInt32)(1011)
 const wkbMultiSurfaceZ = (UInt32)(1012)
+const wkbCurveZ = (UInt32)(1013)
+const wkbSurfaceZ = (UInt32)(1014)
+const wkbPolyhedralSurfaceZ = (UInt32)(1015)
+const wkbTINZ = (UInt32)(1016)
+const wkbTriangleZ = (UInt32)(1017)
+const wkbPointM = (UInt32)(2001)
+const wkbLineStringM = (UInt32)(2002)
+const wkbPolygonM = (UInt32)(2003)
+const wkbMultiPointM = (UInt32)(2004)
+const wkbMultiLineStringM = (UInt32)(2005)
+const wkbMultiPolygonM = (UInt32)(2006)
+const wkbGeometryCollectionM = (UInt32)(2007)
+const wkbCircularStringM = (UInt32)(2008)
+const wkbCompoundCurveM = (UInt32)(2009)
+const wkbCurvePolygonM = (UInt32)(2010)
+const wkbMultiCurveM = (UInt32)(2011)
+const wkbMultiSurfaceM = (UInt32)(2012)
+const wkbCurveM = (UInt32)(2013)
+const wkbSurfaceM = (UInt32)(2014)
+const wkbPolyhedralSurfaceM = (UInt32)(2015)
+const wkbTINM = (UInt32)(2016)
+const wkbTriangleM = (UInt32)(2017)
+const wkbPointZM = (UInt32)(3001)
+const wkbLineStringZM = (UInt32)(3002)
+const wkbPolygonZM = (UInt32)(3003)
+const wkbMultiPointZM = (UInt32)(3004)
+const wkbMultiLineStringZM = (UInt32)(3005)
+const wkbMultiPolygonZM = (UInt32)(3006)
+const wkbGeometryCollectionZM = (UInt32)(3007)
+const wkbCircularStringZM = (UInt32)(3008)
+const wkbCompoundCurveZM = (UInt32)(3009)
+const wkbCurvePolygonZM = (UInt32)(3010)
+const wkbMultiCurveZM = (UInt32)(3011)
+const wkbMultiSurfaceZM = (UInt32)(3012)
+const wkbCurveZM = (UInt32)(3013)
+const wkbSurfaceZM = (UInt32)(3014)
+const wkbPolyhedralSurfaceZM = (UInt32)(3015)
+const wkbTINZM = (UInt32)(3016)
+const wkbTriangleZM = (UInt32)(3017)
 const wkbPoint25D = (UInt32)(0x0000000080000001)
 const wkbLineString25D = (UInt32)(0x0000000080000002)
 const wkbPolygon25D = (UInt32)(0x0000000080000003)

--- a/src/C/cpl_error.jl
+++ b/src/C/cpl_error.jl
@@ -200,6 +200,19 @@ end
 
 
 """
+    CPLSetCurrentErrorHandlerCatchDebug(int bCatchDebug) -> void
+
+Set if the current error handler should intercept debug messages, or if they should be processed by the previous handler.
+
+### Parameters
+* **bCatchDebug**: FALSE if the current error handler should not intercept debug messages
+"""
+function CPLSetCurrentErrorHandlerCatchDebug(bCatchDebug::Cint)
+    ccall((:CPLSetCurrentErrorHandlerCatchDebug,libgdal),Void,(Cint,),bCatchDebug)
+end
+
+
+"""
     CPLPopErrorHandler() -> void
 
 Pop error handler off stack.

--- a/src/C/gdal.jl
+++ b/src/C/gdal.jl
@@ -20,6 +20,38 @@ end
 
 
 """
+    GDALGetDataTypeSizeBits(GDALDataType eDataType) -> int
+
+Get data type size in bits.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bits or zero if it is not recognised.
+"""
+function GDALGetDataTypeSizeBits(eDataType::GDALDataType)
+    ccall((:GDALGetDataTypeSizeBits,libgdal),Cint,(GDALDataType,),eDataType)
+end
+
+
+"""
+    GDALGetDataTypeSizeBytes(GDALDataType) -> int
+
+Get data type size in bytes.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bytes or zero if it is not recognised.
+"""
+function GDALGetDataTypeSizeBytes(arg1::GDALDataType)
+    ccall((:GDALGetDataTypeSizeBytes,libgdal),Cint,(GDALDataType,),arg1)
+end
+
+
+"""
     GDALDataTypeIsComplex(GDALDataType) -> int
 
 Is data type complex?
@@ -1827,8 +1859,8 @@ end
 
 Compute the min/max values for a band.
 """
-function GDALComputeRasterMinMax(hBand::GDALRasterBandH,bApproxOK::Cint,adfMinMax::Array_2_Cdouble)
-    ccall((:GDALComputeRasterMinMax,libgdal),Void,(GDALRasterBandH,Cint,Array_2_Cdouble),hBand,bApproxOK,adfMinMax)
+function GDALComputeRasterMinMax(hBand::GDALRasterBandH,bApproxOK::Cint,adfMinMax::NTuple{2,Cdouble})
+    ccall((:GDALComputeRasterMinMax,libgdal),Void,(GDALRasterBandH,Cint,NTuple{2,Cdouble}),hBand,bApproxOK,adfMinMax)
 end
 
 

--- a/src/C/gdal_alg.jl
+++ b/src/C/gdal_alg.jl
@@ -578,7 +578,7 @@ Create an RPC based transformer.
 ### Parameters
 * **psRPCInfo**: Definition of the RPC parameters.
 * **bReversed**: If true "forward" transformation will be lat/long to pixel/line instead of the normal pixel/line to lat/long.
-* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations).
+* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations). Starting with GDAL 2.1, this may also be set through the RPC_PIXEL_ERROR_THRESHOLD transformer option.
 * **papszOptions**: Other transformer options (i.e. RPC_HEIGHT=<z>).
 
 ### Returns

--- a/src/C/ogr_api.jl
+++ b/src/C/ogr_api.jl
@@ -243,10 +243,26 @@ Get the dimension of the coordinates in this geometry.
 * **hGeom**: handle on the geometry to get the dimension of the coordinates from.
 
 ### Returns
-in practice this will return 2 or 3. It can also return 0 in the case of an empty point.
+this will return 2 or 3.
 """
 function OGR_G_GetCoordinateDimension(arg1::OGRGeometryH)
     ccall((:OGR_G_GetCoordinateDimension,libgdal),Cint,(OGRGeometryH,),arg1)
+end
+
+
+"""
+    OGR_G_CoordinateDimension(OGRGeometryH hGeom) -> int
+
+Get the dimension of the coordinates in this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension of the coordinates from.
+
+### Returns
+this will return 2 for XY, 3 for XYZ and XYM, and 4 for XYZM data.
+"""
+function OGR_G_CoordinateDimension(arg1::OGRGeometryH)
+    ccall((:OGR_G_CoordinateDimension,libgdal),Cint,(OGRGeometryH,),arg1)
 end
 
 
@@ -262,6 +278,68 @@ Set the coordinate dimension.
 """
 function OGR_G_SetCoordinateDimension(arg1::OGRGeometryH,arg2::Cint)
     ccall((:OGR_G_SetCoordinateDimension,libgdal),Void,(OGRGeometryH,Cint),arg1,arg2)
+end
+
+
+"""
+    OGR_G_Is3D(OGRGeometryH hGeom) -> int
+
+See whether this geometry has Z coordinates.
+
+### Parameters
+* **hGeom**: handle on the geometry to check whether it has Z coordinates.
+
+### Returns
+TRUE if the geometry has Z coordinates.
+"""
+function OGR_G_Is3D(arg1::OGRGeometryH)
+    ccall((:OGR_G_Is3D,libgdal),Cint,(OGRGeometryH,),arg1)
+end
+
+
+"""
+    OGR_G_IsMeasured(OGRGeometryH hGeom) -> int
+
+See whether this geometry is measured.
+
+### Parameters
+* **hGeom**: handle on the geometry to check whether it is measured.
+
+### Returns
+TRUE if the geometry has M coordinates.
+"""
+function OGR_G_IsMeasured(arg1::OGRGeometryH)
+    ccall((:OGR_G_IsMeasured,libgdal),Cint,(OGRGeometryH,),arg1)
+end
+
+
+"""
+    OGR_G_Set3D(OGRGeometryH hGeom,
+                int bIs3D) -> void
+
+Add or remove the Z coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set or unset the Z dimension.
+* **bIs3D**: Should the geometry have a Z dimension, either TRUE or FALSE.
+"""
+function OGR_G_Set3D(arg1::OGRGeometryH,arg2::Cint)
+    ccall((:OGR_G_Set3D,libgdal),Void,(OGRGeometryH,Cint),arg1,arg2)
+end
+
+
+"""
+    OGR_G_SetMeasured(OGRGeometryH hGeom,
+                      int bIsMeasured) -> void
+
+Set the coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set or unset the M dimension.
+* **bIsMeasured**: Should the geometry have a M dimension, either TRUE or FALSE.
+"""
+function OGR_G_SetMeasured(arg1::OGRGeometryH,arg2::Cint)
+    ccall((:OGR_G_SetMeasured,libgdal),Void,(OGRGeometryH,Cint),arg1,arg2)
 end
 
 
@@ -1357,6 +1435,38 @@ end
 
 
 """
+    OGR_G_GetPointsZM(OGRGeometryH hGeom,
+                      void * pabyX,
+                      int nXStride,
+                      void * pabyY,
+                      int nYStride,
+                      void * pabyZ,
+                      int nZStride,
+                      void * pabyM,
+                      int nMStride) -> int
+
+Returns all points of line string.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **pabyX**: a buffer of at least (sizeof(double) * nXStride * nPointCount) bytes, may be NULL.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: a buffer of at least (sizeof(double) * nYStride * nPointCount) bytes, may be NULL.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: a buffer of at last size (sizeof(double) * nZStride * nPointCount) bytes, may be NULL.
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+* **pabyM**: a buffer of at last size (sizeof(double) * nMStride * nPointCount) bytes, may be NULL.
+* **nMStride**: the number of bytes between 2 elements of pabyM.
+
+### Returns
+the number of points
+"""
+function OGR_G_GetPointsZM(hGeom::OGRGeometryH,pabyX,nXStride::Cint,pabyY,nYStride::Cint,pabyZ,nZStride::Cint,pabyM,nMStride::Cint)
+    ccall((:OGR_G_GetPointsZM,libgdal),Cint,(OGRGeometryH,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride,pabyM,nMStride)
+end
+
+
+"""
     OGR_G_GetX(OGRGeometryH hGeom,
                int i) -> double
 
@@ -1411,6 +1521,24 @@ end
 
 
 """
+    OGR_G_GetM(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the m coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the M coordinate.
+* **i**: point to get the M coordinate.
+
+### Returns
+the M coordinate of this point.
+"""
+function OGR_G_GetM(arg1::OGRGeometryH,arg2::Cint)
+    ccall((:OGR_G_GetM,libgdal),Cdouble,(OGRGeometryH,Cint),arg1,arg2)
+end
+
+
+"""
     OGR_G_GetPoint(OGRGeometryH hGeom,
                    int i,
                    double * pdfX,
@@ -1428,6 +1556,29 @@ Fetch a point in line string or a point geometry.
 """
 function OGR_G_GetPoint(arg1::OGRGeometryH,iPoint::Cint,arg2,arg3,arg4)
     ccall((:OGR_G_GetPoint,libgdal),Void,(OGRGeometryH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_GetPointZM(OGRGeometryH hGeom,
+                     int i,
+                     double * pdfX,
+                     double * pdfY,
+                     double * pdfZ,
+                     double * pdfM) -> void
+
+Fetch a point in line string or a point geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **i**: the vertex to fetch, from 0 to getNumPoints()-1, zero for a point.
+* **pdfX**: value of x coordinate.
+* **pdfY**: value of y coordinate.
+* **pdfZ**: value of z coordinate.
+* **pdfM**: value of m coordinate.
+"""
+function OGR_G_GetPointZM(arg1::OGRGeometryH,iPoint::Cint,arg2,arg3,arg4,arg5)
+    ccall((:OGR_G_GetPointZM,libgdal),Void,(OGRGeometryH,Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4,arg5)
 end
 
 
@@ -1487,6 +1638,50 @@ end
 
 
 """
+    OGR_G_SetPointM(OGRGeometryH hGeom,
+                    int i,
+                    double dfX,
+                    double dfY,
+                    double dfM) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfM**: input M coordinate to assign.
+"""
+function OGR_G_SetPointM(arg1::OGRGeometryH,iPoint::Cint,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble)
+    ccall((:OGR_G_SetPointM,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_SetPointZM(OGRGeometryH hGeom,
+                     int i,
+                     double dfX,
+                     double dfY,
+                     double dfZ,
+                     double dfM) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfZ**: input Z coordinate to assign.
+* **dfM**: input M coordinate to assign.
+"""
+function OGR_G_SetPointZM(arg1::OGRGeometryH,iPoint::Cint,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble,arg5::Cdouble)
+    ccall((:OGR_G_SetPointZM,libgdal),Void,(OGRGeometryH,Cint,Cdouble,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4,arg5)
+end
+
+
+"""
     OGR_G_AddPoint(OGRGeometryH hGeom,
                    double dfX,
                    double dfY,
@@ -1523,6 +1718,46 @@ end
 
 
 """
+    OGR_G_AddPointM(OGRGeometryH hGeom,
+                    double dfX,
+                    double dfY,
+                    double dfM) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfM**: m coordinate of point to add.
+"""
+function OGR_G_AddPointM(arg1::OGRGeometryH,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble)
+    ccall((:OGR_G_AddPointM,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_AddPointZM(OGRGeometryH hGeom,
+                     double dfX,
+                     double dfY,
+                     double dfZ,
+                     double dfM) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfZ**: z coordinate of point to add.
+* **dfM**: m coordinate of point to add.
+"""
+function OGR_G_AddPointZM(arg1::OGRGeometryH,arg2::Cdouble,arg3::Cdouble,arg4::Cdouble,arg5::Cdouble)
+    ccall((:OGR_G_AddPointZM,libgdal),Void,(OGRGeometryH,Cdouble,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4,arg5)
+end
+
+
+"""
     OGR_G_SetPoints(OGRGeometryH hGeom,
                     int nPointsIn,
                     void * pabyX,
@@ -1546,6 +1781,37 @@ Assign all points in a point or a line string geometry.
 """
 function OGR_G_SetPoints(hGeom::OGRGeometryH,nPointsIn::Cint,pabyX,nXStride::Cint,pabyY,nYStride::Cint,pabyZ,nZStride::Cint)
     ccall((:OGR_G_SetPoints,libgdal),Void,(OGRGeometryH,Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
+end
+
+
+"""
+    OGR_G_SetPointsZM(OGRGeometryH hGeom,
+                      int nPointsIn,
+                      void * pabyX,
+                      int nXStride,
+                      void * pabyY,
+                      int nYStride,
+                      void * pabyZ,
+                      int nZStride,
+                      void * pabyM,
+                      int nMStride) -> void
+
+Assign all points in a point or a line string geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to set the coordinates.
+* **nPointsIn**: number of points being passed in padfX and padfY.
+* **pabyX**: list of X coordinates (double values) of points being assigned.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: list of Y coordinates (double values) of points being assigned.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: list of Z coordinates (double values) of points being assigned (if not NULL, upgrades the geometry to have Z coordinate).
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+* **pabyM**: list of M coordinates (double values) of points being assigned (if not NULL, upgrades the geometry to have M coordinate).
+* **nMStride**: the number of bytes between 2 elements of pabyM.
+"""
+function OGR_G_SetPointsZM(hGeom::OGRGeometryH,nPointsIn::Cint,pabyX,nXStride::Cint,pabyY,nYStride::Cint,pabyZ,nZStride::Cint,pabyM,nMStride::Cint)
+    ccall((:OGR_G_SetPointsZM,libgdal),Void,(OGRGeometryH,Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride,pabyM,nMStride)
 end
 
 

--- a/src/C/ogr_core.jl
+++ b/src/C/ogr_core.jl
@@ -132,16 +132,32 @@ end
 
 
 """
+    OGR_GT_SetM(OGRwkbGeometryType eType) -> OGRwkbGeometryType
+
+Returns the measured geometry type corresponding to the passed geometry type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+measured geometry type corresponding to the passed geometry type.
+"""
+function OGR_GT_SetM(eType::OGRwkbGeometryType)
+    ccall((:OGR_GT_SetM,libgdal),OGRwkbGeometryType,(OGRwkbGeometryType,),eType)
+end
+
+
+"""
     OGR_GT_SetModifier(OGRwkbGeometryType eType,
                        int bHasZ,
                        int bHasM) -> OGRwkbGeometryType
 
-Returns a 2D or 3D geometry type depending on parameter.
+Returns a XY, XYZ, XYM or XYZM geometry type depending on parameter.
 
 ### Parameters
 * **eType**: Input geometry type
 * **bHasZ**: TRUE if the output geometry type must be 3D.
-* **bHasM**: Must be set to FALSE currently.
+* **bHasM**: TRUE if the output geometry type must be measured.
 
 ### Returns
 Output geometry type.
@@ -164,6 +180,22 @@ TRUE if the geometry type is a 3D geometry type.
 """
 function OGR_GT_HasZ(eType::OGRwkbGeometryType)
     ccall((:OGR_GT_HasZ,libgdal),Cint,(OGRwkbGeometryType,),eType)
+end
+
+
+"""
+    OGR_GT_HasM(OGRwkbGeometryType eType) -> int
+
+Return if the geometry type is a measured type.
+
+### Parameters
+* **eType**: Input geometry type
+
+### Returns
+TRUE if the geometry type is a measured type.
+"""
+function OGR_GT_HasM(eType::OGRwkbGeometryType)
+    ccall((:OGR_GT_HasM,libgdal),Cint,(OGRwkbGeometryType,),eType)
 end
 
 

--- a/src/C/ogr_srs_api.jl
+++ b/src/C/ogr_srs_api.jl
@@ -695,7 +695,7 @@ end
 
 """
     OSRCopyGeogCSFrom(OGRSpatialReferenceH hSRS,
-                      OGRSpatialReferenceH hSrcSRS) -> OGRErr
+                      const OGRSpatialReferenceH hSrcSRS) -> OGRErr
 
 Copy GEOGCS from another OGRSpatialReference.
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,6 +10,12 @@ const CPLE_AssertionFailed = 7
 const CPLE_NoWriteAccess = 8
 const CPLE_UserInterrupt = 9
 const CPLE_ObjectNull = 10
+const CPLE_HttpResponse = 11
+const CPLE_AWSBucketNotFound = 12
+const CPLE_AWSObjectNotFound = 13
+const CPLE_AWSAccessDenied = 14
+const CPLE_AWSInvalidCredentials = 15
+const CPLE_AWSSignatureDoesNotMatch = 16
 typealias CPLErr UInt32
 const CE_None = UInt32(0)
 const CE_Debug = UInt32(1)
@@ -35,10 +41,10 @@ const CXT_Attribute = UInt32(2)
 const CXT_Comment = UInt32(3)
 const CXT_Literal = UInt32(4)
 
-type CPLXMLNode # none, line 64:
-    eType::CPLXMLNodeType # none, line 65:
-    pszValue::Cstring # none, line 66:
-    psNext::Ptr{CPLXMLNode} # none, line 67:
+type CPLXMLNode # none, line 70:
+    eType::CPLXMLNodeType # none, line 71:
+    pszValue::Cstring # none, line 72:
+    psNext::Ptr{CPLXMLNode} # none, line 73:
     psChild::Ptr{CPLXMLNode}
 end
 
@@ -167,15 +173,15 @@ const GRIORA_Average = UInt32(5)
 const GRIORA_Mode = UInt32(6)
 const GRIORA_Gauss = UInt32(7)
 
-type GDALRasterIOExtraArg # none, line 313:
-    nVersion::Cint # none, line 314:
-    eResampleAlg::GDALRIOResampleAlg # none, line 315:
-    pfnProgress::GDALProgressFunc # none, line 316:
-    pProgressData::Ptr{Void} # none, line 317:
-    bFloatingPointWindowValidity::Cint # none, line 318:
-    dfXOff::Cdouble # none, line 319:
-    dfYOff::Cdouble # none, line 320:
-    dfXSize::Cdouble # none, line 321:
+type GDALRasterIOExtraArg # none, line 317:
+    nVersion::Cint # none, line 318:
+    eResampleAlg::GDALRIOResampleAlg # none, line 319:
+    pfnProgress::GDALProgressFunc # none, line 320:
+    pProgressData::Ptr{Void} # none, line 321:
+    bFloatingPointWindowValidity::Cint # none, line 322:
+    dfXOff::Cdouble # none, line 323:
+    dfYOff::Cdouble # none, line 324:
+    dfXSize::Cdouble # none, line 325:
     dfYSize::Cdouble
 end
 
@@ -227,83 +233,43 @@ const GPI_CMYK = UInt32(2)
 const GPI_HLS = UInt32(3)
 typealias GSpacing GIntBig
 
-type GDAL_GCP # none, line 394:
-    pszId::Cstring # none, line 395:
-    pszInfo::Cstring # none, line 396:
-    dfGCPPixel::Cdouble # none, line 397:
-    dfGCPLine::Cdouble # none, line 398:
-    dfGCPX::Cdouble # none, line 399:
-    dfGCPY::Cdouble # none, line 400:
+type GDAL_GCP # none, line 398:
+    pszId::Cstring # none, line 399:
+    pszInfo::Cstring # none, line 400:
+    dfGCPPixel::Cdouble # none, line 401:
+    dfGCPLine::Cdouble # none, line 402:
+    dfGCPX::Cdouble # none, line 403:
+    dfGCPY::Cdouble # none, line 404:
     dfGCPZ::Cdouble
 end
 
 
-immutable Array_2_Cdouble # none, line 406:
-    d1::Cdouble # none, line 407:
-    d2::Cdouble
-end
-
-zero(::Type{Array_2_Cdouble}) = begin  # none, line 410:
-        begin  # none, line 411:
-            Array_2_Cdouble(fill(zero(Cdouble),2)...)
-        end
-    end
-
-immutable Array_20_Cdouble # none, line 415:
-    d1::Cdouble # none, line 416:
-    d2::Cdouble # none, line 417:
-    d3::Cdouble # none, line 418:
-    d4::Cdouble # none, line 419:
-    d5::Cdouble # none, line 420:
-    d6::Cdouble # none, line 421:
-    d7::Cdouble # none, line 422:
-    d8::Cdouble # none, line 423:
-    d9::Cdouble # none, line 424:
-    d10::Cdouble # none, line 425:
-    d11::Cdouble # none, line 426:
-    d12::Cdouble # none, line 427:
-    d13::Cdouble # none, line 428:
-    d14::Cdouble # none, line 429:
-    d15::Cdouble # none, line 430:
-    d16::Cdouble # none, line 431:
-    d17::Cdouble # none, line 432:
-    d18::Cdouble # none, line 433:
-    d19::Cdouble # none, line 434:
-    d20::Cdouble
-end
-
-zero(::Type{Array_20_Cdouble}) = begin  # none, line 437:
-        begin  # none, line 438:
-            Array_20_Cdouble(fill(zero(Cdouble),20)...)
-        end
-    end
-
-type GDALRPCInfo # none, line 442:
-    dfLINE_OFF::Cdouble # none, line 443:
-    dfSAMP_OFF::Cdouble # none, line 444:
-    dfLAT_OFF::Cdouble # none, line 445:
-    dfLONG_OFF::Cdouble # none, line 446:
-    dfHEIGHT_OFF::Cdouble # none, line 447:
-    dfLINE_SCALE::Cdouble # none, line 448:
-    dfSAMP_SCALE::Cdouble # none, line 449:
-    dfLAT_SCALE::Cdouble # none, line 450:
-    dfLONG_SCALE::Cdouble # none, line 451:
-    dfHEIGHT_SCALE::Cdouble # none, line 452:
-    adfLINE_NUM_COEFF::Array_20_Cdouble # none, line 453:
-    adfLINE_DEN_COEFF::Array_20_Cdouble # none, line 454:
-    adfSAMP_NUM_COEFF::Array_20_Cdouble # none, line 455:
-    adfSAMP_DEN_COEFF::Array_20_Cdouble # none, line 456:
-    dfMIN_LONG::Cdouble # none, line 457:
-    dfMIN_LAT::Cdouble # none, line 458:
-    dfMAX_LONG::Cdouble # none, line 459:
+type GDALRPCInfo # none, line 410:
+    dfLINE_OFF::Cdouble # none, line 411:
+    dfSAMP_OFF::Cdouble # none, line 412:
+    dfLAT_OFF::Cdouble # none, line 413:
+    dfLONG_OFF::Cdouble # none, line 414:
+    dfHEIGHT_OFF::Cdouble # none, line 415:
+    dfLINE_SCALE::Cdouble # none, line 416:
+    dfSAMP_SCALE::Cdouble # none, line 417:
+    dfLAT_SCALE::Cdouble # none, line 418:
+    dfLONG_SCALE::Cdouble # none, line 419:
+    dfHEIGHT_SCALE::Cdouble # none, line 420:
+    adfLINE_NUM_COEFF::NTuple{20,Cdouble} # none, line 421:
+    adfLINE_DEN_COEFF::NTuple{20,Cdouble} # none, line 422:
+    adfSAMP_NUM_COEFF::NTuple{20,Cdouble} # none, line 423:
+    adfSAMP_DEN_COEFF::NTuple{20,Cdouble} # none, line 424:
+    dfMIN_LONG::Cdouble # none, line 425:
+    dfMIN_LAT::Cdouble # none, line 426:
+    dfMAX_LONG::Cdouble # none, line 427:
     dfMAX_LAT::Cdouble
 end
 
 
-type GDALColorEntry # none, line 463:
-    c1::Int16 # none, line 464:
-    c2::Int16 # none, line 465:
-    c3::Int16 # none, line 466:
+type GDALColorEntry # none, line 431:
+    c1::Int16 # none, line 432:
+    c2::Int16 # none, line 433:
+    c3::Int16 # none, line 434:
     c4::Int16
 end
 
@@ -362,49 +328,21 @@ const GTO_BIT = UInt32(1)
 const GTO_BSQ = UInt32(2)
 const GDAL_GTI2_SIGNATURE = "GTI2"
 
-immutable Array_4_GByte # none, line 548:
-    d1::GByte # none, line 549:
-    d2::GByte # none, line 550:
-    d3::GByte # none, line 551:
-    d4::GByte
-end
-
-zero(::Type{Array_4_GByte}) = begin  # none, line 554:
-        begin  # none, line 555:
-            Array_4_GByte(fill(zero(GByte),4)...)
-        end
-    end
-
-type GDALTransformerInfo # none, line 559:
-    abySignature::Array_4_GByte # none, line 560:
-    pszClassName::Cstring # none, line 561:
-    pfnTransform::GDALTransformerFunc # none, line 562:
-    pfnCleanup::Ptr{Void} # none, line 563:
-    pfnSerialize::Ptr{Void} # none, line 564:
+type GDALTransformerInfo # none, line 516:
+    abySignature::NTuple{4,GByte} # none, line 517:
+    pszClassName::Cstring # none, line 518:
+    pfnTransform::GDALTransformerFunc # none, line 519:
+    pfnCleanup::Ptr{Void} # none, line 520:
+    pfnSerialize::Ptr{Void} # none, line 521:
     pfnCreateSimilar::Ptr{Void}
 end
 
 
-immutable Array_6_Cdouble # none, line 571:
-    d1::Cdouble # none, line 572:
-    d2::Cdouble # none, line 573:
-    d3::Cdouble # none, line 574:
-    d4::Cdouble # none, line 575:
-    d5::Cdouble # none, line 576:
-    d6::Cdouble
-end
-
-zero(::Type{Array_6_Cdouble}) = begin  # none, line 579:
-        begin  # none, line 580:
-            Array_6_Cdouble(fill(zero(Cdouble),6)...)
-        end
-    end
-
-type OGRContourWriterInfo # none, line 584:
-    hLayer::Ptr{Void} # none, line 585:
-    adfGeoTransform::Array_6_Cdouble # none, line 586:
-    nElevField::Cint # none, line 587:
-    nIDField::Cint # none, line 588:
+type OGRContourWriterInfo # none, line 528:
+    hLayer::Ptr{Void} # none, line 529:
+    adfGeoTransform::NTuple{6,Cdouble} # none, line 530:
+    nElevField::Cint # none, line 531:
+    nIDField::Cint # none, line 532:
     nNextID::Cint
 end
 
@@ -432,105 +370,93 @@ const GGA_MetricAverageDistancePts = UInt32(9)
 const GGA_Linear = UInt32(10)
 const GGA_InverseDistanceToAPowerNearestNeighbor = UInt32(11)
 
-type GDALGridInverseDistanceToAPowerOptions # none, line 622:
-    dfPower::Cdouble # none, line 623:
-    dfSmoothing::Cdouble # none, line 624:
-    dfAnisotropyRatio::Cdouble # none, line 625:
-    dfAnisotropyAngle::Cdouble # none, line 626:
-    dfRadius1::Cdouble # none, line 627:
-    dfRadius2::Cdouble # none, line 628:
-    dfAngle::Cdouble # none, line 629:
-    nMaxPoints::GUInt32 # none, line 630:
-    nMinPoints::GUInt32 # none, line 631:
+type GDALGridInverseDistanceToAPowerOptions # none, line 566:
+    dfPower::Cdouble # none, line 567:
+    dfSmoothing::Cdouble # none, line 568:
+    dfAnisotropyRatio::Cdouble # none, line 569:
+    dfAnisotropyAngle::Cdouble # none, line 570:
+    dfRadius1::Cdouble # none, line 571:
+    dfRadius2::Cdouble # none, line 572:
+    dfAngle::Cdouble # none, line 573:
+    nMaxPoints::GUInt32 # none, line 574:
+    nMinPoints::GUInt32 # none, line 575:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridInverseDistanceToAPowerNearestNeighborOptions # none, line 635:
-    dfPower::Cdouble # none, line 636:
-    dfRadius::Cdouble # none, line 637:
-    nMaxPoints::GUInt32 # none, line 638:
-    nMinPoints::GUInt32 # none, line 639:
+type GDALGridInverseDistanceToAPowerNearestNeighborOptions # none, line 579:
+    dfPower::Cdouble # none, line 580:
+    dfRadius::Cdouble # none, line 581:
+    nMaxPoints::GUInt32 # none, line 582:
+    nMinPoints::GUInt32 # none, line 583:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridMovingAverageOptions # none, line 643:
-    dfRadius1::Cdouble # none, line 644:
-    dfRadius2::Cdouble # none, line 645:
-    dfAngle::Cdouble # none, line 646:
-    nMinPoints::GUInt32 # none, line 647:
+type GDALGridMovingAverageOptions # none, line 587:
+    dfRadius1::Cdouble # none, line 588:
+    dfRadius2::Cdouble # none, line 589:
+    dfAngle::Cdouble # none, line 590:
+    nMinPoints::GUInt32 # none, line 591:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridNearestNeighborOptions # none, line 651:
-    dfRadius1::Cdouble # none, line 652:
-    dfRadius2::Cdouble # none, line 653:
-    dfAngle::Cdouble # none, line 654:
+type GDALGridNearestNeighborOptions # none, line 595:
+    dfRadius1::Cdouble # none, line 596:
+    dfRadius2::Cdouble # none, line 597:
+    dfAngle::Cdouble # none, line 598:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridDataMetricsOptions # none, line 658:
-    dfRadius1::Cdouble # none, line 659:
-    dfRadius2::Cdouble # none, line 660:
-    dfAngle::Cdouble # none, line 661:
-    nMinPoints::GUInt32 # none, line 662:
+type GDALGridDataMetricsOptions # none, line 602:
+    dfRadius1::Cdouble # none, line 603:
+    dfRadius2::Cdouble # none, line 604:
+    dfAngle::Cdouble # none, line 605:
+    nMinPoints::GUInt32 # none, line 606:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridLinearOptions # none, line 666:
-    dfRadius::Cdouble # none, line 667:
+type GDALGridLinearOptions # none, line 610:
+    dfRadius::Cdouble # none, line 611:
     dfNoDataValue::Cdouble
 end
 
 
-type GDALGridContext
+type GDALGridContext # none, line 615:
 end
 
 
-immutable Array_3_Cint # none, line 674:
-    d1::Cint # none, line 675:
-    d2::Cint # none, line 676:
-    d3::Cint
-end
-
-zero(::Type{Array_3_Cint}) = begin  # none, line 679:
-        begin  # none, line 680:
-            Array_3_Cint(fill(zero(Cint),3)...)
-        end
-    end
-
-type GDALTriFacet # none, line 684:
-    anVertexIdx::Array_3_Cint # none, line 685:
-    anNeighborIdx::Array_3_Cint
+type GDALTriFacet # none, line 618:
+    anVertexIdx::NTuple{3,Cint} # none, line 619:
+    anNeighborIdx::NTuple{3,Cint}
 end
 
 
-type GDALTriBarycentricCoefficients # none, line 689:
-    dfMul1X::Cdouble # none, line 690:
-    dfMul1Y::Cdouble # none, line 691:
-    dfMul2X::Cdouble # none, line 692:
-    dfMul2Y::Cdouble # none, line 693:
-    dfCstX::Cdouble # none, line 694:
+type GDALTriBarycentricCoefficients # none, line 623:
+    dfMul1X::Cdouble # none, line 624:
+    dfMul1Y::Cdouble # none, line 625:
+    dfMul2X::Cdouble # none, line 626:
+    dfMul2Y::Cdouble # none, line 627:
+    dfCstX::Cdouble # none, line 628:
     dfCstY::Cdouble
 end
 
 
-type GDALTriangulation # none, line 698:
-    nFacets::Cint # none, line 699:
-    pasFacets::Ptr{GDALTriFacet} # none, line 700:
+type GDALTriangulation # none, line 632:
+    nFacets::Cint # none, line 633:
+    pasFacets::Ptr{GDALTriFacet} # none, line 634:
     pasFacetCoefficients::Ptr{GDALTriBarycentricCoefficients}
 end
 
 
-type _CPLXMLNode
+type _CPLXMLNode # none, line 642:
 end
 
 
-type OGRGeomFieldDefnHS
+type OGRGeomFieldDefnHS # none, line 650:
 end
 
 typealias OGRGeomFieldDefnH Ptr{OGRGeomFieldDefnHS}
@@ -556,7 +482,7 @@ const OGR_F_VAL_NULL = 0x00000001
 const OGR_F_VAL_GEOM_TYPE = 0x00000002
 const OGR_F_VAL_WIDTH = 0x00000004
 const OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT = 0x00000008
-const OGR_F_VAL_ALL = 0x07ffffff
+const OGR_F_VAL_ALLOW_DIFFERENT_GEOM_DIM = 0x00000010
 const OGRNullFID = -1
 const OGRUnsetMarker = -21121
 const OLCRandomRead = "RandomRead"
@@ -576,30 +502,32 @@ const OLCStringsAsUTF8 = "StringsAsUTF8"
 const OLCIgnoreFields = "IgnoreFields"
 const OLCCreateGeomField = "CreateGeomField"
 const OLCCurveGeometries = "CurveGeometries"
+const OLCMeasuredGeometries = "MeasuredGeometries"
 const ODsCCreateLayer = "CreateLayer"
 const ODsCDeleteLayer = "DeleteLayer"
 const ODsCCreateGeomFieldAfterCreateLayer = "CreateGeomFieldAfterCreateLayer"
 const ODsCCurveGeometries = "CurveGeometries"
 const ODsCTransactions = "Transactions"
 const ODsCEmulatedTransactions = "EmulatedTransactions"
+const ODsCMeasuredGeometries = "MeasuredGeometries"
 const ODrCCreateDataSource = "CreateDataSource"
 const ODrCDeleteDataSource = "DeleteDataSource"
 const OLMD_FID64 = "OLMD_FID64"
 
-type OGREnvelope # none, line 796:
-    MinX::Cdouble # none, line 797:
-    MaxX::Cdouble # none, line 798:
-    MinY::Cdouble # none, line 799:
+type OGREnvelope # none, line 733:
+    MinX::Cdouble # none, line 734:
+    MaxX::Cdouble # none, line 735:
+    MinY::Cdouble # none, line 736:
     MaxY::Cdouble
 end
 
 
-type OGREnvelope3D # none, line 803:
-    MinX::Cdouble # none, line 804:
-    MaxX::Cdouble # none, line 805:
-    MinY::Cdouble # none, line 806:
-    MaxY::Cdouble # none, line 807:
-    MinZ::Cdouble # none, line 808:
+type OGREnvelope3D # none, line 740:
+    MinX::Cdouble # none, line 741:
+    MaxX::Cdouble # none, line 742:
+    MinY::Cdouble # none, line 743:
+    MaxY::Cdouble # none, line 744:
+    MinZ::Cdouble # none, line 745:
     MaxZ::Cdouble
 end
 
@@ -618,6 +546,11 @@ const wkbCompoundCurve = UInt32(9)
 const wkbCurvePolygon = UInt32(10)
 const wkbMultiCurve = UInt32(11)
 const wkbMultiSurface = UInt32(12)
+const wkbCurve = UInt32(13)
+const wkbSurface = UInt32(14)
+const wkbPolyhedralSurface = UInt32(15)
+const wkbTIN = UInt32(16)
+const wkbTriangle = UInt32(17)
 const wkbNone = UInt32(100)
 const wkbLinearRing = UInt32(101)
 const wkbCircularStringZ = UInt32(1008)
@@ -625,6 +558,45 @@ const wkbCompoundCurveZ = UInt32(1009)
 const wkbCurvePolygonZ = UInt32(1010)
 const wkbMultiCurveZ = UInt32(1011)
 const wkbMultiSurfaceZ = UInt32(1012)
+const wkbCurveZ = UInt32(1013)
+const wkbSurfaceZ = UInt32(1014)
+const wkbPolyhedralSurfaceZ = UInt32(1015)
+const wkbTINZ = UInt32(1016)
+const wkbTriangleZ = UInt32(1017)
+const wkbPointM = UInt32(2001)
+const wkbLineStringM = UInt32(2002)
+const wkbPolygonM = UInt32(2003)
+const wkbMultiPointM = UInt32(2004)
+const wkbMultiLineStringM = UInt32(2005)
+const wkbMultiPolygonM = UInt32(2006)
+const wkbGeometryCollectionM = UInt32(2007)
+const wkbCircularStringM = UInt32(2008)
+const wkbCompoundCurveM = UInt32(2009)
+const wkbCurvePolygonM = UInt32(2010)
+const wkbMultiCurveM = UInt32(2011)
+const wkbMultiSurfaceM = UInt32(2012)
+const wkbCurveM = UInt32(2013)
+const wkbSurfaceM = UInt32(2014)
+const wkbPolyhedralSurfaceM = UInt32(2015)
+const wkbTINM = UInt32(2016)
+const wkbTriangleM = UInt32(2017)
+const wkbPointZM = UInt32(3001)
+const wkbLineStringZM = UInt32(3002)
+const wkbPolygonZM = UInt32(3003)
+const wkbMultiPointZM = UInt32(3004)
+const wkbMultiLineStringZM = UInt32(3005)
+const wkbMultiPolygonZM = UInt32(3006)
+const wkbGeometryCollectionZM = UInt32(3007)
+const wkbCircularStringZM = UInt32(3008)
+const wkbCompoundCurveZM = UInt32(3009)
+const wkbCurvePolygonZM = UInt32(3010)
+const wkbMultiCurveZM = UInt32(3011)
+const wkbMultiSurfaceZM = UInt32(3012)
+const wkbCurveZM = UInt32(3013)
+const wkbSurfaceZM = UInt32(3014)
+const wkbPolyhedralSurfaceZM = UInt32(3015)
+const wkbTINZM = UInt32(3016)
+const wkbTriangleZM = UInt32(3017)
 const wkbPoint25D = UInt32(0x0000000080000001)
 const wkbLineString25D = UInt32(0x0000000080000002)
 const wkbPolygon25D = UInt32(0x0000000080000003)
@@ -646,6 +618,11 @@ const wkbCompoundCurve = UInt32(9)
 const wkbCurvePolygon = UInt32(10)
 const wkbMultiCurve = UInt32(11)
 const wkbMultiSurface = UInt32(12)
+const wkbCurve = UInt32(13)
+const wkbSurface = UInt32(14)
+const wkbPolyhedralSurface = UInt32(15)
+const wkbTIN = UInt32(16)
+const wkbTriangle = UInt32(17)
 const wkbNone = UInt32(100)
 const wkbLinearRing = UInt32(101)
 const wkbCircularStringZ = UInt32(1008)
@@ -653,6 +630,45 @@ const wkbCompoundCurveZ = UInt32(1009)
 const wkbCurvePolygonZ = UInt32(1010)
 const wkbMultiCurveZ = UInt32(1011)
 const wkbMultiSurfaceZ = UInt32(1012)
+const wkbCurveZ = UInt32(1013)
+const wkbSurfaceZ = UInt32(1014)
+const wkbPolyhedralSurfaceZ = UInt32(1015)
+const wkbTINZ = UInt32(1016)
+const wkbTriangleZ = UInt32(1017)
+const wkbPointM = UInt32(2001)
+const wkbLineStringM = UInt32(2002)
+const wkbPolygonM = UInt32(2003)
+const wkbMultiPointM = UInt32(2004)
+const wkbMultiLineStringM = UInt32(2005)
+const wkbMultiPolygonM = UInt32(2006)
+const wkbGeometryCollectionM = UInt32(2007)
+const wkbCircularStringM = UInt32(2008)
+const wkbCompoundCurveM = UInt32(2009)
+const wkbCurvePolygonM = UInt32(2010)
+const wkbMultiCurveM = UInt32(2011)
+const wkbMultiSurfaceM = UInt32(2012)
+const wkbCurveM = UInt32(2013)
+const wkbSurfaceM = UInt32(2014)
+const wkbPolyhedralSurfaceM = UInt32(2015)
+const wkbTINM = UInt32(2016)
+const wkbTriangleM = UInt32(2017)
+const wkbPointZM = UInt32(3001)
+const wkbLineStringZM = UInt32(3002)
+const wkbPolygonZM = UInt32(3003)
+const wkbMultiPointZM = UInt32(3004)
+const wkbMultiLineStringZM = UInt32(3005)
+const wkbMultiPolygonZM = UInt32(3006)
+const wkbGeometryCollectionZM = UInt32(3007)
+const wkbCircularStringZM = UInt32(3008)
+const wkbCompoundCurveZM = UInt32(3009)
+const wkbCurvePolygonZM = UInt32(3010)
+const wkbMultiCurveZM = UInt32(3011)
+const wkbMultiSurfaceZM = UInt32(3012)
+const wkbCurveZM = UInt32(3013)
+const wkbSurfaceZM = UInt32(3014)
+const wkbPolyhedralSurfaceZM = UInt32(3015)
+const wkbTINZM = UInt32(3016)
+const wkbTriangleZM = UInt32(3017)
 const wkbPoint25D = UInt32(0x0000000080000001)
 const wkbLineString25D = UInt32(0x0000000080000002)
 const wkbPolygon25D = UInt32(0x0000000080000003)
@@ -722,7 +738,7 @@ const OJUndefined = UInt32(0)
 const OJLeft = UInt32(1)
 const OJRight = UInt32(2)
 
-type OGRField # none, line 973:
+type OGRField # none, line 998:
     _OGRField::GIntBig
 end
 
@@ -907,41 +923,41 @@ const GWKAOM_Max = UInt32(4)
 const GWKAOM_Min = UInt32(5)
 const GWKAOM_Quant = UInt32(6)
 
-type GDALWarpOptions # none, line 1209:
-    papszWarpOptions::Ptr{Cstring} # none, line 1210:
-    dfWarpMemoryLimit::Cdouble # none, line 1211:
-    eResampleAlg::GDALResampleAlg # none, line 1212:
-    eWorkingDataType::GDALDataType # none, line 1213:
-    hSrcDS::GDALDatasetH # none, line 1214:
-    hDstDS::GDALDatasetH # none, line 1215:
-    nBandCount::Cint # none, line 1216:
-    panSrcBands::Ptr{Cint} # none, line 1217:
-    panDstBands::Ptr{Cint} # none, line 1218:
-    nSrcAlphaBand::Cint # none, line 1219:
-    nDstAlphaBand::Cint # none, line 1220:
-    padfSrcNoDataReal::Ptr{Cdouble} # none, line 1221:
-    padfSrcNoDataImag::Ptr{Cdouble} # none, line 1222:
-    padfDstNoDataReal::Ptr{Cdouble} # none, line 1223:
-    padfDstNoDataImag::Ptr{Cdouble} # none, line 1224:
-    pfnProgress::GDALProgressFunc # none, line 1225:
-    pProgressArg::Ptr{Void} # none, line 1226:
-    pfnTransformer::GDALTransformerFunc # none, line 1227:
-    pTransformerArg::Ptr{Void} # none, line 1228:
-    papfnSrcPerBandValidityMaskFunc::Ptr{GDALMaskFunc} # none, line 1229:
-    papSrcPerBandValidityMaskFuncArg::Ptr{Ptr{Void}} # none, line 1230:
-    pfnSrcValidityMaskFunc::GDALMaskFunc # none, line 1231:
-    pSrcValidityMaskFuncArg::Ptr{Void} # none, line 1232:
-    pfnSrcDensityMaskFunc::GDALMaskFunc # none, line 1233:
-    pSrcDensityMaskFuncArg::Ptr{Void} # none, line 1234:
-    pfnDstDensityMaskFunc::GDALMaskFunc # none, line 1235:
-    pDstDensityMaskFuncArg::Ptr{Void} # none, line 1236:
-    pfnDstValidityMaskFunc::GDALMaskFunc # none, line 1237:
-    pDstValidityMaskFuncArg::Ptr{Void} # none, line 1238:
-    pfnPreWarpChunkProcessor::Ptr{Void} # none, line 1239:
-    pPreWarpProcessorArg::Ptr{Void} # none, line 1240:
-    pfnPostWarpChunkProcessor::Ptr{Void} # none, line 1241:
-    pPostWarpProcessorArg::Ptr{Void} # none, line 1242:
-    hCutline::Ptr{Void} # none, line 1243:
+type GDALWarpOptions # none, line 1234:
+    papszWarpOptions::Ptr{Cstring} # none, line 1235:
+    dfWarpMemoryLimit::Cdouble # none, line 1236:
+    eResampleAlg::GDALResampleAlg # none, line 1237:
+    eWorkingDataType::GDALDataType # none, line 1238:
+    hSrcDS::GDALDatasetH # none, line 1239:
+    hDstDS::GDALDatasetH # none, line 1240:
+    nBandCount::Cint # none, line 1241:
+    panSrcBands::Ptr{Cint} # none, line 1242:
+    panDstBands::Ptr{Cint} # none, line 1243:
+    nSrcAlphaBand::Cint # none, line 1244:
+    nDstAlphaBand::Cint # none, line 1245:
+    padfSrcNoDataReal::Ptr{Cdouble} # none, line 1246:
+    padfSrcNoDataImag::Ptr{Cdouble} # none, line 1247:
+    padfDstNoDataReal::Ptr{Cdouble} # none, line 1248:
+    padfDstNoDataImag::Ptr{Cdouble} # none, line 1249:
+    pfnProgress::GDALProgressFunc # none, line 1250:
+    pProgressArg::Ptr{Void} # none, line 1251:
+    pfnTransformer::GDALTransformerFunc # none, line 1252:
+    pTransformerArg::Ptr{Void} # none, line 1253:
+    papfnSrcPerBandValidityMaskFunc::Ptr{GDALMaskFunc} # none, line 1254:
+    papSrcPerBandValidityMaskFuncArg::Ptr{Ptr{Void}} # none, line 1255:
+    pfnSrcValidityMaskFunc::GDALMaskFunc # none, line 1256:
+    pSrcValidityMaskFuncArg::Ptr{Void} # none, line 1257:
+    pfnSrcDensityMaskFunc::GDALMaskFunc # none, line 1258:
+    pSrcDensityMaskFuncArg::Ptr{Void} # none, line 1259:
+    pfnDstDensityMaskFunc::GDALMaskFunc # none, line 1260:
+    pDstDensityMaskFuncArg::Ptr{Void} # none, line 1261:
+    pfnDstValidityMaskFunc::GDALMaskFunc # none, line 1262:
+    pDstValidityMaskFuncArg::Ptr{Void} # none, line 1263:
+    pfnPreWarpChunkProcessor::Ptr{Void} # none, line 1264:
+    pPreWarpProcessorArg::Ptr{Void} # none, line 1265:
+    pfnPostWarpChunkProcessor::Ptr{Void} # none, line 1266:
+    pPostWarpProcessorArg::Ptr{Void} # none, line 1267:
+    hCutline::Ptr{Void} # none, line 1268:
     dfCutlineBlendDist::Cdouble
 end
 

--- a/src/gdal_alg.jl
+++ b/src/gdal_alg.jl
@@ -575,7 +575,7 @@ Create an RPC based transformer.
 ### Parameters
 * **psRPCInfo**: Definition of the RPC parameters.
 * **bReversed**: If true "forward" transformation will be lat/long to pixel/line instead of the normal pixel/line to lat/long.
-* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations).
+* **dfPixErrThreshold**: the error (measured in pixels) allowed in the iterative solution of pixel/line to lat/long computations (the other way is always exact given the equations). Starting with GDAL 2.1, this may also be set through the RPC_PIXEL_ERROR_THRESHOLD transformer option.
 * **papszOptions**: Other transformer options (i.e. RPC_HEIGHT=<z>).
 
 ### Returns

--- a/src/gdal_h.jl
+++ b/src/gdal_h.jl
@@ -17,6 +17,38 @@ end
 
 
 """
+    GDALGetDataTypeSizeBits(GDALDataType eDataType) -> int
+
+Get data type size in bits.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bits or zero if it is not recognised.
+"""
+function getdatatypesizebits(eDataType::GDALDataType)
+    ccall((:GDALGetDataTypeSizeBits,libgdal),Cint,(GDALDataType,),eDataType)
+end
+
+
+"""
+    GDALGetDataTypeSizeBytes(GDALDataType) -> int
+
+Get data type size in bytes.
+
+### Parameters
+* **eDataType**: type, such as GDT_Byte.
+
+### Returns
+the number of bytes or zero if it is not recognised.
+"""
+function getdatatypesizebytes(arg1::GDALDataType)
+    ccall((:GDALGetDataTypeSizeBytes,libgdal),Cint,(GDALDataType,),arg1)
+end
+
+
+"""
     GDALDataTypeIsComplex(GDALDataType) -> int
 
 Is data type complex?
@@ -1824,8 +1856,8 @@ end
 
 Compute the min/max values for a band.
 """
-function computerasterminmax{T <: GDALRasterBandH}(hBand::Ptr{T},bApproxOK::Integer,adfMinMax::Array_2_Cdouble)
-    ccall((:GDALComputeRasterMinMax,libgdal),Void,(Ptr{GDALRasterBandH},Cint,Array_2_Cdouble),hBand,bApproxOK,adfMinMax)
+function computerasterminmax{T <: GDALRasterBandH}(hBand::Ptr{T},bApproxOK::Integer,adfMinMax::NTuple{2,Cdouble})
+    ccall((:GDALComputeRasterMinMax,libgdal),Void,(Ptr{GDALRasterBandH},Cint,NTuple{2,Cdouble}),hBand,bApproxOK,adfMinMax)
 end
 
 

--- a/src/ogr_api.jl
+++ b/src/ogr_api.jl
@@ -240,10 +240,26 @@ Get the dimension of the coordinates in this geometry.
 * **hGeom**: handle on the geometry to get the dimension of the coordinates from.
 
 ### Returns
-in practice this will return 2 or 3. It can also return 0 in the case of an empty point.
+this will return 2 or 3.
 """
 function getcoordinatedimension(arg1::Ptr{OGRGeometryH})
     ccall((:OGR_G_GetCoordinateDimension,libgdal),Cint,(Ptr{OGRGeometryH},),arg1)
+end
+
+
+"""
+    OGR_G_CoordinateDimension(OGRGeometryH hGeom) -> int
+
+Get the dimension of the coordinates in this geometry.
+
+### Parameters
+* **hGeom**: handle on the geometry to get the dimension of the coordinates from.
+
+### Returns
+this will return 2 for XY, 3 for XYZ and XYM, and 4 for XYZM data.
+"""
+function coordinatedimension(arg1::Ptr{OGRGeometryH})
+    ccall((:OGR_G_CoordinateDimension,libgdal),Cint,(Ptr{OGRGeometryH},),arg1)
 end
 
 
@@ -259,6 +275,68 @@ Set the coordinate dimension.
 """
 function setcoordinatedimension(arg1::Ptr{OGRGeometryH},arg2::Integer)
     ccall((:OGR_G_SetCoordinateDimension,libgdal),Void,(Ptr{OGRGeometryH},Cint),arg1,arg2)
+end
+
+
+"""
+    OGR_G_Is3D(OGRGeometryH hGeom) -> int
+
+See whether this geometry has Z coordinates.
+
+### Parameters
+* **hGeom**: handle on the geometry to check whether it has Z coordinates.
+
+### Returns
+TRUE if the geometry has Z coordinates.
+"""
+function is3d(arg1::Ptr{OGRGeometryH})
+    ccall((:OGR_G_Is3D,libgdal),Cint,(Ptr{OGRGeometryH},),arg1)
+end
+
+
+"""
+    OGR_G_IsMeasured(OGRGeometryH hGeom) -> int
+
+See whether this geometry is measured.
+
+### Parameters
+* **hGeom**: handle on the geometry to check whether it is measured.
+
+### Returns
+TRUE if the geometry has M coordinates.
+"""
+function ismeasured(arg1::Ptr{OGRGeometryH})
+    ccall((:OGR_G_IsMeasured,libgdal),Cint,(Ptr{OGRGeometryH},),arg1)
+end
+
+
+"""
+    OGR_G_Set3D(OGRGeometryH hGeom,
+                int bIs3D) -> void
+
+Add or remove the Z coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set or unset the Z dimension.
+* **bIs3D**: Should the geometry have a Z dimension, either TRUE or FALSE.
+"""
+function set3d(arg1::Ptr{OGRGeometryH},arg2::Integer)
+    ccall((:OGR_G_Set3D,libgdal),Void,(Ptr{OGRGeometryH},Cint),arg1,arg2)
+end
+
+
+"""
+    OGR_G_SetMeasured(OGRGeometryH hGeom,
+                      int bIsMeasured) -> void
+
+Set the coordinate dimension.
+
+### Parameters
+* **hGeom**: handle on the geometry to set or unset the M dimension.
+* **bIsMeasured**: Should the geometry have a M dimension, either TRUE or FALSE.
+"""
+function setmeasured(arg1::Ptr{OGRGeometryH},arg2::Integer)
+    ccall((:OGR_G_SetMeasured,libgdal),Void,(Ptr{OGRGeometryH},Cint),arg1,arg2)
 end
 
 
@@ -1354,6 +1432,38 @@ end
 
 
 """
+    OGR_G_GetPointsZM(OGRGeometryH hGeom,
+                      void * pabyX,
+                      int nXStride,
+                      void * pabyY,
+                      int nYStride,
+                      void * pabyZ,
+                      int nZStride,
+                      void * pabyM,
+                      int nMStride) -> int
+
+Returns all points of line string.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **pabyX**: a buffer of at least (sizeof(double) * nXStride * nPointCount) bytes, may be NULL.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: a buffer of at least (sizeof(double) * nYStride * nPointCount) bytes, may be NULL.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: a buffer of at last size (sizeof(double) * nZStride * nPointCount) bytes, may be NULL.
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+* **pabyM**: a buffer of at last size (sizeof(double) * nMStride * nPointCount) bytes, may be NULL.
+* **nMStride**: the number of bytes between 2 elements of pabyM.
+
+### Returns
+the number of points
+"""
+function getpointszm(hGeom::Ptr{OGRGeometryH},pabyX,nXStride::Integer,pabyY,nYStride::Integer,pabyZ,nZStride::Integer,pabyM,nMStride::Integer)
+    ccall((:OGR_G_GetPointsZM,libgdal),Cint,(Ptr{OGRGeometryH},Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride,pabyM,nMStride)
+end
+
+
+"""
     OGR_G_GetX(OGRGeometryH hGeom,
                int i) -> double
 
@@ -1408,6 +1518,24 @@ end
 
 
 """
+    OGR_G_GetM(OGRGeometryH hGeom,
+               int i) -> double
+
+Fetch the m coordinate of a point from a geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the M coordinate.
+* **i**: point to get the M coordinate.
+
+### Returns
+the M coordinate of this point.
+"""
+function getm(arg1::Ptr{OGRGeometryH},arg2::Integer)
+    ccall((:OGR_G_GetM,libgdal),Cdouble,(Ptr{OGRGeometryH},Cint),arg1,arg2)
+end
+
+
+"""
     OGR_G_GetPoint(OGRGeometryH hGeom,
                    int i,
                    double * pdfX,
@@ -1425,6 +1553,29 @@ Fetch a point in line string or a point geometry.
 """
 function getpoint(arg1::Ptr{OGRGeometryH},iPoint::Integer,arg2,arg3,arg4)
     ccall((:OGR_G_GetPoint,libgdal),Void,(Ptr{OGRGeometryH},Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_GetPointZM(OGRGeometryH hGeom,
+                     int i,
+                     double * pdfX,
+                     double * pdfY,
+                     double * pdfZ,
+                     double * pdfM) -> void
+
+Fetch a point in line string or a point geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry from which to get the coordinates.
+* **i**: the vertex to fetch, from 0 to getNumPoints()-1, zero for a point.
+* **pdfX**: value of x coordinate.
+* **pdfY**: value of y coordinate.
+* **pdfZ**: value of z coordinate.
+* **pdfM**: value of m coordinate.
+"""
+function getpointzm(arg1::Ptr{OGRGeometryH},iPoint::Integer,arg2,arg3,arg4,arg5)
+    ccall((:OGR_G_GetPointZM,libgdal),Void,(Ptr{OGRGeometryH},Cint,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),arg1,iPoint,arg2,arg3,arg4,arg5)
 end
 
 
@@ -1484,6 +1635,50 @@ end
 
 
 """
+    OGR_G_SetPointM(OGRGeometryH hGeom,
+                    int i,
+                    double dfX,
+                    double dfY,
+                    double dfM) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfM**: input M coordinate to assign.
+"""
+function setpointm(arg1::Ptr{OGRGeometryH},iPoint::Integer,arg2::Real,arg3::Real,arg4::Real)
+    ccall((:OGR_G_SetPointM,libgdal),Void,(Ptr{OGRGeometryH},Cint,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_SetPointZM(OGRGeometryH hGeom,
+                     int i,
+                     double dfX,
+                     double dfY,
+                     double dfZ,
+                     double dfM) -> void
+
+Set the location of a vertex in a point or linestring geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to add a vertex to.
+* **i**: the index of the vertex to assign (zero based) or zero for a point.
+* **dfX**: input X coordinate to assign.
+* **dfY**: input Y coordinate to assign.
+* **dfZ**: input Z coordinate to assign.
+* **dfM**: input M coordinate to assign.
+"""
+function setpointzm(arg1::Ptr{OGRGeometryH},iPoint::Integer,arg2::Real,arg3::Real,arg4::Real,arg5::Real)
+    ccall((:OGR_G_SetPointZM,libgdal),Void,(Ptr{OGRGeometryH},Cint,Cdouble,Cdouble,Cdouble,Cdouble),arg1,iPoint,arg2,arg3,arg4,arg5)
+end
+
+
+"""
     OGR_G_AddPoint(OGRGeometryH hGeom,
                    double dfX,
                    double dfY,
@@ -1520,6 +1715,46 @@ end
 
 
 """
+    OGR_G_AddPointM(OGRGeometryH hGeom,
+                    double dfX,
+                    double dfY,
+                    double dfM) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfM**: m coordinate of point to add.
+"""
+function addpointm(arg1::Ptr{OGRGeometryH},arg2::Real,arg3::Real,arg4::Real)
+    ccall((:OGR_G_AddPointM,libgdal),Void,(Ptr{OGRGeometryH},Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4)
+end
+
+
+"""
+    OGR_G_AddPointZM(OGRGeometryH hGeom,
+                     double dfX,
+                     double dfY,
+                     double dfZ,
+                     double dfM) -> void
+
+Add a point to a geometry (line string or point).
+
+### Parameters
+* **hGeom**: handle to the geometry to add a point to.
+* **dfX**: x coordinate of point to add.
+* **dfY**: y coordinate of point to add.
+* **dfZ**: z coordinate of point to add.
+* **dfM**: m coordinate of point to add.
+"""
+function addpointzm(arg1::Ptr{OGRGeometryH},arg2::Real,arg3::Real,arg4::Real,arg5::Real)
+    ccall((:OGR_G_AddPointZM,libgdal),Void,(Ptr{OGRGeometryH},Cdouble,Cdouble,Cdouble,Cdouble),arg1,arg2,arg3,arg4,arg5)
+end
+
+
+"""
     OGR_G_SetPoints(OGRGeometryH hGeom,
                     int nPointsIn,
                     void * pabyX,
@@ -1543,6 +1778,37 @@ Assign all points in a point or a line string geometry.
 """
 function setpoints(hGeom::Ptr{OGRGeometryH},nPointsIn::Integer,pabyX,nXStride::Integer,pabyY,nYStride::Integer,pabyZ,nZStride::Integer)
     ccall((:OGR_G_SetPoints,libgdal),Void,(Ptr{OGRGeometryH},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride)
+end
+
+
+"""
+    OGR_G_SetPointsZM(OGRGeometryH hGeom,
+                      int nPointsIn,
+                      void * pabyX,
+                      int nXStride,
+                      void * pabyY,
+                      int nYStride,
+                      void * pabyZ,
+                      int nZStride,
+                      void * pabyM,
+                      int nMStride) -> void
+
+Assign all points in a point or a line string geometry.
+
+### Parameters
+* **hGeom**: handle to the geometry to set the coordinates.
+* **nPointsIn**: number of points being passed in padfX and padfY.
+* **pabyX**: list of X coordinates (double values) of points being assigned.
+* **nXStride**: the number of bytes between 2 elements of pabyX.
+* **pabyY**: list of Y coordinates (double values) of points being assigned.
+* **nYStride**: the number of bytes between 2 elements of pabyY.
+* **pabyZ**: list of Z coordinates (double values) of points being assigned (if not NULL, upgrades the geometry to have Z coordinate).
+* **nZStride**: the number of bytes between 2 elements of pabyZ.
+* **pabyM**: list of M coordinates (double values) of points being assigned (if not NULL, upgrades the geometry to have M coordinate).
+* **nMStride**: the number of bytes between 2 elements of pabyM.
+"""
+function setpointszm(hGeom::Ptr{OGRGeometryH},nPointsIn::Integer,pabyX,nXStride::Integer,pabyY,nYStride::Integer,pabyZ,nZStride::Integer,pabyM,nMStride::Integer)
+    ccall((:OGR_G_SetPointsZM,libgdal),Void,(Ptr{OGRGeometryH},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint,Ptr{Void},Cint),hGeom,nPointsIn,pabyX,nXStride,pabyY,nYStride,pabyZ,nZStride,pabyM,nMStride)
 end
 
 

--- a/src/ogr_srs_api.jl
+++ b/src/ogr_srs_api.jl
@@ -692,7 +692,7 @@ end
 
 """
     OSRCopyGeogCSFrom(OGRSpatialReferenceH hSRS,
-                      OGRSpatialReferenceH hSrcSRS) -> OGRErr
+                      const OGRSpatialReferenceH hSrcSRS) -> OGRErr
 
 Copy GEOGCS from another OGRSpatialReference.
 """


### PR DESCRIPTION
From now on I'd like to stick to official releases if possible.
The usage of NTuple instead of immutable composites in the new Clang.jl cleans up `common.jl` a bit.