### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("GDAL"); Pkg.test("GDAL"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("GDAL")'
+  - LD_LIBRARY_PATH="/home/travis/.julia/v0.6/Conda/deps/usr/lib/" julia -e 'Pkg.build("GDAL"); Pkg.test("GDAL"; coverage=true)'


### PR DESCRIPTION
After building, thus setting up conda. Rerun Julia with the Conda installation as its dynamic library path. This circumvents #42