### PR TITLE
use conda-forge gdal on unix

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
 BinDeps
-Conda
+@unix Conda
 @windows WinRPM


### PR DESCRIPTION
Minimum GDAL version that Pkg.build("GDAL") now accepts is 2.1
No longer require Conda on Windows