### PR TITLE
use conda-forge's gdal recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("GDAL"); Pkg.build("GDAL"); Pkg.test("GDAL"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("GDAL"); Pkg.test("GDAL"; coverage=true)'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
-branches:
-  only:
-    - master
-    - /release-.*/
 
 notifications:
   - provider: Email

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,11 +3,10 @@ using Conda
 
 @BinDeps.setup
 
-libgdal = library_dependency("libgdal", aliases=["gdal","gdal111","gdal201",
+libgdal = library_dependency("libgdal", aliases=["gdal","gdal111","gdal200","gdal201",
                                                  "gdal_w32","gdal_w64"])
 
-# install older gdal on windows
-@windows_only provides(Conda.Manager, "libgdal==1.11.2", libgdal)
+@windows_only provides(Conda.Manager, "libgdal", libgdal)
 @unix_only provides(Conda.Manager, "libgdal", libgdal)
 
 @BinDeps.install Dict(:libgdal => :libgdal)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,11 +12,13 @@ function isgdal2(name, handle)
 end
 
 libgdal = library_dependency("libgdal",
-                             aliases=["gdal","gdal210","gdal201","gdal200",
+                             aliases=["gdal","gdal201","gdal200",
                                       "gdal_w32","gdal_w64"],
                              validate=isgdal2)
 
-@windows_only provides(Conda.Manager, "libgdal", libgdal)
-@unix_only provides(Conda.Manager, "libgdal", libgdal)
+# conda-forge has a well maintained gdal recipe
+# https://github.com/conda-forge/gdal-feedstock
+Conda.add_channel("conda-forge")
+provides(Conda.Manager, "gdal", libgdal)
 
 @BinDeps.install Dict(:libgdal => :libgdal)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,8 +3,18 @@ using Conda
 
 @BinDeps.setup
 
-libgdal = library_dependency("libgdal", aliases=["gdal","gdal111","gdal200","gdal201",
-                                                 "gdal_w32","gdal_w64"])
+function isgdal2(name, handle)
+    fptr = Libdl.dlsym(handle, :GDALVersionInfo)
+    versionptr = ccall(fptr,Cstring,(Cstring,),"RELEASE_NAME")
+    versionstring = bytestring(versionptr)
+    gdalversion = convert(VersionNumber, versionstring)
+    gdalversion >= v"2.0.0"
+end
+
+libgdal = library_dependency("libgdal",
+                             aliases=["gdal","gdal210","gdal201","gdal200",
+                                      "gdal_w32","gdal_w64"],
+                             validate=isgdal2)
 
 @windows_only provides(Conda.Manager, "libgdal", libgdal)
 @unix_only provides(Conda.Manager, "libgdal", libgdal)


### PR DESCRIPTION
This conda channel has a GDAL recipe that works well on all platforms, is actively maintained, and has GDAL 2.1.

With the validate function in `build.jl` we won't accept GDAL 1.x anymore. This was around on Travis, causing builds to fail.

With this all is green, except Windows 32 bits, I'll open a separate issue about that.

Possible downside of using conda-forge gdal instead of default channel libgdal is that it's 100MB heavier: 

https://travis-ci.org/visr/GDAL.jl/jobs/132722834#L123-L139
https://travis-ci.org/visr/GDAL.jl/jobs/132740954#L123-L146

Mainly due to pulling in MKL.
